### PR TITLE
OSD-14993: Automate backplane-cli release cycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,11 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Goreleaser
+dist/
+
+# backplane-cli binary
+backplane-cli
+/ocm-backplane
+

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,43 @@
+project_name: ocm-backplane
+
+before:
+  hooks:
+    - go mod tidy
+    - go generate ./...
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+      - "GO111MODULE=on"
+      - "GOFLAGS=-mod=readonly -trimpath"
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    main: ./cmd/ocm-backplane/
+    binary: ocm-backplane
+
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      amd64: x86_64
+
+checksum:
+  name_template: "checksums.txt"
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+release:
+  github:
+    owner: "openshift"
+    name: "backplane-cli"

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,12 @@ getlint:
 lint: getlint
 	$(GOPATH)/bin/golangci-lint run
 
+ensure-goreleaser:
+	go install github.com/goreleaser/goreleaser@v1.14.1
+
+release: ensure-goreleaser
+	goreleaser release --rm-dist
+
 test:
 	for t in $$(go list ./...); do go test -v $$t ; done
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,49 @@
+# How to generate a new release
+
+This document describes how to generate a new release for backplane-cli.
+
+**Note:** Only maintainers or owners of this repository can perform the below steps.
+
+### GitHub Token
+
+To release to GitHub, you'll need to export a `GITHUB_TOKEN` environment variable, which should contain a valid GitHub token with the repo scope.
+
+It will be used to deploy releases to your GitHub repository. You can create a new GitHub token [here](https://github.com/settings/tokens/new).
+
+- Pick a name and a reasonable expiration date (1 day should be enough).
+- Grant API and write_repository permissions.
+- Export the token for later use:
+
+```bash
+export GITHUB_TOKEN="YOUR_GH_TOKEN"
+```
+
+### Local repository setup
+
+Fork `openshift/backplane-cli` and add the git upstream.
+
+```bash
+git clone <your-fork>
+cd backplane-cli
+git remote add upstream https://github.com/openshift/backplane-cli.git
+```
+
+### Cutting a new release
+
+Create a tag on the latest master.
+
+```bash
+git fetch upstream
+git checkout upstream/master
+git tag -a ${VERSION} -m "release ${VERSION}"
+git push upstream $VERSION
+```
+
+Run goreleaser to build the binaries and create the release page.
+
+```bash
+git checkout upstream/master
+make release
+```
+
+A new release will show up in the release page.


### PR DESCRIPTION
This PR aims to automate `openshift/backplane-cli` repository's release process by leveraging goreleaser.
<hr>

Resolves: [OSD-14993](https://issues.redhat.com/browse/OSD-14993)