### PR TITLE
OSD-14677: Added backplane-cli upgrade based on the latest version

### DIFF
--- a/cmd/ocm-backplane/root.go
+++ b/cmd/ocm-backplane/root.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/hello"
+	"github.com/openshift/backplane-cli/cmd/ocm-backplane/upgrade"
 
 	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
@@ -81,4 +82,5 @@ func init() {
 
 	// Register sub-commands
 	rootCmd.AddCommand(hello.HelloCmd)
+	rootCmd.AddCommand(upgrade.UpgradeCmd)
 }

--- a/cmd/ocm-backplane/upgrade/upgrade.go
+++ b/cmd/ocm-backplane/upgrade/upgrade.go
@@ -1,0 +1,46 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/openshift/backplane-cli/internal/github"
+	"github.com/openshift/backplane-cli/internal/upgrade"
+	"github.com/openshift/backplane-cli/pkg/info"
+	"github.com/spf13/cobra"
+)
+
+func long() string {
+	return strings.Join([]string{
+		"Upgrades the latest version release based on",
+		"your machine's OS and architecture.",
+	}, " ")
+}
+
+var UpgradeCmd = &cobra.Command{
+	Use:   "upgrade",
+	Short: "Upgrades the current backplane-cli to the latest version",
+	Long:  long(),
+
+	RunE: runUpgrade,
+	Args: cobra.ArbitraryArgs,
+
+	SilenceUsage: true,
+}
+
+func runUpgrade(cmd *cobra.Command, _ []string) error {
+
+	ctx, cancel := context.WithCancel(cmd.Context())
+	defer cancel()
+
+	git := github.NewClient()
+
+	if err := git.CheckConnection(); err != nil {
+		return fmt.Errorf("checking connection to the git server: %w", err)
+	}
+
+	upgrade := upgrade.NewCmd(git)
+
+	return upgrade.UpgradePlugin(ctx, info.Version)
+}

--- a/go.mod
+++ b/go.mod
@@ -14,14 +14,19 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/swag v0.21.1 // indirect
 	github.com/google/uuid v1.3.0 // indirect
-	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/yaml v0.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/perimeterx/marshmallow v1.1.4 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/sys v0.4.0 // indirect
+	golang.org/x/sys v0.2.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+require (
+	github.com/Masterminds/semver v1.5.0
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/pkg/errors v0.9.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
@@ -45,6 +47,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/perimeterx/marshmallow v1.1.4 h1:pZLDH9RjlLGGorbXhcaQLhfuV0pFMNfPO55FuFkxqLw=
 github.com/perimeterx/marshmallow v1.1.4/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -70,8 +74,8 @@ github.com/ugorji/go v1.2.7/go.mod h1:nF9osbDWLy6bDVv/Rtoh6QgnvNDpmCalQV5urGCCS6
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
-golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -1,0 +1,214 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"runtime"
+	"strings"
+
+	"github.com/openshift/backplane-cli/internal/upgrade"
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrRequestFailed   = errors.New("request failed")
+	ErrArchiveNotFound = errors.New("archive not found")
+)
+
+const (
+	gitHubApiEndPoint = "https://api.github.com/repos/openshift/backplane-cli"
+	assetTemplateName = "backplane-cli_%s_%s_%s.tar.gz" // version, GOOS, GOARCH
+)
+
+func NewClient(opts ...ClientOption) *Client {
+	var cfg ClientConfig
+
+	cfg.Option(opts...)
+	cfg.Default()
+
+	return &Client{
+		cfg: cfg,
+	}
+}
+
+// GetLatestVersion returns latest version from the github API
+func (c *Client) GetLatestVersion(ctx context.Context) (latest upgrade.Release, err error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	data, err := c.get(
+		ctx,
+		fmt.Sprintf("%s/releases/latest", c.cfg.BaseURL),
+	)
+	if err != nil {
+		return latest, err
+	}
+
+	// Release type filters the latest release tag name and asserts
+	githubReleaseResponse := upgrade.Release{}
+	err = json.Unmarshal(data, &githubReleaseResponse)
+	if err != nil {
+		return latest, err
+	}
+
+	return githubReleaseResponse, nil
+}
+
+// GetReleaseArchive returns archive based on the OS type and arc
+func (c *Client) GetReleaseArchive(ctx context.Context, latestVersion upgrade.Release) ([]byte, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	osConfig := OSConfig{
+		OSType: runtime.GOOS,
+		OSArch: runtime.GOARCH,
+	}
+
+	// Find browser download url based on OS type and arc
+	assetURL, ok := osConfig.FindAssetURL(latestVersion)
+	if !ok {
+		return nil, ErrArchiveNotFound
+	}
+
+	archiveData, err := c.get(ctx, assetURL)
+	if err != nil {
+		return nil, fmt.Errorf("requesting release archive: %w", err)
+	}
+
+	return archiveData, nil
+}
+
+// Get data from the API providing the context and base url
+// Context allowed to cancel when calling to the API
+func (c *Client) get(ctx context.Context, url string) ([]byte, error) {
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		url,
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("building request: %w", err)
+	}
+
+	res, err := c.cfg.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("running request for %q: %w", url, err)
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, ErrRequestFailed
+	}
+
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	return data, nil
+}
+
+// CheckConnection is validating connection to the API end point
+func (c *Client) CheckConnection() error {
+	url, err := url.Parse(c.cfg.BaseURL)
+	if err != nil {
+		return fmt.Errorf("parsing base url: %w", err)
+	}
+
+	if _, err := net.LookupIP(url.Host); err != nil {
+		return fmt.Errorf("looking up host %q: %w", url.Host, err)
+	}
+
+	return nil
+}
+
+// Client defines the configuration for GitHub client
+type Client struct {
+	cfg ClientConfig
+}
+
+// ClientConfig defines http client and base url for the API
+type ClientConfig struct {
+	Client  http.Client
+	BaseURL string
+}
+
+func (c *ClientConfig) Option(opts ...ClientOption) {
+	for _, opt := range opts {
+		opt.ConfigureClient(c)
+	}
+}
+func (c *ClientConfig) Default() {
+	if c.BaseURL == "" {
+		c.BaseURL = gitHubApiEndPoint
+	}
+}
+
+type ClientOption interface {
+	ConfigureClient(*ClientConfig)
+}
+
+// OSConfig defines os type and arch
+type OSConfig struct {
+	OSType string
+	OSArch string
+}
+
+// FindAssetURL returns the matching browser download url and matching status
+func (osConfig *OSConfig) FindAssetURL(latestVersion upgrade.Release) (string, bool) {
+	for _, asset := range latestVersion.Assets {
+		if osConfig.isMatchingArchive(asset, latestVersion.TagName) {
+			return asset.DownloadUrl, true
+		}
+
+	}
+
+	return "", false
+}
+
+// isMatchingArchive checks asset name match with mapped OS type and arch
+func (osConfig *OSConfig) isMatchingArchive(asset upgrade.ReleaseAsset, version string) bool {
+	name := fmt.Sprintf(
+		assetTemplateName,
+		strings.TrimPrefix(version, "v"),
+		mapOS(osConfig.OSType),
+		mapArch(osConfig.OSArch),
+	)
+
+	return asset.Name == name
+}
+
+// mapArch returns desired arch name
+func mapArch(goarch string) string {
+	switch goarch {
+	case "amd64":
+		return "x86_64"
+	default:
+		return goarch
+	}
+}
+
+// mapOS returns matching lowercase OS type name
+func mapOS(goos string) string {
+	switch goos {
+	case "linux":
+		return "Linux"
+	case "darwin":
+		return "Darwin"
+	case "windows":
+		return "Windows"
+	default:
+		return ""
+	}
+}

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -1,0 +1,158 @@
+package github_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openshift/backplane-cli/internal/github"
+	"github.com/openshift/backplane-cli/internal/upgrade"
+)
+
+func TestGetLatestVersion(t *testing.T) {
+
+	for name, tc := range map[string]struct {
+		Actual          upgrade.Release
+		ExpectedVersion string
+		ExpectedAssets  []upgrade.ReleaseAsset
+	}{
+		"no releases versions": {
+			Actual: upgrade.Release{
+				TagName: "",
+				Assets:  []upgrade.ReleaseAsset{},
+			},
+			ExpectedVersion: "",
+			ExpectedAssets:  []upgrade.ReleaseAsset{},
+		},
+		"latest releases versions": {
+			Actual: upgrade.Release{
+				TagName: "v0.0.1",
+				Assets:  []upgrade.ReleaseAsset{},
+			},
+			ExpectedVersion: "v0.0.1",
+			ExpectedAssets:  []upgrade.ReleaseAsset{},
+		},
+	} {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+
+			t.Parallel()
+
+			expected := tc.Actual
+			data, _ := json.Marshal(tc.Actual)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write(data)
+			}))
+
+			defer srv.Close()
+
+			client := github.NewClient(
+				github.WithBaseURL(srv.URL),
+				github.WithClient(*srv.Client()),
+			)
+			res, err := client.GetLatestVersion(context.Background())
+			if err != nil {
+				t.Errorf("expected err to be nil got %v", err)
+			}
+			if res.TagName != tc.ExpectedVersion {
+				t.Errorf("expected res to be %s got %s", expected, res)
+			}
+
+		})
+	}
+}
+
+func TestFindAssetURL(t *testing.T) {
+
+	for name, tc := range map[string]struct {
+		LatestRelease upgrade.Release
+		osConfig      github.OSConfig
+		match         bool
+		ExpectedAsert string
+	}{
+		"no marching assert": {
+			LatestRelease: upgrade.Release{
+				TagName: "",
+				Assets:  []upgrade.ReleaseAsset{},
+			},
+			osConfig:      github.OSConfig{},
+			match:         false,
+			ExpectedAsert: "",
+		},
+		"check matching asert for Mac": {
+			LatestRelease: upgrade.Release{
+				TagName: "v0.0.1",
+				Assets: []upgrade.ReleaseAsset{
+					{
+						Name:        "backplane-cli_0.0.1_Darwin_arm64.tar.gz",
+						DownloadUrl: "https://github.com/openshift/backplane-cli/releases/download/v0.0.1/backplane-cli_0.0.1_Darwin_arm64.tar.gz",
+					},
+				},
+			},
+			osConfig: github.OSConfig{
+				OSType: "darwin",
+				OSArch: "arm64",
+			},
+			match:         true,
+			ExpectedAsert: "https://github.com/openshift/backplane-cli/releases/download/v0.0.1/backplane-cli_0.0.1_Darwin_arm64.tar.gz",
+		},
+		"check matching asert for Linux": {
+			LatestRelease: upgrade.Release{
+				TagName: "v0.0.1",
+				Assets: []upgrade.ReleaseAsset{
+					{
+						Name:        "backplane-cli_0.0.1_Linux_arm64.tar.gz",
+						DownloadUrl: "https://github.com/openshift/backplane-cli/releases/download/v0.0.1/backplane-cli_0.0.1_Linux_arm64.tar.gz",
+					},
+				},
+			},
+			osConfig: github.OSConfig{
+				OSType: "linux",
+				OSArch: "arm64",
+			},
+			match:         true,
+			ExpectedAsert: "https://github.com/openshift/backplane-cli/releases/download/v0.0.1/backplane-cli_0.0.1_Linux_arm64.tar.gz",
+		},
+		"check asert for unsupported OS ": {
+			LatestRelease: upgrade.Release{
+				TagName: "v0.0.1",
+				Assets: []upgrade.ReleaseAsset{
+					{
+						Name:        "backplane-cli_0.0.1_Linux_arm64.tar.gz",
+						DownloadUrl: "https://github.com/openshift/backplane-cli/releases/download/v0.0.1/backplane-cli_0.0.1_Linux_arm64.tar.gz",
+					},
+					{
+						Name:        "backplane-cli_0.0.1_Darwin_arm64.tar.gz",
+						DownloadUrl: "https://github.com/openshift/backplane-cli/releases/download/v0.0.1/backplane-cli_0.0.1_Darwin_arm64.tar.gz",
+					},
+				},
+			},
+			osConfig: github.OSConfig{
+				OSType: "windows",
+				OSArch: "arm64",
+			},
+			match:         false,
+			ExpectedAsert: "",
+		},
+	} {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+
+			t.Parallel()
+			downloadUrl, assertMatch := tc.osConfig.FindAssetURL(tc.LatestRelease)
+
+			if assertMatch != tc.match {
+				t.Errorf("expected res to be %t got %t", assertMatch, tc.match)
+			}
+
+			if downloadUrl != tc.ExpectedAsert {
+				t.Errorf("expected res to be %s got %s", tc.ExpectedAsert, downloadUrl)
+			}
+
+		})
+	}
+}

--- a/internal/github/options.go
+++ b/internal/github/options.go
@@ -1,0 +1,15 @@
+package github
+
+import "net/http"
+
+type WithBaseURL string
+
+func (w WithBaseURL) ConfigureClient(c *ClientConfig) {
+	c.BaseURL = string(w)
+}
+
+type WithClient http.Client
+
+func (w WithClient) ConfigureClient(c *ClientConfig) {
+	c.Client = http.Client(w)
+}

--- a/internal/upgrade/options.go
+++ b/internal/upgrade/options.go
@@ -1,0 +1,47 @@
+package upgrade
+
+import (
+	"io"
+
+	"github.com/sirupsen/logrus"
+)
+
+type WithLog struct{ Log logrus.FieldLogger }
+
+func (w WithLog) ConfigureCmd(c *CmdConfig) {
+	c.Log = w.Log
+}
+
+func (w WithLog) ConfigureSafeWriter(c *SafeWriterConfig) {
+	c.Log = w.Log
+}
+
+type WithOut struct{ Out io.Writer }
+
+func (w WithOut) ConfigureCmd(c *CmdConfig) {
+	c.Out = w.Out
+}
+
+type WithWriter struct{ Writer Writer }
+
+func (w WithWriter) ConfigureCmd(c *CmdConfig) {
+	c.Writer = w.Writer
+}
+
+type WithBinaryName string
+
+func (w WithBinaryName) ConfigureCmd(c *CmdConfig) {
+	c.BinaryName = string(w)
+}
+
+type WithOrg string
+
+func (w WithOrg) ConfigureCmd(c *CmdConfig) {
+	c.Org = string(w)
+}
+
+type WithRepo string
+
+func (w WithRepo) ConfigureCmd(c *CmdConfig) {
+	c.Repo = string(w)
+}

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -1,0 +1,220 @@
+package upgrade
+
+import (
+	"archive/tar"
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/Masterminds/semver"
+	"github.com/sirupsen/logrus"
+)
+
+// Release type defines the tag and its assets
+type Release struct {
+	TagName string         `json:"tag_name"`
+	Assets  []ReleaseAsset `json:"assets"`
+}
+
+// ReleaseAsset defines the name and download url
+type ReleaseAsset struct {
+	Name        string `json:"name"`
+	DownloadUrl string `json:"browser_download_url"`
+}
+
+// GitServer defines generic functions for getting the latest release and archive
+type GitServer interface {
+	GetLatestVersion(ctx context.Context) (Release, error)
+	GetReleaseArchive(ctx context.Context, release Release) ([]byte, error)
+}
+
+type Writer interface {
+	Write(path string, data []byte) error
+}
+
+func NewCmd(git GitServer, opts ...CmdOption) *Cmd {
+	var cfg CmdConfig
+
+	cfg.Option(opts...)
+	cfg.Default()
+
+	return &Cmd{
+		cfg: cfg,
+
+		git: git,
+	}
+}
+
+type Cmd struct {
+	cfg CmdConfig
+
+	git GitServer
+}
+
+// UpgradePlugin upgrade OS binary based on the latest version
+func (c *Cmd) UpgradePlugin(ctx context.Context, currentVersion string) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	latestVersion, err := c.git.GetLatestVersion(ctx)
+	if err != nil {
+		return fmt.Errorf("getting latest version for project '%s/%s': %w", c.cfg.Org, c.cfg.Repo, err)
+	}
+
+	proceed, err := shouldUpdate(currentVersion, latestVersion)
+	if err != nil {
+		return fmt.Errorf("comparing current version to latest: %w", err)
+	}
+
+	if !proceed {
+		_, err := fmt.Fprintln(c.cfg.Out, "No upgrade available.")
+
+		return err
+	}
+
+	if confirmed := confirmUpgrade(latestVersion, c); !confirmed {
+		_, err := fmt.Fprintln(c.cfg.Out, "Upgrade cancelled.")
+
+		return err
+	}
+
+	latestBin, err := c.getLatestBinary(ctx, latestVersion)
+	if err != nil {
+		return fmt.Errorf("retrieving latest binary: %w", err)
+	}
+
+	binPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("retrieving the current executable path: %w", err)
+	}
+
+	if err := c.cfg.Writer.Write(binPath, latestBin); err != nil {
+		return fmt.Errorf("writing new binary: %w", err)
+	} else {
+		successMessage := fmt.Sprintf("Backplane CLI has been upgraded to %s", latestVersion.TagName)
+		fmt.Fprintln(c.cfg.Out, successMessage)
+	}
+
+	return nil
+}
+
+// getLatestBinary returns the data based on the release version
+func (c *Cmd) getLatestBinary(ctx context.Context, release Release) ([]byte, error) {
+
+	rawArc, err := c.git.GetReleaseArchive(ctx, release)
+
+	if err != nil {
+		return nil, fmt.Errorf("getting release archive for project '%s/%s' at version %q: %w", c.cfg.Org, c.cfg.Repo, release.TagName, err)
+	}
+
+	unzipped, err := gzip.NewReader(bytes.NewBuffer(rawArc))
+	if err != nil {
+		return nil, fmt.Errorf("reading zipped archive: %w", err)
+	}
+
+	arc := tar.NewReader(unzipped)
+
+	for {
+		next, err := arc.Next()
+		if errors.Is(err, io.EOF) {
+			return nil, errors.New("binary not found")
+		} else if err != nil {
+			return nil, fmt.Errorf("searching tar archive: %w", err)
+		}
+		if next.Name == c.cfg.BinaryName {
+			break
+		}
+	}
+
+	res, err := io.ReadAll(arc)
+	if err != nil {
+		return nil, fmt.Errorf("reading binary from archive: %w", err)
+	}
+
+	return res, nil
+}
+
+func shouldUpdate(current string, latest Release) (bool, error) {
+	curVer, err := semver.NewVersion(current)
+	if err != nil {
+		return false, fmt.Errorf("parsing current version %q: %w", current, err)
+	}
+
+	latestVer, err := semver.NewVersion(latest.TagName)
+	if err != nil {
+		return false, fmt.Errorf("parsing latest version %q: %w", latest, err)
+	}
+
+	return curVer.LessThan(latestVer), nil
+}
+
+func confirmUpgrade(latest Release, c *Cmd) bool {
+
+	message := fmt.Sprintf(
+		"A newer version %q is available.\nWould you like to upgrade? (y/N)", latest.TagName,
+	)
+	fmt.Fprintln(c.cfg.Out, message)
+
+	input, _ := c.cfg.Reader.ReadString('\n')
+
+	input = strings.TrimSpace(input)
+
+	return strings.EqualFold(input, "y")
+}
+
+type CmdConfig struct {
+	Log    logrus.FieldLogger
+	Out    io.Writer
+	Writer Writer
+	Reader *bufio.Reader
+
+	BinaryName string
+	Org        string
+	Repo       string
+}
+
+func (c *CmdConfig) Option(opts ...CmdOption) {
+	for _, opt := range opts {
+		opt.ConfigureCmd(c)
+	}
+}
+
+func (c *CmdConfig) Default() {
+	if c.Log == nil {
+		c.Log = logrus.New()
+	}
+
+	if c.Out == nil {
+		c.Out = os.Stdout
+	}
+
+	if c.Writer == nil {
+		c.Writer = NewSafeWriter()
+	}
+
+	if c.Reader == nil {
+		c.Reader = bufio.NewReader(os.Stdin)
+	}
+
+	if c.BinaryName == "" {
+		c.BinaryName = "backplane-cli"
+	}
+
+	if c.Org == "" {
+		c.Org = "openshift"
+	}
+
+	if c.Repo == "" {
+		c.Repo = "backplane-cli"
+	}
+}
+
+type CmdOption interface {
+	ConfigureCmd(*CmdConfig)
+}

--- a/internal/upgrade/writer.go
+++ b/internal/upgrade/writer.go
@@ -1,0 +1,90 @@
+package upgrade
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func NewSafeWriter(opts ...SafeWriterOption) *SafeWriter {
+	var cfg SafeWriterConfig
+
+	cfg.Option(opts...)
+	cfg.Default()
+
+	return &SafeWriter{
+		cfg: cfg,
+	}
+}
+
+type SafeWriter struct {
+	cfg SafeWriterConfig
+}
+
+func (w *SafeWriter) Write(path string, data []byte) error {
+	backup, err := w.backup(path)
+	if err != nil {
+		return fmt.Errorf("backing up path: %w", err)
+	}
+
+	const perms = os.FileMode(0o755)
+
+	if err := os.WriteFile(path, data, perms); err != nil {
+		if backup != "" {
+			if err := os.Rename(backup, path); err != nil {
+				w.cfg.Log.Errorf("restoring from backup: %v", err)
+			}
+		}
+
+		return fmt.Errorf("writing to path %q: %w", path, err)
+	}
+
+	if err := os.Remove(backup); err != nil {
+		return fmt.Errorf("cleaning up old binary: %w", err)
+	}
+
+	return nil
+}
+
+var ErrNotAFile = errors.New("not a file")
+
+func (w *SafeWriter) backup(path string) (string, error) {
+	if stat, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	} else if err != nil {
+		return "", fmt.Errorf("inspecting file path: %w", err)
+	} else if stat.IsDir() {
+		return "", ErrNotAFile
+	}
+
+	backup := path + "_" + time.Now().Format("2006.01.02_15:04:05")
+
+	if err := os.Rename(path, backup); err != nil {
+		return "", fmt.Errorf("backing up file path: %w", err)
+	}
+
+	return backup, nil
+}
+
+type SafeWriterConfig struct {
+	Log logrus.FieldLogger
+}
+
+func (c *SafeWriterConfig) Option(opts ...SafeWriterOption) {
+	for _, opt := range opts {
+		opt.ConfigureSafeWriter(c)
+	}
+}
+
+func (c *SafeWriterConfig) Default() {
+	if c.Log == nil {
+		c.Log = logrus.New()
+	}
+}
+
+type SafeWriterOption interface {
+	ConfigureSafeWriter(*SafeWriterConfig)
+}

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -1,0 +1,6 @@
+// This file contains information about backplane-cli.
+
+package info
+
+// Version of the backplane-cli
+const Version = "0.0.0"


### PR DESCRIPTION
### Introduction
This PR introduces `ocm backplane upgrade` command that based on GitHub latest release 

### How to use it ?
```
$ ocm backplane upgrade
? A newer version "v0.0.1" is available.
Would you like to upgrade? (y/N)
```