### PR TITLE
OSD-14684: Add Backplane cloud console and credentials commands

### DIFF
--- a/cmd/ocm-backplane/cloud/cloud.go
+++ b/cmd/ocm-backplane/cloud/cloud.go
@@ -1,0 +1,22 @@
+package cloud
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var CloudCmd *cobra.Command = &cobra.Command{
+	Use:               "cloud",
+	Short:             "Cloud Access and Subcommands",
+	Args:              cobra.NoArgs,
+	DisableAutoGenTag: true,
+	Run:               help,
+}
+
+func init() {
+	CloudCmd.AddCommand(CredentialsCmd)
+	CloudCmd.AddCommand(ConsoleCmd)
+}
+
+func help(cmd *cobra.Command, _ []string) {
+	_ = cmd.Help()
+}

--- a/cmd/ocm-backplane/cloud/cloud_suite_test.go
+++ b/cmd/ocm-backplane/cloud/cloud_suite_test.go
@@ -1,0 +1,20 @@
+package cloud
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestIt(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cloud Test Suite")
+}
+
+func MakeIoReader(s string) io.ReadCloser {
+	r := io.NopCloser(strings.NewReader(s)) // r type is io.ReadCloser
+	return r
+}

--- a/cmd/ocm-backplane/cloud/console.go
+++ b/cmd/ocm-backplane/cloud/console.go
@@ -1,0 +1,212 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/go-yaml/yaml"
+	"github.com/pkg/browser"
+	logger "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	BackplaneApi "github.com/openshift/backplane-api/pkg/client"
+	"github.com/openshift/backplane-cli/pkg/utils"
+)
+
+var consoleArgs struct {
+	browser      bool
+	backplaneURL string
+	output       string
+}
+
+type ConsoleResponse struct {
+	ConsoleLink string `json:"ConsoleLink" yaml:"ConsoleLink"`
+}
+
+var consoleStrFmt string = `Console Link:
+  Link: %s`
+
+func (r *ConsoleResponse) String() string {
+	return fmt.Sprintf(consoleStrFmt, r.ConsoleLink)
+}
+
+// Environment variable that indicates if open by browser is set as default
+const EnvBrowserDefault = "BACKPLANE_DEFAULT_OPEN_BROWSER"
+
+// ConsoleCmd represents the cloud credentials command
+var ConsoleCmd = &cobra.Command{
+	Use:   "console [CLUSTERID|EXTERNAL_ID|CLUSTER_NAME|CLUSTER_NAME_SEARCH]",
+	Short: "Requests a link to cluster's cloud provider's console",
+	Long: `Requests a link that utilizes temporary cloud credentials for the cluster's cloud provider's web console.
+	This allows us to be able to perform operations such as debugging an issue, troubleshooting a customer
+	misconfiguration, or directly access the underlying cloud infrastructure. If no cluster identifier is provided, the
+	currently logged in cluster will be used.`,
+	Example:      " backplane cloud console\n backplane cloud console <id>\n backplane cloud console %test%\n backplane cloud console <external_id>",
+	Args:         cobra.RangeArgs(0, 1),
+	Aliases:      []string{"link", "web"},
+	RunE:         runConsole,
+	SilenceUsage: true,
+}
+
+func init() {
+	flags := ConsoleCmd.Flags()
+	flags.BoolVarP(
+		&consoleArgs.browser,
+		"browser",
+		"b",
+		false,
+		fmt.Sprintf("Open a browser after the console container starts. Can also be set via the environment variable '%s'", EnvBrowserDefault),
+	)
+	flags.StringVar(
+		&consoleArgs.backplaneURL,
+		"url",
+		"",
+		"URL of backplane API",
+	)
+	flags.StringVarP(
+		&consoleArgs.output,
+		"output",
+		"o",
+		"text",
+		"Format the output of the console response.",
+	)
+}
+
+func runConsole(cmd *cobra.Command, argv []string) (err error) {
+	var clusterKey string
+
+	err = validateParams(argv)
+
+	if err != nil {
+		return err
+	}
+
+	// ========= Get The cluster ID =============================
+	if len(argv) == 1 {
+		// if explicitly one cluster key given, use it to log in.
+		clusterKey = argv[0]
+		logger.WithField("Search Key", clusterKey).Debugln("Finding target cluster")
+	} else if len(argv) == 0 {
+		// if no args given, try to log into the cluster that the user is logged into
+		clusterInfo, err := utils.GetBackplaneClusterFromConfig()
+		if err != nil {
+			return err
+		}
+		clusterKey = clusterInfo.ClusterID
+	}
+
+	clusterId, clusterName, err := utils.DefaultOCMInterface.GetTargetCluster(clusterKey)
+	if err != nil {
+		return err
+	}
+
+	logger.WithFields(logger.Fields{
+		"ID":   clusterId,
+		"Name": clusterName}).Infoln("Target cluster")
+
+	// ============Get Backplane URl ==========================
+	if consoleArgs.backplaneURL == "" {
+		consoleArgs.backplaneURL, err = utils.DefaultOCMInterface.GetBackplaneURL()
+		if err != nil || consoleArgs.backplaneURL == "" {
+			return fmt.Errorf("can't find backplane url: %w", err)
+		}
+		logger.Infof("Using backplane URL: %s\n", consoleArgs.backplaneURL)
+	}
+
+	// ======== Get cloudconsole from backplane API ============
+	response, err := getCloudConsole(consoleArgs.backplaneURL, clusterId)
+	if err != nil {
+		return err
+	}
+
+	// ====== Render cloud console response based on output format
+	err = renderCloudConsole(response)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateParams(argv []string) (err error) {
+	// Check if env variable 'BACKPLANE_DEFAULT_OPEN_BROWSER' is set
+	if env, ok := os.LookupEnv(EnvBrowserDefault); ok {
+		// if set, try to parse it as a bool and pass it into consoleArgs.browser
+		consoleArgs.browser, err = strconv.ParseBool(env)
+		if err != nil {
+			return fmt.Errorf("unable to parse boolean value from environment variable %s", EnvBrowserDefault)
+		}
+	}
+	if len(argv) > 1 {
+		return fmt.Errorf("expected exactly one cluster")
+	}
+	return nil
+}
+
+// getCloudConsole returns console response calling to public Backplane API
+func getCloudConsole(backplaneURL string, clusterId string) (*ConsoleResponse, error) {
+	logger.Debugln("Getting Cloud Console")
+	client, err := utils.DefaultClientUtils.GetBackplaneClient(backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.GetCloudConsole(context.TODO(), clusterId)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, utils.TryPrintAPIError(resp, false)
+	}
+
+	credsResp, err := BackplaneApi.ParseGetCloudConsoleResponse(resp)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse response body from backplane:\n  Status Code: %d", resp.StatusCode)
+	}
+
+	if len(credsResp.Body) == 0 {
+		return nil, fmt.Errorf("empty response from backplane")
+	}
+
+	cliResp := &ConsoleResponse{}
+	cliResp.ConsoleLink = *credsResp.JSON200.ConsoleLink
+
+	return cliResp, nil
+}
+
+// renderCloudConsole output the data based output type
+func renderCloudConsole(response *ConsoleResponse) error {
+
+	if consoleArgs.browser {
+		if err := browser.OpenURL(response.ConsoleLink); err != nil {
+			logger.Warnf("failed opening browser: %s", err)
+		} else {
+			return nil
+		}
+	}
+
+	switch consoleArgs.output {
+	case "yaml":
+		yamlBytes, err := yaml.Marshal(response)
+		if err != nil {
+			return err
+		}
+		fmt.Println("---")
+		fmt.Println(string(yamlBytes))
+		return nil
+	case "json":
+		jsonBytes, err := json.Marshal(response)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(jsonBytes))
+		return nil
+	default:
+		fmt.Println(response)
+	}
+
+	return nil
+}

--- a/cmd/ocm-backplane/cloud/console_test.go
+++ b/cmd/ocm-backplane/cloud/console_test.go
@@ -1,0 +1,172 @@
+package cloud
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/backplane-cli/pkg/client/mocks"
+	"github.com/openshift/backplane-cli/pkg/utils"
+	mocks2 "github.com/openshift/backplane-cli/pkg/utils/mocks"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+var _ = Describe("Cloud console command", func() {
+
+	var (
+		mockCtrl           *gomock.Controller
+		mockClient         *mocks.MockClientInterface
+		mockClientWithResp *mocks.MockClientWithResponsesInterface
+		mockOcmInterface   *mocks2.MockOCMInterface
+		mockClientUtil     *mocks2.MockClientUtils
+
+		testClusterId    string
+		trueClusterId    string
+		proxyUri         string
+		consoleAWSUrl    string
+		consoleGcloudUrl string
+
+		fakeAWSResp    *http.Response
+		fakeGCloudResp *http.Response
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockClient = mocks.NewMockClientInterface(mockCtrl)
+		mockClientWithResp = mocks.NewMockClientWithResponsesInterface(mockCtrl)
+
+		mockOcmInterface = mocks2.NewMockOCMInterface(mockCtrl)
+		utils.DefaultOCMInterface = mockOcmInterface
+
+		mockClientUtil = mocks2.NewMockClientUtils(mockCtrl)
+		utils.DefaultClientUtils = mockClientUtil
+
+		testClusterId = "test123"
+		trueClusterId = "trueID123"
+		proxyUri = "https://shard.apps"
+		consoleAWSUrl = "https://signin.aws.amazon.com/federation?Action=login"
+		consoleGcloudUrl = "https://cloud.google.com/"
+
+		mockClientWithResp.EXPECT().LoginClusterWithResponse(gomock.Any(), gomock.Any()).Return(nil, nil).Times(0)
+
+		// Define fake AWS response
+		fakeAWSResp = &http.Response{
+			Body: MakeIoReader(
+				fmt.Sprintf(`{"proxy_uri":"proxy", "statusCode":200, "message":"msg", "ConsoleLink":"%s"}`, consoleAWSUrl),
+			),
+			Header:     map[string][]string{},
+			StatusCode: http.StatusOK,
+		}
+		fakeAWSResp.Header.Add("Content-Type", "json")
+
+		// Define fake AWS response
+		fakeGCloudResp = &http.Response{
+			Body: MakeIoReader(
+				fmt.Sprintf(`{"proxy_uri":"proxy", "statusCode":200, "message":"msg", "ConsoleLink":"%s"}`, consoleGcloudUrl),
+			),
+			Header:     map[string][]string{},
+			StatusCode: http.StatusOK,
+		}
+		fakeGCloudResp.Header.Add("Content-Type", "json")
+
+		// Clear config file
+		_ = clientcmd.ModifyConfig(clientcmd.NewDefaultPathOptions(), api.Config{}, true)
+		clientcmd.UseModifyConfigLock = false
+
+		// Disabled log output
+		log.SetOutput(io.Discard)
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	Context("Execute cloud console command", func() {
+		It("should return AWS cloud console", func() {
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterId).Return(trueClusterId, testClusterId, nil)
+			mockOcmInterface.EXPECT().GetBackplaneURL().Return(proxyUri, nil).AnyTimes()
+			mockClientUtil.EXPECT().GetBackplaneClient(proxyUri).Return(mockClient, nil).AnyTimes()
+			mockClient.EXPECT().GetCloudConsole(gomock.Any(), trueClusterId).Return(fakeAWSResp, nil)
+
+			err := runConsole(nil, []string{testClusterId})
+
+			Expect(err).To(BeNil())
+		})
+
+		It("should return GCP cloud console", func() {
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterId).Return(trueClusterId, testClusterId, nil)
+			mockOcmInterface.EXPECT().GetBackplaneURL().Return(proxyUri, nil).AnyTimes()
+			mockClientUtil.EXPECT().GetBackplaneClient(proxyUri).Return(mockClient, nil).AnyTimes()
+			mockClient.EXPECT().GetCloudConsole(gomock.Any(), trueClusterId).Return(fakeGCloudResp, nil)
+			err := runConsole(nil, []string{testClusterId})
+
+			Expect(err).To(BeNil())
+		})
+
+	})
+
+	Context("get Cloud Console", func() {
+		It("should return AWS cloud URL", func() {
+			mockOcmInterface.EXPECT().GetBackplaneURL().Return(proxyUri, nil).AnyTimes()
+			mockClient.EXPECT().GetCloudConsole(gomock.Any(), trueClusterId).Return(fakeAWSResp, nil)
+			mockClientUtil.EXPECT().GetBackplaneClient(proxyUri).Return(mockClient, nil).AnyTimes()
+			cloudResponse, err := getCloudConsole(proxyUri, trueClusterId)
+			Expect(err).To(BeNil())
+
+			Expect(cloudResponse.ConsoleLink).To(Equal(consoleAWSUrl))
+
+		})
+
+		It("should return Gcloud cloud URL", func() {
+			mockOcmInterface.EXPECT().GetBackplaneURL().Return(proxyUri, nil).AnyTimes()
+			mockClientUtil.EXPECT().GetBackplaneClient(proxyUri).Return(mockClient, nil).AnyTimes()
+			mockClient.EXPECT().GetCloudConsole(gomock.Any(), trueClusterId).Return(fakeGCloudResp, nil)
+			cloudResponse, err := getCloudConsole(proxyUri, trueClusterId)
+			Expect(err).To(BeNil())
+
+			Expect(cloudResponse.ConsoleLink).To(Equal(consoleGcloudUrl))
+
+		})
+
+		It("should fail when AWS Unavailable", func() {
+			fakeAWSResp.StatusCode = http.StatusInternalServerError
+			mockOcmInterface.EXPECT().GetBackplaneURL().Return(proxyUri, nil).AnyTimes()
+			mockClient.EXPECT().GetCloudConsole(gomock.Any(), trueClusterId).Return(fakeAWSResp, nil)
+			mockClientUtil.EXPECT().GetBackplaneClient(proxyUri).Return(mockClient, nil).AnyTimes()
+			_, err := getCloudConsole(proxyUri, trueClusterId)
+			Expect(err).NotTo(BeNil())
+
+			Expect(err.Error()).Should(ContainSubstring("error from backplane: \n Status Code: 500\n"))
+
+		})
+
+		It("should fail when GCP Unavailable", func() {
+			fakeGCloudResp.StatusCode = http.StatusInternalServerError
+			mockOcmInterface.EXPECT().GetBackplaneURL().Return(proxyUri, nil).AnyTimes()
+			mockClientUtil.EXPECT().GetBackplaneClient(proxyUri).Return(mockClient, nil).AnyTimes()
+			mockClient.EXPECT().GetCloudConsole(gomock.Any(), trueClusterId).Return(fakeGCloudResp, nil)
+			_, err := getCloudConsole(proxyUri, trueClusterId)
+			Expect(err).NotTo(BeNil())
+
+			Expect(err.Error()).Should(ContainSubstring("error from backplane: \n Status Code: 500\n"))
+
+		})
+
+		It("should fail for unauthorized BP-API", func() {
+			fakeAWSResp.StatusCode = http.StatusUnauthorized
+			mockOcmInterface.EXPECT().GetBackplaneURL().Return(proxyUri, nil).AnyTimes()
+			mockClientUtil.EXPECT().GetBackplaneClient(proxyUri).Return(mockClient, nil).AnyTimes()
+			mockClient.EXPECT().GetCloudConsole(gomock.Any(), trueClusterId).Return(fakeAWSResp, nil)
+			_, err := getCloudConsole(proxyUri, trueClusterId)
+			Expect(err).NotTo(BeNil())
+
+			Expect(err.Error()).Should(ContainSubstring("error from backplane: \n Status Code: 401\n"))
+
+		})
+	})
+})

--- a/cmd/ocm-backplane/cloud/credentials.go
+++ b/cmd/ocm-backplane/cloud/credentials.go
@@ -1,0 +1,230 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/go-yaml/yaml"
+	logger "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	BackplaneApi "github.com/openshift/backplane-api/pkg/client"
+	"github.com/openshift/backplane-cli/pkg/utils"
+)
+
+var credentialArgs struct {
+	backplaneURL string
+	output       string
+}
+
+type CredentialsResponse interface {
+	// String returns a friendly message outlining how users can setup cloud environment access
+	String() string
+
+	// fmtExport sets environment variables for users to export to setup cloud environment access
+	fmtExport() string
+}
+
+type AWSCredentialsResponse struct {
+	AccessKeyId     string `json:"AccessKeyId" yaml:"AccessKeyId"`
+	SecretAccessKey string `json:"SecretAccessKey" yaml:"SecretAccessKey"`
+	SessionToken    string `json:"SessionToken" yaml:"SessionToken"`
+	Region          string `json:"Region" yaml:"Region"`
+	Expiration      string `json:"Expiration" yaml:"Expiration"`
+}
+
+type GCPCredentialsResponse struct {
+	ProjectId string `json:"project_id" yaml:"project_id"`
+}
+
+const (
+	// format strings for printing AWS credentials as a string or as environment variables
+	awsCredentialsStringFormat = `Temporary Credentials:
+  AccessKeyId: %s
+  SecretAccessKey: %s
+  SessionToken: %s
+  Region: %s
+  Expires: %s`
+	awsExportFormat = `export AWS_ACCESS_KEY_ID=%s
+export AWS_SECRET_ACCESS_KEY=%s
+export AWS_SESSION_TOKEN=%s
+export AWS_DEFAULT_REGION=%s`
+
+	// format strings for printing GCP credentials as a string or as environment variables
+	gcpCredentialsStringFormat = `If this is your first time, run "gcloud auth login" and then
+gcloud config set project %s`
+	gcpExportFormat = `export CLOUDSDK_CORE_PROJECT=%s`
+)
+
+func (r *AWSCredentialsResponse) String() string {
+	return fmt.Sprintf(awsCredentialsStringFormat, r.AccessKeyId, r.SecretAccessKey, r.SessionToken, r.Region, r.Expiration)
+}
+
+func (r *AWSCredentialsResponse) fmtExport() string {
+	return fmt.Sprintf(awsExportFormat, r.AccessKeyId, r.SecretAccessKey, r.SessionToken, r.Region)
+}
+
+func (r *GCPCredentialsResponse) String() string {
+	return fmt.Sprintf(gcpCredentialsStringFormat, r.ProjectId)
+}
+
+func (r *GCPCredentialsResponse) fmtExport() string {
+	return fmt.Sprintf(gcpExportFormat, r.ProjectId)
+}
+
+// CredentialsCmd represents the cloud credentials command
+var CredentialsCmd = &cobra.Command{
+	Use:   "credentials [CLUSTERID|EXTERNAL_ID|CLUSTER_NAME|CLUSTER_NAME_SEARCH]",
+	Short: "Requests a set of temporary cloud credentials for the cluster's cloud provider",
+	Long: `Requests a set of temporary cloud credentials for the cluster's cloud provider. This allows us to be able to
+	perform operations such as debugging an issue, troubleshooting a customer misconfiguration, or directly access the
+	underlying cloud infrastructure. If no cluster identifier is provided, the currently logged in cluster will be used.`,
+	Example:      " backplane cloud credentials\n backplane cloud credentials <id>\n backplane cloud credentials %test%\n backplane cloud credentials <external_id>",
+	Args:         cobra.RangeArgs(0, 1),
+	Aliases:      []string{"creds", "cred"},
+	RunE:         runCredentials,
+	SilenceUsage: true,
+}
+
+func init() {
+	flags := CredentialsCmd.Flags()
+	flags.StringVar(
+		&credentialArgs.backplaneURL,
+		"url",
+		"",
+		"URL of backplane API",
+	)
+	flags.StringVarP(
+		&credentialArgs.output,
+		"output",
+		"o",
+		"text",
+		"Format the output of the credentials response. One of text|json|yaml|env",
+	)
+}
+
+func runCredentials(cmd *cobra.Command, argv []string) error {
+	var clusterKey string
+
+	if len(argv) == 1 {
+		// if explicitly one cluster key given, use it to log in.
+		clusterKey = argv[0]
+		logger.WithField("Search Key", clusterKey).Debugln("Finding target cluster")
+	} else if len(argv) == 0 {
+		// if no args given, try to log into the cluster that the user is logged into
+		clusterInfo, err := utils.GetBackplaneClusterFromConfig()
+		if err != nil {
+			return err
+		}
+		clusterKey = clusterInfo.ClusterID
+	} else {
+		return fmt.Errorf("expected exactly one cluster")
+	}
+
+	clusterId, clusterName, err := utils.DefaultOCMInterface.GetTargetCluster(clusterKey)
+	if err != nil {
+		return err
+	}
+
+	cluster, err := utils.DefaultOCMInterface.GetClusterInfoByID(clusterId)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster info for %s: %w", clusterId, err)
+	}
+
+	cloudProvider := cluster.CloudProvider().ID()
+
+	logger.WithFields(logger.Fields{
+		"ID":   clusterId,
+		"Name": clusterName}).Infoln("Target cluster")
+
+	// ============Get Backplane URl ==========================
+	if credentialArgs.backplaneURL == "" {
+		credentialArgs.backplaneURL, err = utils.DefaultOCMInterface.GetBackplaneURL()
+		if err != nil || credentialArgs.backplaneURL == "" {
+			return fmt.Errorf("can't find backplane url: %w", err)
+		}
+		logger.Infof("Using backplane URL: %s\n", credentialArgs.backplaneURL)
+	}
+
+	// ======== Call Endpoint ==================================
+	logger.Debugln("Getting Cloud Credentials")
+
+	credsResp, _ := getCloudCredential(credentialArgs.backplaneURL, clusterId)
+
+	// ======== Render cloud credentials =======================
+	switch cloudProvider {
+	case "aws":
+		cliResp := &AWSCredentialsResponse{}
+		if err := json.Unmarshal([]byte(*credsResp.JSON200.Credentials), cliResp); err != nil {
+			return fmt.Errorf("unable to unmarshal AWS credentials response from backplane %s: %w", *credsResp.JSON200.Credentials, err)
+		}
+		cliResp.Region = *credsResp.JSON200.Region
+		return renderCloudCredentials(cliResp)
+	case "gcp":
+		cliResp := &GCPCredentialsResponse{}
+		if err := json.Unmarshal([]byte(*credsResp.JSON200.Credentials), cliResp); err != nil {
+			return fmt.Errorf("unable to unmarshal GCP credentials response from backplane %s: %w", *credsResp.JSON200.Credentials, err)
+		}
+		return renderCloudCredentials(cliResp)
+	default:
+		return fmt.Errorf("unsupported cloud provider: %s", cloudProvider)
+	}
+}
+
+// getCloudCredential returns Cloud Credentials Response
+func getCloudCredential(backplaneURL string, clusterId string) (*BackplaneApi.GetCloudCredentialsResponse, error) {
+
+	client, err := utils.DefaultClientUtils.GetBackplaneClient(backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.GetCloudCredentials(context.TODO(), clusterId)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, utils.TryPrintAPIError(resp, false)
+	}
+
+	logger.Debugln("Parsing response")
+	credsResp, err := BackplaneApi.ParseGetCloudCredentialsResponse(resp)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse response body from backplane:\n  Status Code: %d : err: %v", resp.StatusCode, err)
+	}
+
+	if len(credsResp.Body) == 0 {
+		return nil, fmt.Errorf("empty response from backplane")
+	}
+	return credsResp, nil
+}
+
+// renderCloudCredentials displays the results of `ocm backplane cloud credentials` for AWS clusters
+func renderCloudCredentials(creds CredentialsResponse) error {
+	switch credentialArgs.output {
+	case "env":
+		fmt.Println(creds.fmtExport())
+		return nil
+	case "yaml":
+		yamlBytes, err := yaml.Marshal(creds)
+		if err != nil {
+			return err
+		}
+		fmt.Println("---")
+		fmt.Println(string(yamlBytes))
+		return nil
+	case "json":
+		jsonBytes, err := json.Marshal(creds)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(jsonBytes))
+		return nil
+	default:
+		fmt.Println(creds)
+	}
+	return nil
+}

--- a/cmd/ocm-backplane/cloud/credentials_test.go
+++ b/cmd/ocm-backplane/cloud/credentials_test.go
@@ -1,0 +1,138 @@
+package cloud
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/backplane-cli/pkg/client/mocks"
+	"github.com/openshift/backplane-cli/pkg/utils"
+	mocks2 "github.com/openshift/backplane-cli/pkg/utils/mocks"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+var _ = Describe("Cloud console command", func() {
+
+	var (
+		mockCtrl           *gomock.Controller
+		mockClient         *mocks.MockClientInterface
+		mockClientWithResp *mocks.MockClientWithResponsesInterface
+		mockOcmInterface   *mocks2.MockOCMInterface
+		mockClientUtil     *mocks2.MockClientUtils
+
+		trueClusterId string
+		proxyUri      string
+		credentialAWS string
+		credentialGcp string
+
+		fakeAWSResp    *http.Response
+		fakeGCloudResp *http.Response
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockClient = mocks.NewMockClientInterface(mockCtrl)
+		mockClientWithResp = mocks.NewMockClientWithResponsesInterface(mockCtrl)
+
+		mockOcmInterface = mocks2.NewMockOCMInterface(mockCtrl)
+		utils.DefaultOCMInterface = mockOcmInterface
+
+		mockClientUtil = mocks2.NewMockClientUtils(mockCtrl)
+		utils.DefaultClientUtils = mockClientUtil
+
+		trueClusterId = "trueID123"
+		proxyUri = "https://shard.apps"
+		credentialAWS = "fake aws credential"
+		credentialGcp = "fake gcp credential"
+
+		mockClientWithResp.EXPECT().LoginClusterWithResponse(gomock.Any(), gomock.Any()).Return(nil, nil).Times(0)
+
+		// Define fake AWS response
+		fakeAWSResp = &http.Response{
+			Body: MakeIoReader(
+				fmt.Sprintf(`{"proxy_uri":"proxy", "statusCode":200, "message":"msg", "JSON200":"%s"}`, credentialAWS),
+			),
+			Header:     map[string][]string{},
+			StatusCode: http.StatusOK,
+		}
+		fakeAWSResp.Header.Add("Content-Type", "json")
+
+		// Define fake AWS response
+		fakeGCloudResp = &http.Response{
+			Body: MakeIoReader(
+				fmt.Sprintf(`{"proxy_uri":"proxy", "statusCode":200, "message":"msg", "JSON200":"%s"}`, credentialGcp),
+			),
+			Header:     map[string][]string{},
+			StatusCode: http.StatusOK,
+		}
+		fakeGCloudResp.Header.Add("Content-Type", "json")
+
+		// Clear config file
+		_ = clientcmd.ModifyConfig(clientcmd.NewDefaultPathOptions(), api.Config{}, true)
+		clientcmd.UseModifyConfigLock = false
+
+		// Disabled log output
+		log.SetOutput(io.Discard)
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	Context("test get Cloud Credential", func() {
+
+		It("should return AWS cloud credential", func() {
+			mockOcmInterface.EXPECT().GetBackplaneURL().Return(proxyUri, nil).AnyTimes()
+			mockClientUtil.EXPECT().GetBackplaneClient(proxyUri).Return(mockClient, nil).AnyTimes()
+			mockClient.EXPECT().GetCloudCredentials(gomock.Any(), trueClusterId).Return(fakeAWSResp, nil)
+
+			crdentialResponse, err := getCloudCredential(proxyUri, trueClusterId)
+			Expect(err).To(BeNil())
+
+			Expect(crdentialResponse.JSON200).NotTo(BeNil())
+
+		})
+
+		It("should fail when AWS Unavailable", func() {
+			fakeAWSResp.StatusCode = http.StatusInternalServerError
+			mockOcmInterface.EXPECT().GetBackplaneURL().Return(proxyUri, nil).AnyTimes()
+			mockClientUtil.EXPECT().GetBackplaneClient(proxyUri).Return(mockClient, nil).AnyTimes()
+			mockClient.EXPECT().GetCloudCredentials(gomock.Any(), trueClusterId).Return(fakeAWSResp, nil)
+			_, err := getCloudCredential(proxyUri, trueClusterId)
+			Expect(err).NotTo(BeNil())
+
+			Expect(err.Error()).Should(ContainSubstring("error from backplane: \n Status Code: 500\n"))
+
+		})
+
+		It("should fail when GCP Unavailable", func() {
+			fakeGCloudResp.StatusCode = http.StatusInternalServerError
+			mockOcmInterface.EXPECT().GetBackplaneURL().Return(proxyUri, nil).AnyTimes()
+			mockClientUtil.EXPECT().GetBackplaneClient(proxyUri).Return(mockClient, nil).AnyTimes()
+			mockClient.EXPECT().GetCloudCredentials(gomock.Any(), trueClusterId).Return(fakeGCloudResp, nil)
+			_, err := getCloudCredential(proxyUri, trueClusterId)
+			Expect(err).NotTo(BeNil())
+
+			Expect(err.Error()).Should(ContainSubstring("error from backplane: \n Status Code: 500\n"))
+
+		})
+
+		It("should fail for unauthorized BP-API", func() {
+			fakeAWSResp.StatusCode = http.StatusUnauthorized
+			mockOcmInterface.EXPECT().GetBackplaneURL().Return(proxyUri, nil).AnyTimes()
+			mockClientUtil.EXPECT().GetBackplaneClient(proxyUri).Return(mockClient, nil).AnyTimes()
+			mockClient.EXPECT().GetCloudCredentials(gomock.Any(), trueClusterId).Return(fakeAWSResp, nil)
+			_, err := getCloudCredential(proxyUri, trueClusterId)
+			Expect(err).NotTo(BeNil())
+
+			Expect(err.Error()).Should(ContainSubstring("error from backplane: \n Status Code: 401\n"))
+
+		})
+	})
+
+})

--- a/cmd/ocm-backplane/root.go
+++ b/cmd/ocm-backplane/root.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/openshift/backplane-cli/cmd/ocm-backplane/cloud"
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/upgrade"
 
 	log "github.com/sirupsen/logrus"
@@ -80,4 +81,5 @@ func init() {
 
 	// Register sub-commands
 	rootCmd.AddCommand(upgrade.UpgradeCmd)
+	rootCmd.AddCommand(cloud.CloudCmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,12 @@ go 1.18
 require (
 	github.com/golang/mock v1.6.0
 	github.com/olekukonko/tablewriter v0.0.5
+	github.com/onsi/ginkgo v1.16.4
+	github.com/onsi/gomega v1.23.0
 	github.com/openshift-online/ocm-cli v0.1.65
 	github.com/openshift-online/ocm-sdk-go v0.1.316
 	github.com/openshift/backplane-api v0.0.0-20230203044845-10f2b341bf54
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	golang.org/x/term v0.3.0
@@ -26,6 +29,7 @@ require (
 	github.com/deepmap/oapi-codegen v1.12.4 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/getkin/kin-openapi v0.113.0 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
@@ -63,6 +67,7 @@ require (
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/perimeterx/marshmallow v1.1.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/prometheus/client_golang v1.13.0 // indirect
@@ -80,6 +85,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.26.1 // indirect
@@ -96,6 +102,7 @@ require (
 
 require (
 	github.com/Masterminds/semver v1.5.0
+	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1
 )

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,7 @@ github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQL
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/getkin/kin-openapi v0.113.0 h1:t9aNS/q5Agr7a55Jp1AuZ3sR2WzHESv3Dd2ys4UphsM=
 github.com/getkin/kin-openapi v0.113.0/go.mod h1:l5e9PaFUo9fyLJCPGQeXI2ML8c3P8BHOEV2VaAVf/pc=
@@ -120,6 +121,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/go-yaml/yaml v2.1.0+incompatible h1:RYi2hDdss1u4YE7GwixGzWwVo47T8UQwnTLB6vQiq+o=
+github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -353,6 +356,7 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
@@ -368,6 +372,7 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/onsi/gomega v1.23.0 h1:/oxKu9c2HVap+F3PfKort2Hw5DEU+HGlW8n+tguWsys=
+github.com/onsi/gomega v1.23.0/go.mod h1:Z/NWtiqwBrwUt4/2loMmHL63EDLnYHmVbuBpDr2vQAg=
 github.com/openshift-online/ocm-cli v0.1.65 h1:GSleKek+tFfEwPmuNfqAKV2u/g8b2bjJG+48t/WyAqU=
 github.com/openshift-online/ocm-cli v0.1.65/go.mod h1:mwqx30zOzIGdgnuOfG04sr6WUYvTvLWZySZ7tMv+XpA=
 github.com/openshift-online/ocm-sdk-go v0.1.316 h1:rBU+bW5fSqIk2xiTNRLpSgBsPxAC+kDYHKUWsxWDqCk=
@@ -378,6 +383,8 @@ github.com/perimeterx/marshmallow v1.1.4 h1:pZLDH9RjlLGGorbXhcaQLhfuV0pFMNfPO55F
 github.com/perimeterx/marshmallow v1.1.4/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -639,6 +646,7 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -818,6 +826,7 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:aPpfJ7XW+gOuirDoZ8gHhLh3kZ1B08FtV2bbmy7Jv3s=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
## Introduction 
This PR adds the following things to backplane cli 

* Add cloud console command 
```
ocm backplane cloud console <cluster-id>
```

* Add cloud credentials command 
```
ocm backplane cloud credentials <cluster-id>
```

## Reference 
[OSD-14684](https://issues.redhat.com/browse/OSD-14684)
 