### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+### What type of PR is this?
+
+_(bug/feature/cleanup/documentation)_
+
+### What this PR does / Why we need it?
+
+### Which Jira/Github issue(s) does this PR fix?
+
+_Resolves #_
+
+### Special notes for your reviewer
+
+### Pre-checks (if applicable)
+
+- [ ] Ran unit tests locally
+- [ ] Validated the changes in a cluster
+- [ ] Included documentation changes with PR


### PR DESCRIPTION
There are cases where PRs are submitted with no description. This is a poor posture from a compliance and review perspective. This PR adds a template to encourage engineers to answer a standard set of questions when submitted.