### PR TITLE
Deprecate tunnel call in cluster.go and add BACKPLANE_CONFIG environment variable

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -7,5 +7,6 @@ const (
 	Version = "0.0.0"
 
 	BACKPLANE_URL_ENV_NAME     = "BACKPLANE_URL"
-	BACKPLANE_CONFIG_FILE_PATH = "~/.backplane.json"
+	BACKPLANE_CONFIG_PATH_ENV_NAME     = "BACKPLANE_CONFIG"
+	BACKPLANE_CONFIG_DEFAULT_PATH = "~/.backplane.json"
 )

--- a/pkg/utils/cluster.go
+++ b/pkg/utils/cluster.go
@@ -58,20 +58,20 @@ func GetBackplaneClusterFromConfig() (BackplaneCluster, error) {
 func GetBackplaneClusterFromClusterKey(clusterKey string) (BackplaneCluster, error) {
 	logger.WithField("SearchKey", clusterKey).Debugln("Finding target cluster")
 	clusterID, clusterName, err := DefaultOCMInterface.GetTargetCluster(clusterKey)
+
 	if err != nil {
 		return BackplaneCluster{}, err
 	}
 
-	// TODO: Deprecate tunneling
-	//backplaneHost, err := DefaultOCMInterface.GetBackplaneShard(clusterID)
-	backplaneHost := ""
+	backplaneURL, err := DefaultOCMInterface.GetBackplaneURL()
+
 	if err != nil {
 		return BackplaneCluster{}, err
 	}
 	cluster := BackplaneCluster{
 		ClusterID:     clusterID,
-		BackplaneHost: backplaneHost,
-		ClusterURL:    fmt.Sprintf("%s/backplane/cluster/%s", backplaneHost, clusterID),
+		BackplaneHost: backplaneURL,
+		ClusterURL:    fmt.Sprintf("%s/backplane/cluster/%s", backplaneURL, clusterID),
 	}
 	logger.WithFields(logger.Fields{
 		"ClusterID":     cluster.ClusterID,

--- a/pkg/utils/cluster_test.go
+++ b/pkg/utils/cluster_test.go
@@ -1,12 +1,15 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/openshift/backplane-cli/pkg/utils/mocks"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -210,4 +213,74 @@ func TestGetClusterIDAndHostFromClusterURL(t *testing.T) {
 
 		})
 	}
+}
+
+func TestGetBackplaneClusterFromClusterKey(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+
+
+	mockOcmInterface := mocks.NewMockOCMInterface(mockCtrl)
+
+	// So we can clean up at the end
+	tempDefaultOCMInterface := DefaultOCMInterface
+
+	DefaultOCMInterface = mockOcmInterface
+
+	t.Run("it errors if BACKPLANE_URL_ENV_NAME is empty", func(_ *testing.T) {
+		backplaneConfigPath := "~/.backplane.json"
+		errorResp := fmt.Errorf("failed to read file %s : %v", backplaneConfigPath, errors.New("File not found"))
+		mockOcmInterface.EXPECT().GetBackplaneURL().Return("", errorResp)
+		mockOcmInterface.EXPECT().GetTargetCluster("cluster-key").Return("1234", "cluster-key", nil)
+
+		_, err := GetBackplaneClusterFromClusterKey("cluster-key")
+		if err != errorResp {
+			t.Errorf("expected errorResp %v, got %v", errorResp, err)
+		}
+	})
+
+	t.Run("it errors if BACKPLANE_CONFIG_FILE_PATH cannot be decoded", func(_ *testing.T) {
+		backplaneConfigPath := "~/.backplane.json"
+		errorResp := fmt.Errorf("failed to decode file %s : %v", backplaneConfigPath, errors.New("File could not be decoded"))
+		mockOcmInterface.EXPECT().GetBackplaneURL().Return("", errorResp)
+		mockOcmInterface.EXPECT().GetTargetCluster("cluster-key").Return("1234", "cluster-key", nil)
+
+		_, err := GetBackplaneClusterFromClusterKey("cluster-key")
+		if err != errorResp {
+			t.Errorf("expected errorResp %v, got %v", errorResp, err)
+		}
+	})
+
+	t.Run("it errors if BACKPLANE_URL_ENV_NAME is empty", func(_ *testing.T) {
+		errorResp := fmt.Errorf("%s env variable is empty", "BACKPLANE_URL")
+		mockOcmInterface.EXPECT().GetBackplaneURL().Return("", errorResp)
+		mockOcmInterface.EXPECT().GetTargetCluster("cluster-key").Return("1234", "cluster-key", nil)
+
+		_, err := GetBackplaneClusterFromClusterKey("cluster-key")
+		if err != errorResp {
+			t.Errorf("expected errorResp %v, got %v", errorResp, err)
+		}
+	})
+
+	t.Run("it returns a cluster struct from a valid cluster key", func(_ *testing.T) {
+		mockOcmInterface.EXPECT().GetBackplaneURL().Return("https://backplane-url.cluster-key.redhat.com", nil)
+		mockOcmInterface.EXPECT().GetTargetCluster("cluster-key").Return("1234", "cluster-key", nil)
+
+		cluster, err := GetBackplaneClusterFromClusterKey("cluster-key")
+
+		expectedCluster := BackplaneCluster{
+			ClusterID:     "1234",
+			BackplaneHost: "https://backplane-url.cluster-key.redhat.com",
+			ClusterURL:    fmt.Sprintf("%s/backplane/cluster/%s", "https://backplane-url.cluster-key.redhat.com", "1234"),
+		}
+
+		if err != nil {
+			t.Errorf("expected errorResp %v, got %v", nil, err)
+		}
+
+		if !reflect.DeepEqual(cluster, expectedCluster) {
+			t.Errorf("expected clusters %v and %v to be equal", cluster, expectedCluster)
+		}
+	})
+
+	DefaultOCMInterface = tempDefaultOCMInterface
 }

--- a/pkg/utils/ocmWrapper.go
+++ b/pkg/utils/ocmWrapper.go
@@ -136,7 +136,6 @@ func (*DefaultOCMInterfaceImpl) IsProduction() (bool, error) {
 
 // GetBackplaneURL from local settings
 func (*DefaultOCMInterfaceImpl) GetBackplaneURL() (string, error) {
-
 	// get backplane URL from BACKPLANE_URL env variables
 	bpURL, hasURL := os.LookupEnv(info.BACKPLANE_URL_ENV_NAME)
 	if hasURL {
@@ -147,13 +146,12 @@ func (*DefaultOCMInterfaceImpl) GetBackplaneURL() (string, error) {
 		}
 	} else {
 		// get backplane URL for user home folder .backplane.json file
-		homeDir, _ := os.UserHomeDir()
-		filePath := homeDir + "/" + info.BACKPLANE_CONFIG_FILE_PATH
+		filePath := getBackplaneConfigFile()
 		if _, err := os.Stat(filePath); err == nil {
 			file, err := os.Open(filePath)
 
 			if err != nil {
-				return "", fmt.Errorf("failed to read file %s : %v", info.BACKPLANE_URL_ENV_NAME, err)
+				return "", fmt.Errorf("failed to read file %s : %v", filePath, err)
 			}
 
 			defer file.Close()
@@ -162,13 +160,22 @@ func (*DefaultOCMInterfaceImpl) GetBackplaneURL() (string, error) {
 			err = decoder.Decode(&configuration)
 
 			if err != nil {
-				return "", fmt.Errorf("failed to decode file %s : %v", info.BACKPLANE_URL_ENV_NAME, err)
+				return "", fmt.Errorf("failed to decode file %s : %v", filePath, err)
 			}
 			return configuration.URL, nil
 		}
 
 	}
 	return "", nil
+}
+
+func getBackplaneConfigFile() string {
+	path, bpConfigFound := os.LookupEnv(info.BACKPLANE_CONFIG_PATH_ENV_NAME)
+	if bpConfigFound {
+		return path
+	}
+
+	return info.BACKPLANE_CONFIG_DEFAULT_PATH
 }
 
 func getClusters(client *cmv1.ClustersClient, clusterKey string) ([]*cmv1.Cluster, error) {

--- a/pkg/utils/util_test.go
+++ b/pkg/utils/util_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/openshift/backplane-cli/pkg/info"
 )
 
 func TestParseParamFlag(t *testing.T) {
@@ -100,6 +102,24 @@ func TestGetBackplaneURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetBackplaneConfigFile(t *testing.T) {
+	t.Run("it returns the Backplane configuration file path if it exists in the user's env", func(t *testing.T) {
+		t.Setenv(info.BACKPLANE_CONFIG_PATH_ENV_NAME, "~/.backplane.stg.env.json")
+		path := getBackplaneConfigFile()
+		if path != "~/.backplane.stg.env.json" {
+			t.Errorf("expected path to be %v, got %v", "~/.backplane.stg.env.json", path)
+		}
+	})
+
+	t.Run("it returns the default configuration file path if it does not exist in the user's env", func(t *testing.T) {
+		path := getBackplaneConfigFile()
+		expectedPath := info.BACKPLANE_CONFIG_DEFAULT_PATH
+		if path != expectedPath {
+			t.Errorf("expected path to be %v, got %v", expectedPath, path)
+		}
+	})
 }
 
 func TestMatchBaseDomain(t *testing.T) {


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / Why we need it?
This pull request replaces the call to get the backplane host from the hive shard with a call to `GetBackplaneURL()`. This removes the dependency on `ocm backplane tunnel`. 

If the environment variable isn't set, or the path to the config file does not exist or is invalid, it shows an error. 

If those are valid, it uses that configuration file or environment variable as the program's `BACKPLANE_URL`. 

### Which Jira/Github issue(s) does this PR fix?

_Resolves [OSD-14678](https://issues.redhat.com/browse/OSD-14678)_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
