### PR TITLE
Add elevate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ To setup the PS1(prompt) for bash/zsh, please follow [these instructions](./docs
 | `ocm backplane console [flags]`                                             | Launch the OpenShift console of the current logged in cluster                            |
 | `ocm backplane cloud console`                                               | Launch the current logged in cluster's cloud provider console                            |
 | `ocm backplane cloud credentials [flags]`                                   | Retrieve a set of temporary cloud credentials for the cluster's cloud provider           |
+| `ocm backplane elevate <reason> -- <command>`                               | Elevate privileges to backplane-cluster-admin and add a reason to the api request        |
 | `ocm-backplane monitoring <prometheus/alertmanager/thanos/grafana> [flags]` | Launch the specified monitoring UI (Deprecated following v4.11)                          |
 | `ocm-backplane project <project_name>`                                      | Manipulate the Kubeconfig and set the namespace of the current context to `project_name` |
 | `ocm-backplane script describe <script> [flags]`                            | Describe the given backplane script                                                      |

--- a/cmd/ocm-backplane/elevate/elevate.go
+++ b/cmd/ocm-backplane/elevate/elevate.go
@@ -1,0 +1,20 @@
+package elevate
+
+import (
+	"github.com/openshift/backplane-cli/pkg/elevate"
+	"github.com/spf13/cobra"
+)
+
+var ElevateCmd = &cobra.Command{
+	Use:          "elevate <REASON> <COMMAND>",
+	Short:        "Give a justification for elevating privileges to backplane-cluster-admin and attach it to your user object",
+	Long:         `Elevate to backplane-cluster-admin, and give a reason to do so. This will then be forwarded to your audit collection backend of your choice as the 'Impersonate-User-Extra' HTTP header, which can then be used for tracking, compliance, and security reasons. The command creates a temporary kubeconfig and clusterrole for your user, to allow you to add the extra header to your Kube API request.`,
+	Example:      "ocm backplane elevate <reason> -- get po -A",
+	Args:         cobra.MinimumNArgs(2),
+	RunE:         runElevate,
+	SilenceUsage: true,
+}
+
+func runElevate(cmd *cobra.Command, argv []string) error {
+	return elevate.RunElevate(argv)
+}

--- a/cmd/ocm-backplane/root.go
+++ b/cmd/ocm-backplane/root.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/cloud"
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/console"
+	"github.com/openshift/backplane-cli/cmd/ocm-backplane/elevate"
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/login"
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/logout"
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/managedJob"
@@ -89,6 +90,7 @@ func init() {
 	// Register sub-commands
 	rootCmd.AddCommand(login.LoginCmd)
 	rootCmd.AddCommand(upgrade.UpgradeCmd)
+	rootCmd.AddCommand(elevate.ElevateCmd)
 	rootCmd.AddCommand(cloud.CloudCmd)
 	rootCmd.AddCommand(logout.LogoutCmd)
 	rootCmd.AddCommand(script.NewScriptCmd())

--- a/pkg/elevate/elevate.go
+++ b/pkg/elevate/elevate.go
@@ -1,0 +1,90 @@
+package elevate
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/openshift/backplane-cli/pkg/utils"
+	logger "github.com/sirupsen/logrus"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+var (
+	OsRemove              = os.Remove
+	ExecCmd               = exec.Command
+	ReadKubeConfigRaw     = utils.ReadKubeconfigRaw
+	WriteKubeconfigToFile = utils.CreateTempKubeConfig
+)
+
+func AddElevationReasonToRawKubeconfig(config api.Config, elevationReason string) error {
+	logger.Debugln("Adding reason for backplane-cluster-admin elevation")
+	if config.Contexts[config.CurrentContext] == nil {
+		return errors.New("No current kubeconfig context")
+	}
+
+	currentCtxUsername := config.Contexts[config.CurrentContext].AuthInfo
+
+	if config.AuthInfos[currentCtxUsername] == nil {
+		return errors.New("No current user information")
+	}
+
+	if config.AuthInfos[currentCtxUsername].ImpersonateUserExtra == nil {
+		config.AuthInfos[currentCtxUsername].ImpersonateUserExtra = make(map[string][]string)
+	}
+
+	config.AuthInfos[currentCtxUsername].ImpersonateUserExtra["reason"] = []string{elevationReason}
+	config.AuthInfos[currentCtxUsername].Impersonate = "backplane-cluster-admin"
+
+	return nil
+}
+
+func RunElevate(argv []string) error {
+	logger.Debugln("Finding target cluster from kubeconfig")
+	config, err := ReadKubeConfigRaw()
+
+	if err != nil {
+		return err
+	}
+
+	err = AddElevationReasonToRawKubeconfig(config, argv[0])
+	if err != nil {
+		return err
+	}
+
+	err = WriteKubeconfigToFile(&config)
+	if err != nil {
+		return err
+	}
+
+	logger.Debug("Adding impersonation RBAC allow permissions to kubeconfig")
+
+	elevateCmd := argv[1:]
+
+	logger.Debugln("Executing command with temporary kubeconfig as backplane-cluster-admin")
+	ocCmd := ExecCmd("oc", elevateCmd...)
+
+	ocCmd.Env = append(ocCmd.Env, os.Environ()...)
+	ocCmd.Stderr = os.Stderr
+	ocCmd.Stdout = os.Stdout
+
+	if err != nil {
+		return err
+	}
+
+	err = ocCmd.Run()
+	kubeconfigPath, _ := os.LookupEnv("KUBECONFIG")
+	defer func() {
+		logger.Debugln("Command error; Cleaning up temporary kubeconfig")
+		err := OsRemove(kubeconfigPath)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/elevate/elevate_test.go
+++ b/pkg/elevate/elevate_test.go
@@ -1,0 +1,200 @@
+package elevate
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+func fakeExecCommandError(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestHelperProcessError", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
+}
+
+func fakeExecCommandSuccess(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestHelperProcessSuccess", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
+}
+
+func TestHelperProcessError(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	os.Exit(1)
+}
+
+func TestHelperProcessSuccess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprintf(os.Stdout, "")
+	os.Exit(0)
+}
+
+func TestAddElevationReasonToRawKubeconfig(t *testing.T) {
+	t.Run("It returns an error if there is no current kubeconfig context", func(t *testing.T) {
+		if err := AddElevationReasonToRawKubeconfig(
+			api.Config{},
+			"Production cluster",
+		); err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("it returns an error if there is no user info in kubeconfig", func(t *testing.T) {
+		if err := AddElevationReasonToRawKubeconfig(
+			api.Config{
+				Kind:        "Config",
+				APIVersion:  "v1",
+				Preferences: api.Preferences{},
+				Clusters: map[string]*api.Cluster{
+					"dummy_cluster": {
+						Server: "https://api-backplane.apps.something.com/backplane/cluster/configcluster",
+					},
+				},
+				Contexts: map[string]*api.Context{
+					"default/test123/anonymous": {
+						Cluster:   "dummy_cluster",
+						Namespace: "default",
+					},
+				},
+				CurrentContext: "default/test123/anonymous",
+			},
+			"Production cluster",
+		); err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("it succeeds if the auth info exists for the current context", func(t *testing.T) {
+		if err := AddElevationReasonToRawKubeconfig(
+			api.Config{
+				Kind:        "Config",
+				APIVersion:  "v1",
+				Preferences: api.Preferences{},
+				Clusters: map[string]*api.Cluster{
+					"dummy_cluster": {
+						Server: "https://api-backplane.apps.something.com/backplane/cluster/configcluster",
+					},
+				},
+				AuthInfos: map[string]*api.AuthInfo{
+					"anonymous": {
+						LocationOfOrigin: "England",
+					},
+				},
+				Contexts: map[string]*api.Context{
+					"default/test123/anonymous": {
+						Cluster:   "dummy_cluster",
+						Namespace: "default",
+						AuthInfo:  "anonymous",
+					},
+				},
+				CurrentContext: "default/test123/anonymous",
+			},
+			"Production cluster",
+		); err != nil {
+			t.Errorf("Expected no errors, got %v", err)
+		}
+	})
+}
+
+func TestRunElevate(t *testing.T) {
+	t.Run("It errors if we cannot load the kubeconfig", func(t *testing.T) {
+		ExecCmd = exec.Command
+		OsRemove = os.Remove
+		ReadKubeConfigRaw = func() (api.Config, error) {
+			return *api.NewConfig(), errors.New("cannot load kfg")
+		}
+		if err := RunElevate([]string{}); err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("It errors if kubeconfig has no current context", func(t *testing.T) {
+		ExecCmd = exec.Command
+		OsRemove = os.Remove
+		ReadKubeConfigRaw = func() (api.Config, error) {
+			return *api.NewConfig(), nil
+		}
+		if err := RunElevate([]string{"oc", "get pods"}); err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("It errors if the exec command errors", func(t *testing.T) {
+		ExecCmd = fakeExecCommandError
+		OsRemove = os.Remove
+		ReadKubeConfigRaw = func() (api.Config, error) {
+			return api.Config{
+				Kind:        "Config",
+				APIVersion:  "v1",
+				Preferences: api.Preferences{},
+				Clusters: map[string]*api.Cluster{
+					"dummy_cluster": {
+						Server: "https://api-backplane.apps.something.com/backplane/cluster/configcluster",
+					},
+				},
+				AuthInfos: map[string]*api.AuthInfo{
+					"anonymous": {
+						LocationOfOrigin: "England",
+					},
+				},
+				Contexts: map[string]*api.Context{
+					"default/test123/anonymous": {
+						Cluster:   "dummy_cluster",
+						Namespace: "default",
+						AuthInfo:  "anonymous",
+					},
+				},
+				CurrentContext: "default/test123/anonymous",
+			}, nil
+		}
+
+		if err := RunElevate([]string{"oc", "get pods"}); err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("It suceeds if the command succeeds and we can clean up the tmp kubeconfig", func(t *testing.T) {
+		ExecCmd = fakeExecCommandSuccess
+		OsRemove = func(name string) error { return nil }
+		ReadKubeConfigRaw = func() (api.Config, error) {
+			return api.Config{
+				Kind:        "Config",
+				APIVersion:  "v1",
+				Preferences: api.Preferences{},
+				Clusters: map[string]*api.Cluster{
+					"dummy_cluster": {
+						Server: "https://api-backplane.apps.something.com/backplane/cluster/configcluster",
+					},
+				},
+				AuthInfos: map[string]*api.AuthInfo{
+					"anonymous": {
+						LocationOfOrigin: "England",
+					},
+				},
+				Contexts: map[string]*api.Context{
+					"default/test123/anonymous": {
+						Cluster:   "dummy_cluster",
+						Namespace: "default",
+						AuthInfo:  "anonymous",
+					},
+				},
+				CurrentContext: "default/test123/anonymous",
+			}, nil
+		}
+		if err := RunElevate([]string{"oc", "get pods"}); err != nil {
+			t.Errorf("Expected no errors, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
### What type of PR is this?

_(feature)_

### What this PR does / Why we need it?

This pull request add the ability to elevate to `backplane-cluster-admin` using `ocm-backplane`, as well as adding an optional `ElevationReason` to the Kube API request in-place. 

This makes audit tracking and resolving compliance tickets easier, reducing the burden on on-call developers, managers, and users of backplane. 

Usage: 
`ocm backplane elevate <reason-string> <command>`
`ocm backplane elevate 'Getting pods in all namespaces' -- get po -A`. 

#### How it works: 
`--as backplane-cluster-admin` is added to end the request, which is sent to `os.Exec`. A new temporary kubeconfig with the `impersonation.user-extra` property "elevationReason"=<reason> is then created. A new temporary role is created (and the old one deleted) that allows adding this extra field to the API HTTP request (see [docs](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation) for why this is necessary). 
We then set this to kubeconfig environment variable for that request, perform it, delete the temporary kubeconfig, and return the result. 

#### To test:
`make`
`BACKPLANE_URL=<backplane-url> ./ocm-backplane elevate 'foo bar' -- get pods -v=8`
You should see the `Elevation` header in the HTTP request to the kubernetes API:

```
:results:
I0314 14:11:00.942266  358945 loader.go:372] Config loaded from file:  /tmp/1478328690
I0314 14:11:00.942567  358945 round_trippers.go:463] GET https://<backplane-url>
I0314 14:11:00.942572  358945 round_trippers.go:469] Request Headers:
I0314 14:11:00.942578  358945 round_trippers.go:473]     Accept: application/json, */*
I0314 14:11:00.942582  358945 round_trippers.go:473]     Impersonate-User: backplane-cluster-admin
I0314 14:11:00.942586  358945 round_trippers.go:473]     Impersonate-Extra-Reason: foo bar
I0314 14:11:00.942590  358945 round_trippers.go:473]     User-Agent: oc/4.11.0 (linux/amd64) kubernetes/1928ac4
I0314 14:11:01.568122  358945 round_trippers.go:574] Response Status: 200 OK in 625 milliseconds
....
```

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_https://issues.redhat.com/browse/OSD-13235

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ x ] Ran unit tests locally
- [ x ] Validated the changes in a cluster
- [x] Included documentation changes with PR
