### PR TITLE
Add flag to login to managing cluster instead of target cluster

### DIFF
--- a/pkg/utils/mocks/ocmWrapperMock.go
+++ b/pkg/utils/mocks/ocmWrapperMock.go
@@ -64,6 +64,22 @@ func (mr *MockOCMInterfaceMockRecorder) GetClusterInfoByID(arg0 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterInfoByID", reflect.TypeOf((*MockOCMInterface)(nil).GetClusterInfoByID), arg0)
 }
 
+// GetManagingCluster mocks base method.
+func (m *MockOCMInterface) GetManagingCluster(arg0 string) (string, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetManagingCluster", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetManagingCluster indicates an expected call of GetManagingCluster.
+func (mr *MockOCMInterfaceMockRecorder) GetManagingCluster(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetManagingCluster", reflect.TypeOf((*MockOCMInterface)(nil).GetManagingCluster), arg0)
+}
+
 // GetOCMAccessToken mocks base method.
 func (m *MockOCMInterface) GetOCMAccessToken() (*string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### What type of PR is this?

Feature 

### What this PR does / Why we need it?

This change introduces an optional `--manager` flag to ocm backplane login which will cause the CLI to look up the cluster's "managing" cluster (either a Hive shard, or a Hypershift Management Cluster) and log in to that instead.

Note that this change will not work for Hive-based clusters in Staging/Integration environments, as their managing cluster exists in a different environment. (however, this is not a problem for Hypershift clusters)

This change also fixes some small formatting issues in the existing `login.go` (code indented unnecessarily).

### Pre-checks (if applicable)

- [X] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
