### PR TITLE
OSD-15582: Make backplane-api server regex loosely restricted

### DIFF
--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	ClustersPageSize             = 50
-	BackplaneApiUrlRegexp string = `(?mi)^https:\/\/api\.(.*).backplane\.devshift\.net(.*)`
+	BackplaneApiUrlRegexp string = `(?mi)^https:\/\/api\.(.*).backplane\.(.*)`
 	ClusterIDRegexp       string = "/?backplane/cluster/([a-zA-Z0-9]+)/?"
 )
 


### PR DESCRIPTION
Follows up on https://github.com/openshift/backplane-cli/pull/44