### PR TITLE
OSD-15550 - Add error handling and unit test for empty list of scripts

### DIFF
--- a/cmd/ocm-backplane/script/listScripts.go
+++ b/cmd/ocm-backplane/script/listScripts.go
@@ -81,9 +81,14 @@ func newListScriptCmd() *cobra.Command {
 				return fmt.Errorf("unable to parse response body from backplane: Status Code: %d", resp.StatusCode)
 			}
 
+			scriptList := *(*[]bpclient.Script)(listResp.JSON200) 
+			if (len(scriptList) == 0) {
+				return fmt.Errorf("no scripts found")
+			}
+
 			headings := []string{"NAME", "DESCRIPTION"}
 			rows := make([][]string, 0)
-			for _, s := range *(*[]bpclient.Script)(listResp.JSON200) {
+			for _, s := range scriptList {
 				rows = append(rows, []string{*s.CanonicalName, *s.Description})
 			}
 

--- a/cmd/ocm-backplane/script/listScripts_test.go
+++ b/cmd/ocm-backplane/script/listScripts_test.go
@@ -153,5 +153,20 @@ var _ = Describe("list script command", func() {
 
 			Expect(err).ToNot(BeNil())
 		})
+
+		It("should handle an empty list of scripts without errors", func() {
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterId).Return(trueClusterId, testClusterId, nil)
+			mockOcmInterface.EXPECT().GetBackplaneURL().Return(proxyUri, nil).AnyTimes()
+			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterId)).Return(false, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil).AnyTimes()
+			mockClientUtil.EXPECT().MakeRawBackplaneAPIClient(gomock.Any()).Return(mockClient, nil)
+			fakeResp.Body = MakeIoReader("[]")
+			mockClient.EXPECT().GetScripts(gomock.Any(), &bpclient.GetScriptsParams{}).Return(fakeResp, nil)
+
+			sut.SetArgs([]string{"list", testJobId, "--cluster-id", testClusterId})
+			err := sut.Execute()
+
+			Expect(err).ToNot(BeNil())
+		})
 	})
 })


### PR DESCRIPTION
### What type of PR is this?

Bug

### What this PR does / Why we need it?

When a user does not have any script listed for them, Backplane CLI throws a vague error which is bad user experience. This PR fixes the issue.

### Which Jira/Github issue(s) does this PR fix?

[OSD-15550](https://issues.redhat.com//browse/OSD-15550)

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [x] Included documentation changes with PR
