### PR TITLE
Tweak regex to conform to prod URL

### DIFF
--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	ClustersPageSize             = 50
-	BackplaneApiUrlRegexp string = `(?mi)^https:\/\/api\.(.*).backplane\.(.*)`
+	BackplaneApiUrlRegexp string = `(?mi)^https:\/\/api\.(.*)backplane\.(.*)`
 	ClusterIDRegexp       string = "/?backplane/cluster/([a-zA-Z0-9]+)/?"
 )
 


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / Why we need it?
It was assumed that all Backplane API URLs will be in the form of `api.{env}.backplane.{openshift|devshift}.{com|net}` but the production URL doesn't specify the OCM environment in it (`api.backplane.openshift` ).

This PR tweaks the bp-api regex to conform to the same.