### PR TITLE
Bug fix: proxy-url not exists after login

### DIFF
--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -94,6 +94,9 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 		}
 		logger.Debugf("Using backplane Proxy URL: %s\n", proxyUrl)
 	}
+	if len(proxyUrl) == 0 {
+		proxyUrl = bpConfig.ProxyURL
+	}
 
 	clusterId, clusterName, err := utils.DefaultOCMInterface.GetTargetCluster(clusterKey)
 	if err != nil {
@@ -173,7 +176,7 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 
 	// Add proxy URL to target cluster
 
-	if globalOpts.ProxyURL != "" {
+	if proxyUrl != "" {
 		targetCluster.ProxyURL = proxyUrl
 	}
 


### PR DESCRIPTION
### What type of PR is this?

_(bug/feature/cleanup/documentation)_
bug
### What this PR does / Why we need it?
write proxy-url to kubeconfig after login
### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
