### PR TITLE
Change config file name

### DIFF
--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/openshift/backplane-cli/pkg/info"
 )
@@ -24,13 +25,14 @@ func GetBackplaneConfigFile() string {
 
 // Get Backplane config default path
 func getConfiDefaultPath(fileName string) string {
-	configDir, err := os.UserConfigDir()
-
+	UserHomeDir, err := os.UserHomeDir()
 	if err != nil {
 		return fileName
 	}
 
-	return configDir + "/" + fileName
+	configFilePath := filepath.Join(UserHomeDir, ".config", fileName)
+
+	return configFilePath
 }
 
 // Get Backplane ProxyUrl from config

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -14,32 +14,41 @@ type BackplaneConfiguration struct {
 	ProxyURL string `json:"proxy-url"`
 }
 
-func GetBackplaneConfigFile() string {
+func GetBackplaneConfigFile() (string, error) {
 	path, bpConfigFound := os.LookupEnv(info.BACKPLANE_CONFIG_PATH_ENV_NAME)
 	if bpConfigFound {
-		return path
+		return path, nil
 	}
 
-	return getConfiDefaultPath(info.BACKPLANE_CONFIG_DEFAULT_FILE_NAME)
+	configFile, err := getDefaultConfigPath()
+	if err != nil {
+		return "", err
+	}
+
+	return configFile, nil
 }
 
 // Get Backplane config default path
-func getConfiDefaultPath(fileName string) string {
+func getDefaultConfigPath() (string, error) {
 	UserHomeDir, err := os.UserHomeDir()
 	if err != nil {
-		return fileName
+		return "", err
 	}
 
-	configFilePath := filepath.Join(UserHomeDir, ".config", fileName)
+	configFilePath := filepath.Join(UserHomeDir, info.BACKPLANE_CONFIG_DEFAULT_FILE_PATH, info.BACKPLANE_CONFIG_DEFAULT_FILE_NAME)
 
-	return configFilePath
+	return configFilePath, nil
 }
 
 // Get Backplane ProxyUrl from config
 func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 
 	// Check proxy url from the config file
-	filePath := GetBackplaneConfigFile()
+	filePath, err := GetBackplaneConfigFile()
+	if err != nil {
+		return bpConfig, err
+	}
+
 	if _, err := os.Stat(filePath); err == nil {
 		file, err := os.Open(filePath)
 

--- a/pkg/cli/config/config_test.go
+++ b/pkg/cli/config/config_test.go
@@ -9,15 +9,25 @@ import (
 func TestGetBackplaneConfigFile(t *testing.T) {
 	t.Run("it returns the Backplane configuration file path if it exists in the user's env", func(t *testing.T) {
 		t.Setenv(info.BACKPLANE_CONFIG_PATH_ENV_NAME, "~/.backplane.stg.env.json")
-		path := GetBackplaneConfigFile()
+		path, err := GetBackplaneConfigFile()
+		if err != nil {
+			t.Error(err)
+		}
 		if path != "~/.backplane.stg.env.json" {
 			t.Errorf("expected path to be %v, got %v", "~/.backplane.stg.env.json", path)
 		}
 	})
 
 	t.Run("it returns the default configuration file path if it does not exist in the user's env", func(t *testing.T) {
-		path := GetBackplaneConfigFile()
-		expectedPath := getConfiDefaultPath(info.BACKPLANE_CONFIG_DEFAULT_FILE_NAME)
+		path, err := GetBackplaneConfigFile()
+		if err != nil {
+			t.Error(err)
+		}
+
+		expectedPath, err := getDefaultConfigPath()
+		if err != nil {
+			t.Error(err)
+		}
 		if path != expectedPath {
 			t.Errorf("expected path to be %v, got %v", expectedPath, path)
 		}

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -10,7 +10,7 @@ const (
 	BACKPLANE_URL_ENV_NAME             = "BACKPLANE_URL"
 	BACKPLANE_PROXY_ENV_NAME           = "HTTPS_PROXY"
 	BACKPLANE_CONFIG_PATH_ENV_NAME     = "BACKPLANE_CONFIG"
-	BACKPLANE_CONFIG_DEFAULT_FILE_NAME = ".backplane.json"
+	BACKPLANE_CONFIG_DEFAULT_FILE_NAME = "backplane.json"
 
 	// GitHub API get fetch the latest tag
 	UpstreamReleaseAPI = "https://api.github.com/repos/openshift/backplane-cli/releases/latest"

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -10,7 +10,8 @@ const (
 	BACKPLANE_URL_ENV_NAME             = "BACKPLANE_URL"
 	BACKPLANE_PROXY_ENV_NAME           = "HTTPS_PROXY"
 	BACKPLANE_CONFIG_PATH_ENV_NAME     = "BACKPLANE_CONFIG"
-	BACKPLANE_CONFIG_DEFAULT_FILE_NAME = "backplane.json"
+	BACKPLANE_CONFIG_DEFAULT_FILE_PATH = ".config/backplane"
+	BACKPLANE_CONFIG_DEFAULT_FILE_NAME = "config.json"
 
 	// GitHub API get fetch the latest tag
 	UpstreamReleaseAPI = "https://api.github.com/repos/openshift/backplane-cli/releases/latest"


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / Why we need it?
- Adhere to configuration file naming on UNIX systems.
- Refrain the use of `os.UserConfigDir()` to fetch the configuration file path as in Darwin (MacOS), it returns `$HOME/Library/Application Support` instead of `$HOME/.config`.

### Special notes for your reviewer

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
