### PR TITLE
Fix upgrade and version check

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,8 +19,6 @@ builds:
     ldflags:
       # The "-X" go flag sets the Version
       - -X github.com/openshift/backplane-cli/pkg/info.Version={{.Version}}
-      - "-extldflags=-zrelro" # Hardening ELF binaries: https://www.redhat.com/en/blog/hardening-elf-binaries-using-relocation-read-only-relro
-      - "-extldflags=-znow"
     main: ./cmd/ocm-backplane/
     binary: ocm-backplane
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,14 +16,16 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+      # The "-X" go flag sets the Version
+      - -X github.com/openshift/backplane-cli/pkg/info.Version={{.Version}}
+      - "-extldflags=-zrelro" # Hardening ELF binaries: https://www.redhat.com/en/blog/hardening-elf-binaries-using-relocation-read-only-relro
+      - "-extldflags=-znow"
     main: ./cmd/ocm-backplane/
     binary: ocm-backplane
 
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      amd64: x86_64
+  - name_template: '{{ .ProjectName }}_{{- .Version }}_{{- title .Os }}_{{- if eq .Arch "amd64" }}x86_64{{- else }}{{ .Arch }}{{ end}}'
 
 checksum:
   name_template: "checksums.txt"

--- a/cmd/ocm-backplane/version/version.go
+++ b/cmd/ocm-backplane/version/version.go
@@ -13,7 +13,7 @@ import (
 var VersionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Prints the version",
-	Long:  `Prints the version number of the client.`,
+	Long:  `Prints the version number of Backplane CLI`,
 	RunE:  runVersion,
 }
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -22,7 +22,7 @@ var (
 
 const (
 	gitHubApiEndPoint = "https://api.github.com/repos/openshift/backplane-cli"
-	assetTemplateName = "backplane-cli_%s_%s_%s.tar.gz" // version, GOOS, GOARCH
+	assetTemplateName = "ocm-backplane_%s_%s_%s.tar.gz" // version, GOOS, GOARCH
 )
 
 func NewClient(opts ...ClientOption) *Client {
@@ -194,6 +194,8 @@ func mapArch(goarch string) string {
 	switch goarch {
 	case "amd64":
 		return "x86_64"
+	case "arm64":
+		return "arm64"
 	default:
 		return goarch
 	}

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -87,8 +87,8 @@ func TestFindAssetURL(t *testing.T) {
 				TagName: "v0.0.1",
 				Assets: []upgrade.ReleaseAsset{
 					{
-						Name:        "backplane-cli_0.0.1_Darwin_arm64.tar.gz",
-						DownloadUrl: "https://github.com/openshift/backplane-cli/releases/download/v0.0.1/backplane-cli_0.0.1_Darwin_arm64.tar.gz",
+						Name:        "ocm-backplane_0.0.1_Darwin_arm64.tar.gz",
+						DownloadUrl: "https://github.com/openshift/backplane-cli/releases/download/v0.0.1/ocm-backplane_0.0.1_Darwin_arm64.tar.gz",
 					},
 				},
 			},
@@ -97,15 +97,15 @@ func TestFindAssetURL(t *testing.T) {
 				OSArch: "arm64",
 			},
 			match:         true,
-			ExpectedAsert: "https://github.com/openshift/backplane-cli/releases/download/v0.0.1/backplane-cli_0.0.1_Darwin_arm64.tar.gz",
+			ExpectedAsert: "https://github.com/openshift/backplane-cli/releases/download/v0.0.1/ocm-backplane_0.0.1_Darwin_arm64.tar.gz",
 		},
 		"check matching asert for Linux": {
 			LatestRelease: upgrade.Release{
 				TagName: "v0.0.1",
 				Assets: []upgrade.ReleaseAsset{
 					{
-						Name:        "backplane-cli_0.0.1_Linux_arm64.tar.gz",
-						DownloadUrl: "https://github.com/openshift/backplane-cli/releases/download/v0.0.1/backplane-cli_0.0.1_Linux_arm64.tar.gz",
+						Name:        "ocm-backplane_0.0.1_Linux_arm64.tar.gz",
+						DownloadUrl: "https://github.com/openshift/backplane-cli/releases/download/v0.0.1/ocm-backplane_0.0.1_Linux_arm64.tar.gz",
 					},
 				},
 			},
@@ -114,19 +114,19 @@ func TestFindAssetURL(t *testing.T) {
 				OSArch: "arm64",
 			},
 			match:         true,
-			ExpectedAsert: "https://github.com/openshift/backplane-cli/releases/download/v0.0.1/backplane-cli_0.0.1_Linux_arm64.tar.gz",
+			ExpectedAsert: "https://github.com/openshift/backplane-cli/releases/download/v0.0.1/ocm-backplane_0.0.1_Linux_arm64.tar.gz",
 		},
 		"check asert for unsupported OS ": {
 			LatestRelease: upgrade.Release{
 				TagName: "v0.0.1",
 				Assets: []upgrade.ReleaseAsset{
 					{
-						Name:        "backplane-cli_0.0.1_Linux_arm64.tar.gz",
-						DownloadUrl: "https://github.com/openshift/backplane-cli/releases/download/v0.0.1/backplane-cli_0.0.1_Linux_arm64.tar.gz",
+						Name:        "ocm-backplane_0.0.1_Linux_arm64.tar.gz",
+						DownloadUrl: "https://github.com/openshift/backplane-cli/releases/download/v0.0.1/ocm-backplane_0.0.1_Linux_arm64.tar.gz",
 					},
 					{
-						Name:        "backplane-cli_0.0.1_Darwin_arm64.tar.gz",
-						DownloadUrl: "https://github.com/openshift/backplane-cli/releases/download/v0.0.1/backplane-cli_0.0.1_Darwin_arm64.tar.gz",
+						Name:        "ocm-backplane_0.0.1_Darwin_arm64.tar.gz",
+						DownloadUrl: "https://github.com/openshift/backplane-cli/releases/download/v0.0.1/ocm-backplane_0.0.1_Darwin_arm64.tar.gz",
 					},
 				},
 			},

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -203,7 +203,7 @@ func (c *CmdConfig) Default() {
 	}
 
 	if c.BinaryName == "" {
-		c.BinaryName = "backplane-cli"
+		c.BinaryName = "ocm-backplane"
 	}
 
 	if c.Org == "" {

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -7,9 +7,6 @@ import (
 )
 
 const (
-	// Version of the backplane-cli
-	Version = "0.0.0"
-
 	BACKPLANE_URL_ENV_NAME             = "BACKPLANE_URL"
 	BACKPLANE_PROXY_ENV_NAME           = "HTTPS_PROXY"
 	BACKPLANE_CONFIG_PATH_ENV_NAME     = "BACKPLANE_CONFIG"
@@ -28,4 +25,10 @@ const (
 	GitHubHost = "github.com"
 )
 
-var UpstreamREADMETagged = fmt.Sprintf(UpstreamREADMETemplate, Version)
+var (
+	// Version of the backplane-cli
+	// This will be set via Goreleaser during the build process
+	Version string
+
+	UpstreamREADMETagged = fmt.Sprintf(UpstreamREADMETemplate, Version)
+)


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / Why we need it?
This PR fixes how we fetch binaries for upgrades and well as enforces the `version` of backplane CLI to not be static.

### Which Jira/Github issue(s) does this PR fix?
https://issues.redhat.com/browse/OSD-15761

### Special notes for your reviewer
#### Instructions to test
- The `version` is not static anymore and is populated by goreleaser's build dynamically upon each release based on tags.
- Run a goreleaser local build: `goreleaser build --skip-validate`. This will generate the release artifacts in the `dist/` folder.
- Run the newly generated binary: `./dist/ocm-backplane_linux_amd64_v1/ocm-backplane upgrade` or `./dist/ocm-backplane_linux_amd64_v1/ocm-backplane version`.
### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
