### PR TITLE
Update PS1-setup.md

### DIFF
--- a/docs/PS1-setup.md
+++ b/docs/PS1-setup.md
@@ -20,7 +20,7 @@ function cluster_function() {
   echo $clustername.$baseid
 }
 KUBE_PS1_BINARY=oc
-KUBE_PS1_CLUSTER_FUNCTION=cluster_function
+export KUBE_PS1_CLUSTER_FUNCTION=cluster_function
 PS1='[\u@\h \W $(kube_ps1)]\$ '
 ~~~
 


### PR DESCRIPTION
When using os.LookupEnv it checks for environment variable in the system listed at $env
Setting **export** in the .bashrc  fixes the warning.

```
$ env | grep KUBE_PS1
KUBE_PS1_CLUSTER_FUNCTION=cluster_function
```

### What type of PR is this?

_(bug/feature/cleanup/documentation)_

### What this PR does / Why we need it?

### Which Jira/Github issue(s) does this PR fix?

Warning shows: 
```WARN[0002] Env KUBE_PS1_CLUSTER_FUNCTION is not detected. It is recommended to set PS1 to learn which cluster you are operating on, refer https://github.com/openshift/backplane-cli/blob/main/docs/PS1-setup.md. ```
Even tho I do have the function properly setup and working
```
$ echo $KUBE_PS1_CLUSTER_FUNCTION
cluster_function
```

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
