### PR TITLE
Inform user when bp old is used

### DIFF
--- a/cmd/ocm-backplane/upgrade/upgrade.go
+++ b/cmd/ocm-backplane/upgrade/upgrade.go
@@ -40,6 +40,10 @@ func runUpgrade(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("checking connection to the git server: %w", err)
 	}
 
+	latest, err := info.GetLatestVersion()
+	if err != nil && info.Version != latest {
+		fmt.Print("You are using the old version of backplane-cli, please upgrade to latest vesrion using 'ocm-backplane upgrade' .")
+	}
 	upgrade := upgrade.NewCmd(git)
 
 	return upgrade.UpgradePlugin(ctx, info.Version)

--- a/cmd/ocm-backplane/upgrade/upgrade.go
+++ b/cmd/ocm-backplane/upgrade/upgrade.go
@@ -51,18 +51,10 @@ func runUpgrade(cmd *cobra.Command, _ []string) error {
 		fmt.Printf("Already up-to-date. Current version: %s\n", info.Version)
 		return nil
 	}
-
-	// Print the latest version number and ask for confirmation before upgrading
-	fmt.Printf("Latest version: %s\n", latestVersion.TagName)
-	fmt.Printf("Do you want to upgrade to the latest version? (y/n): ")
-	var answer string
-	_, _ = fmt.Scanln(&answer)
-	answer = strings.ToLower(strings.TrimSpace(answer))
-	if answer != "y" && answer != "yes" {
-		fmt.Println("Upgrade cancelled.")
-		return nil
-	}
-
+	
+	fmt.Printf("A new version (%s) of Backplane CLI is available.\n", latestVersion.TagName)
+	fmt.Println("Please run the command 'ocm backplane upgrade' to upgrade to the latest version.")
+	
 	upgrade := upgrade.NewCmd(git)
 
 	return upgrade.UpgradePlugin(ctx, latestVersion.TagName)

--- a/cmd/ocm-backplane/version/version.go
+++ b/cmd/ocm-backplane/version/version.go
@@ -1,25 +1,55 @@
 package version
 
 import (
+	"encoding/json"
 	"fmt"
-	"os"
+	"runtime/debug"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/backplane-cli/pkg/info"
 )
 
-// VersionCmd represents the version command
+// versionResponse is necessary for the JSON version response. It uses the three
+// variables that get set during the build.
+type versionResponse struct {
+	Commit  string `json:"commit"`
+	Version string `json:"version"`
+	Latest  string `json:"latest"`
+}
+
+
 var VersionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Prints the version",
-	Long:  `Prints the version number of Backplane CLI`,
+	Short: "Display the version",
+	Long:  "Prints the version number of Backplane CLI",
 	RunE:  runVersion,
 }
 
-func runVersion(cmd *cobra.Command, argv []string) error {
-	// Print the version
-	_, _ = fmt.Fprintf(os.Stdout, "%s\n", info.Version)
+func runVersion(cmd *cobra.Command, args []string) error {
+	gitCommit := "unknown"
 
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				gitCommit = setting.Value
+				break
+			}
+		}
+	}
+
+	latest, _ := info.GetLatestVersion() 
+	ver, err := json.MarshalIndent(&versionResponse{
+		Commit:  gitCommit,
+		Version: info.Version,
+		Latest:  strings.TrimPrefix(latest, "v"),
+	}, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(ver))
 	return nil
 }
+
+

--- a/cmd/ocm-backplane/version/version.go
+++ b/cmd/ocm-backplane/version/version.go
@@ -1,69 +1,25 @@
 package version
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"runtime/debug"
-	"strings"
+	"os"
 
 	"github.com/spf13/cobra"
 
-	"github.com/openshift/backplane-cli/internal/github"
 	"github.com/openshift/backplane-cli/pkg/info"
-	//"github.com/openshift/backplane-cli/pkg/info"
 )
 
-// versionResponse is necessary for the JSON version response. It uses the three
-// variables that get set during the build.
-type versionResponse struct {
-	Commit  string `json:"commit"`
-	Version string `json:"version"`
-	Latest  string `json:"latest"`
-}
-
+// VersionCmd represents the version command
 var VersionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Display the version",
-	Long:  "Prints the version number of Backplane CLI",
+	Short: "Prints the version",
+	Long:  `Prints the version number of Backplane CLI`,
 	RunE:  runVersion,
 }
 
-func runVersion(cmd *cobra.Command, _ []string) error {
+func runVersion(cmd *cobra.Command, argv []string) error {
+	// Print the version
+	_, _ = fmt.Fprintf(os.Stdout, "%s\n", info.Version)
 
-	ctx, cancel := context.WithCancel(cmd.Context())
-	defer cancel()
-
-	git := github.NewClient()
-
-	if err := git.CheckConnection(); err != nil {
-		return fmt.Errorf("checking connection to the git server: %w", err)
-	}
-	gitCommit := "unknown"
-
-	if info, ok := debug.ReadBuildInfo(); ok {
-		for _, setting := range info.Settings {
-			if setting.Key == "vcs.revision" {
-				gitCommit = setting.Value
-				break
-			}
-		}
-	}
-
-		// Get the latest version from the GitHub API
-		latest, err := git.GetLatestVersion(ctx)
-		if err != nil {
-			return err
-		}
-
-	ver, err := json.MarshalIndent(&versionResponse{
-		Commit:  gitCommit,
-		Version: info.Version,
-		Latest:  strings.TrimPrefix(latest.TagName, "v"),
-	}, "", "  ")
-	if err != nil {
-		return err
-	}
-	fmt.Println(string(ver))
 	return nil
 }

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -3,10 +3,8 @@
 package info
 
 import (
-	"encoding/json"
-	"io"
-	"net/http"
-	"time"
+	"fmt"
+
 )
 
 const (
@@ -25,51 +23,17 @@ const (
 	// GitHub README page
 	UpstreamREADMETemplate = "https://github.com/openshift/backplane-cli/-/blob/%s/README.md"
 
-	VersionAddressTemplate = "https://github.com/openshift/backplane-cli/releases/download/v%s/backplane-cli_%s_%s_%s.tar.gz" // version, version, GOOS, GOARCH
+
 
 	// GitHub Host
 	GitHubHost = "github.com"
 )
 
 var (
-
-	GitCommit string
-
-
+	// Version of the backplane-cli
+	// This will be set via Goreleaser during the build process
 	Version string
+
+	UpstreamREADMETagged = fmt.Sprintf(UpstreamREADMETemplate, Version)
 )
 
-
-type gitHubResponse struct {
-	TagName string `json:"tag_name"`
-}
-
-
-func GetLatestVersion() (latest string, err error) {
-	client := http.Client{
-		Timeout: time.Second * 2,
-	}
-
-	req, err := http.NewRequest(http.MethodGet, UpstreamReleaseAPI, nil)
-	if err != nil {
-		return latest, err
-	}
-
-	res, err := client.Do(req)
-	if err != nil {
-		return latest, err
-	}
-
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		return latest, err
-	}
-
-	githubResp := gitHubResponse{}
-	err = json.Unmarshal(body, &githubResp)
-	if err != nil {
-		return latest, err
-	}
-
-	return githubResp.TagName, nil
-}

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -36,4 +36,3 @@ var (
 
 	UpstreamREADMETagged = fmt.Sprintf(UpstreamREADMETemplate, Version)
 )
-


### PR DESCRIPTION
### What type of PR is this?

feature
### What this PR does / Why we need it?
Implement functionality to inform user when old ocm-backplane version is used to access the cluster
### Which Jira/Github issue(s) does this PR fix?
[OSD-14573](https://issues.redhat.com/browse/OSD-14573)
_Resolves #_
[OSD-14573](https://issues.redhat.com/browse/OSD-14573)
### Special notes for your reviewer

### Pre-checks (if applicable)

- [ Yes ] Ran unit tests locally
- [ Yes ] Validated the changes in a cluster
- [No ] Included documentation changes with PR
