### PR TITLE
Re-add build-ocm-container makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,3 +118,10 @@ skopeo-push: image
 		--dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
 		"docker-daemon:${IMAGE_URI_LATEST}" \
 		"docker://${IMAGE_URI_LATEST}"
+
+build-ocm-container:
+	@if test -z ${HOME}/.config/backplane/config.json ; then echo 'no backplane config file found at $HOME/.config/backplane/config.json - needed for building onto ocm-container' ; exit 1 ; fi
+	cp ~/.config/backplane/config.json ./hack/ocm-container/backplane.config.temp
+	@if test -z ${CONTAINER_SUBSYS} ; then echo 'CONTAINER_SUBSYS must be set. Hint: `source ~/.config/ocm-container/env.source`' ; exit 1 ; fi
+	pushd ./hack/ocm-container/ ; ${CONTAINER_SUBSYS} build --network host -t ocm-container:latest .
+	rm ./hack/ocm-container/backplane.config.temp || true

--- a/hack/ocm-container/Dockerfile
+++ b/hack/ocm-container/Dockerfile
@@ -1,0 +1,51 @@
+### Download the binaries
+# Anything in this image must be COPY'd into the final image, below
+FROM registry.access.redhat.com/ubi8/ubi as builder
+
+RUN dnf update -y && dnf install -y git golang make && dnf clean all
+
+ENV I_AM_IN_CONTAINER="I-am-in-container"
+
+# Add RH-IT-Root-CA to enable secure internal repo cloning
+ADD https://password.corp.redhat.com/RH-IT-Root-CA.crt /etc/pki/ca-trust/source/anchors/
+RUN update-ca-trust
+
+ADD ./container-setup/install /container-setup/install
+WORKDIR /container-setup/install
+
+RUN ./install-backplane.sh
+
+FROM ocm-container:latest
+
+RUN microdnf --assumeyes install \
+    podman \
+    fuse-overlayfs \
+    shadow-utils \
+    crun
+
+# Overlay over overlay is often denied by the kernel, so this creates non overlay volumes to be used within the container.
+VOLUME /var/lib/containers
+
+# adjust storage.conf to enable fuse-overlayfs storage.
+RUN sed -i -e 's|^#mount_program|mount_program|g' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
+
+# add containers.conf file to make sure containers run easier.
+COPY containers.conf /etc/containers/containers.conf
+
+ENV I_AM_IN_CONTAINER="I-am-in-container"
+
+RUN mkdir -p /root/.config/backplane
+COPY backplane.config.temp /root/.config/backplane/config.json
+
+COPY --from=builder /usr/local/bin/ocm-backplane /usr/local/bin
+COPY --from=builder /etc/bash_completion.d/backplane-cli /etc/bash_completion.d
+
+ADD ./container-setup/utils /container-setup/utils
+WORKDIR /container-setup/utils
+RUN ./install-utils.sh
+
+ENV PATH "$PATH:/root/utils"
+RUN rm -rf /container-setup
+
+WORKDIR /root
+ENTRYPOINT ["/bin/bash"]

--- a/hack/ocm-container/container-setup/install/install-backplane.sh
+++ b/hack/ocm-container/container-setup/install/install-backplane.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+if [ "$I_AM_IN_CONTAINER" != "I-am-in-container" ]; then
+  echo "must be run in container";
+  exit 1;
+fi
+
+echo "in container";
+
+mkdir /usr/local/backplane -p
+pushd /usr/local/backplane
+
+if [[ -d backplane-cli ]] ;
+then
+  rm -r ./backplane-cli
+fi
+
+git clone --single-branch --branch main https://github.com/openshift/backplane-cli.git
+pushd backplane-cli
+make build
+mv ocm-backplane /usr/local/bin/ocm-backplane
+chmod 755 /usr/local/bin/ocm-backplane
+
+ocm-backplane completion bash > /etc/bash_completion.d/backplane-cli
+
+popd
+popd

--- a/hack/ocm-container/container-setup/utils/bin/backplane-login
+++ b/hack/ocm-container/container-setup/utils/bin/backplane-login
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+
+if [ -z $1 ]
+then
+  echo "First parameter must be a cluster"
+  exit 1
+fi
+
+# Login to OCM first
+echo "Logging into OCM"
+if [ "$OCM_URL" == "" ];
+then
+  OCM_URL="https://api.openshift.com"
+fi
+ocm login --token=$OFFLINE_ACCESS_TOKEN --url=$OCM_URL
+
+echo "Logging into cluster $1"
+
+# Login to the Cluster
+ocm backplane login "$1"

--- a/hack/ocm-container/container-setup/utils/bin/backplane-login-owner
+++ b/hack/ocm-container/container-setup/utils/bin/backplane-login-owner
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -eEuo pipefail
+
+if [ -z $1 ]
+then
+  echo "First parameter must be a cluster"
+  exit 1
+fi
+
+# Login to OCM first
+echo "Logging into OCM"
+if [ "$OCM_URL" == "" ];
+then
+  OCM_URL="https://api.openshift.com"
+fi
+ocm login --token=$OFFLINE_ACCESS_TOKEN --url=$OCM_URL
+
+
+
+echo "Finding owner of cluster $1"
+CLUSTERID=$(get-shards-clusterid -c ${1})
+
+echo "Logging into the owner of cluster $1 - $CLUSTERID"
+
+# Login to the Cluster
+ocm backplane login "$CLUSTERID"

--- a/hack/ocm-container/container-setup/utils/bin/backplane-logout
+++ b/hack/ocm-container/container-setup/utils/bin/backplane-logout
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+# Set sshuttle pid file
+if [ -z $1 ]
+then
+  PIDFILE=$(pwd)/sshuttle.pid
+else
+  PIDFILE=$1
+fi
+
+# Check if pid file exists
+if [ ! -f ${PIDFILE} ]
+then
+    echo "sshuttle pid file ${PIDFILE} not found, exiting..."
+    exit 1
+fi
+
+# Log out of the Cluster
+echo "Logging out of the cluster"
+ocm backplane logout
+kill $(cat ${PIDFILE})

--- a/hack/ocm-container/container-setup/utils/install-utils.sh
+++ b/hack/ocm-container/container-setup/utils/install-utils.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -e
+
+if [ "$I_AM_IN_CONTAINER" != "I-am-in-container" ]; then
+  echo "must be run in container";
+  exit 1;
+fi
+
+echo "in container";
+
+mkdir -p ${HOME}/utils
+
+mv /container-setup/utils/bin/* ${HOME}/utils
+
+# find *-sre-utils.bashrc in ~/.bashrc.d
+BASHRC_DIR=${HOME}/.bashrc.d
+FIND_PATTERN="*-sre-utils.bashrc"
+SRE_UTILS_BASHRC=$(find ${BASHRC_DIR} -iname ${FIND_PATTERN} -print -quit)
+if [ -z ${SRE_UTILS_BASHRC} ]
+then
+  echo "Expecting to find '${FIND_PATTERN}' file in ${BASHRC_DIR}"
+  exit 1
+fi
+
+# change *-login to backplane-login in bashrc
+sed -i 's/\w*-login/backplane-login/g' ${SRE_UTILS_BASHRC}
+
+# change cluster_function for PS1
+# add a new line ahead as sre-utils.bashrc may not end with a new line
+cat >> ${SRE_UTILS_BASHRC} << EOF
+
+function cluster_function() {
+  info="\$(ocm backplane status)"
+  clustername=\$(echo "\$info" | grep "Cluster Name" | awk '{print \$3}')
+  baseid=\$(echo "\$info" | grep "Cluster Basedomain" | awk '{print \$3}' | cut -d'.' -f1,2)
+  echo \$clustername.\$baseid
+}
+EOF
+
+# Add elevation alias
+cat >> ${SRE_UTILS_BASHRC} << EOF
+
+alias oc-elevate="oc --as backplane-cluster-admin"
+EOF

--- a/hack/ocm-container/containers.conf
+++ b/hack/ocm-container/containers.conf
@@ -1,0 +1,12 @@
+[containers]
+netns="host"
+userns="host"
+ipcns="host"
+utsns="host"
+cgroupns="host"
+cgroups="disabled"
+log_driver = "k8s-file"
+[engine]
+cgroup_manager = "cgroupfs"
+events_logger="file"
+runtime="crun"


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / Why we need it?
Re-adds the ability to run `make build-ocm-container` on top of `ocm-container`, allowing us to use backplane inside of `ocm-container` instances. 

To test: 
Run `make build-ocm-container`. It should now use this format for logging in: 
```
[17:38:23] hectorkemp:backplane-cli git:(readd-make-ocm-container) $ ocm-container a-cluster
Logging into cluster a-cluster
INFO[0001] Target cluster                                ID=123456 Name=a-cluster
```
### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
