### PR TITLE
Improve error message clarity when the backplane url is empty

### DIFF
--- a/cmd/ocm-backplane/cloud/console.go
+++ b/cmd/ocm-backplane/cloud/console.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -116,8 +117,12 @@ func runConsole(cmd *cobra.Command, argv []string) (err error) {
 	} else {
 		// Get Backplane configuration
 		bpConfig, err := config.GetBackplaneConfiguration()
-		if err != nil || bpConfig.URL == "" {
+		if err != nil {
 			return fmt.Errorf("can't find backplane url: %w", err)
+		}
+
+		if bpConfig.URL == "" {
+			return errors.New("empty backplane url - check your backplane-cli configuration")
 		}
 		bpURL = bpConfig.URL
 		logger.Infof("Using backplane URL: %s\n", bpURL)

--- a/cmd/ocm-backplane/cloud/credentials.go
+++ b/cmd/ocm-backplane/cloud/credentials.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -161,8 +162,12 @@ func runCredentials(cmd *cobra.Command, argv []string) error {
 	} else {
 		// Get Backplane configuration
 		bpConfig, err := GetBackplaneConfiguration()
-		if err != nil || bpConfig.URL == "" {
+		if err != nil {
 			return fmt.Errorf("can't find backplane url: %w", err)
+		}
+
+		if bpConfig.URL == "" {
+			return errors.New("empty backplane url - check your backplane-cli configuration")
 		}
 		bpURL = bpConfig.URL
 		logger.Infof("Using backplane URL: %s\n", bpURL)

--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -2,6 +2,7 @@ package login
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -126,7 +127,7 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 	}
 
 	if bpUrl == "" {
-		return fmt.Errorf("can't find backplane url: %s", bpConfig.URL)
+		return errors.New("empty backplane url - check your backplane-cli configuration")
 	}
 
 	logger.Debugf("Using backplane URL: %s\n", bpUrl)

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/openshift/backplane-api v0.0.0-20230203044845-10f2b341bf54
 	github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.15.0
@@ -94,6 +93,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
 	github.com/perimeterx/marshmallow v1.1.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.13.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -12,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/openshift/backplane-cli/internal/upgrade"
-	"github.com/pkg/errors"
 )
 
 var (


### PR DESCRIPTION
### What type of PR is this?

cleanup

### What this PR does / Why we need it?

[OSD-16175](https://issues.redhat.com//browse/OSD-16175)

As SREs are switching to the new backplane-cli, sometimes they get a confusing error message:

```
2023/04/27 11:52:41 getting AWS credentials from backplane-api
2023/04/27 11:52:42 can't find backplane url: %!w(<nil>)
```

The message comes from the following block of code when there there is no error, but the format string attempts to insert one:

```go
		if err != nil || bpConfig.URL == "" {
			return fmt.Errorf("can't find backplane url: %w", err)
		}
```

This PR attempts to address it by returning this instead:
```go
		if bpConfig.URL == "" {
			return errors.New("empty backplane url - check your backplane-cli configuration")
		}
```
