### PR TITLE
Give faster feedback when logging into hibernating clusters

### DIFF
--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -99,7 +99,6 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 
 	// Get Backplane configuration
 	bpConfig, err := config.GetBackplaneConfiguration()
-
 	if err != nil {
 		return err
 	}
@@ -171,6 +170,12 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 		return err
 	}
 	logger.Debugln("Found OCM access token")
+
+	// Not great if there's an error checking if the cluster is hibernating, but ignore it for now and continue
+	if isHibernating, _ := utils.DefaultOCMInterface.IsClusterHibernating(clusterId); isHibernating {
+		// If it is hibernating, don't try to connect as it will fail
+		return fmt.Errorf("cluster %s is hibernating, login failed", clusterKey)
+	}
 
 	// Query backplane-api for proxy url
 	bpAPIClusterUrl, err := doLogin(bpUrl, clusterId, *accessToken)

--- a/cmd/ocm-backplane/login/login_test.go
+++ b/cmd/ocm-backplane/login/login_test.go
@@ -254,7 +254,7 @@ var _ = Describe("Login command", func() {
 			globalOpts.ProxyURL = "https://squid.myproxy.com"
 			mockClientUtil.EXPECT().SetClientProxyUrl(globalOpts.ProxyURL).Return(nil)
 			mockOcmInterface.EXPECT().GetTargetCluster("configcluster").Return(testClusterId, "dummy_cluster", nil)
-			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterId)).Return(false, nil).AnyTimes()
+			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(testClusterId)).Return(false, nil).AnyTimes()
 			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil)
 			mockClientUtil.EXPECT().MakeRawBackplaneAPIClientWithAccessToken(backplaneAPIUri, testToken).Return(mockClient, nil)
 			mockClient.EXPECT().LoginCluster(gomock.Any(), gomock.Eq(testClusterId)).Return(fakeResp, nil)


### PR DESCRIPTION
### What type of PR is this?

cleanup

### What this PR does / Why we need it?

Currently, when we try to login to a cluster that is hibernating, it tries for 30 seconds before returning an error. This PR checks right away so we can give faster feedback since a login should never work for a hibernating cluster.

```
❯ time ocm backplane login ${HIBERNATING_CLUSTER}
INFO[0000] Target cluster                                ID=${ID} Name=${NAME}
ERRO[0030] cluster ${NAME} is hibernating, login failed 
ocm backplane login ${HIBERNATING_CLUSTER}  0.07s user 0.08s system 0% cpu 30.949 total
```

### Which Jira/Github issue(s) does this PR fix?

[OSD-16184](https://issues.redhat.com//browse/OSD-16184)