### PR TITLE
Add ability to use libraries with test jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To setup the PS1(prompt) for bash/zsh, please follow [these instructions](https:
 | `ocm-backplane managedJob list [flags]`                                     | Retrieve a list of backplane managed job resources                                       |
 | `ocm-backplane managedJob logs <job_name> [flags]`                          | Retrieve logs of the specified managed job resource                                      |
 | `ocm-backplane managedJob delete <job_name> [flags]`                        | Delete the specified managed job resource                                                |
-| `ocm-backplane testJob create <script> [flags]`                             | Create a backplane test job on a non-production cluster for testing                      |
+| `ocm-backplane testJob create <script> [flags]`                             | Create a backplane test managed job on a non-production cluster for testing. To use with bash libraries, make sure the libraries are in the scripts directory in the format `source /managed-scripts/<path-from-managed-scripts-scripts-dir>`                      |
 | `ocm-backplane testJob get <job_name> [flags]`                              | Retrieve a backplane test job resource                                                   |
 | `ocm-backplane testJob list [flags]`                                        | Retrieve a list of backplane test job resources                                          |
 | `ocm-backplane testJob logs <job_name> [flags]`                             | Retrieve logs of the specified test job resource                                         |

--- a/cmd/ocm-backplane/testJob/getTestJobLogs.go
+++ b/cmd/ocm-backplane/testJob/getTestJobLogs.go
@@ -104,6 +104,5 @@ func runGetTestJobLogs(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	cmd.PersistentFlags().BoolP("follow", "f", false, "Specify if logs should be streamed")
 	return nil
 }

--- a/cmd/ocm-backplane/testJob/testJob.go
+++ b/cmd/ocm-backplane/testJob/testJob.go
@@ -28,6 +28,8 @@ func NewTestJobCommand() *cobra.Command {
 	// raw Flag
 	cmd.PersistentFlags().Bool("raw", false, "Prints the raw response returned by the backplane API")
 
+	cmd.PersistentFlags().BoolP("follow", "f", false, "Specify if logs should be streamed")
+
 	cmd.AddCommand(
 		newCreateTestJobCommand(),
 		newGetTestJobCommand(),


### PR DESCRIPTION
### What type of PR is this?

_feature_

### What this PR does / Why we need it?
- Allows us to import bash libraries into managed scripts, and test them using test jobs. 
It does this by finding the file and inlining the function into the script itself. 
For a managed script example.sh:                           
```
---                                                        
#!/bin/bash                                                
source /managed-scripts/libs/lib.sh                        
                                                           
echo_foo "Hello"                                           
---                                                        
```                                                  
And function /managed-scripts/libs/lib.sh                  
```
---                                                        
#!/bin/bash                                                
                                                           
 function echo_foo () {                                    
     echo $1                                               
 }                                                         
                                                           
---                                                        
```                                                     
Inline into function before source definition of example.sh
```
#!/bin/bash                                                
cat << EOF > lib.sh                                        
#!/bin/bash                                                
                                                           
 function echo_foo () {                                    
     echo $1                                               
 }                                                         
                                                           
EOF                                                        
source lib.sh                                              
                                                           
echo_foo "Hello"                                           
```
- Fixes an issue with `ocm-backplane testjob logs` where the `-f` flag does not work. 
### Which Jira/Github issue(s) does this PR fix?

_Resolves #_https://issues.redhat.com/browse/OSD-13310

### Special notes for your reviewer
To test: 
Check out https://github.com/openshift/managed-scripts/pull/109/files
```
make
cd managed-scripts/scripts/examples/lib-sourcer
path/to/repo/backplane-cli/ocm-backplane testjob create
path/to/repo/backplane-cli/ocm-backplane testjob logs <job-name>
```

### Pre-checks (if applicable)

- [x ] Ran unit tests locally
- [ x] Validated the changes in a cluster
- [x] Included documentation changes with PR
