### PR TITLE
OSD-16162: Add Backplane Session command

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,53 @@ Logging into multiple clusters via different terminal instances.
   ```
   $ export BACKPLANE_DEFAULT_OPEN_BROWSER=true
   $ ocm backplane cloud console
-  ```
+  `
+
+## Backplane Session 
+Backplane session command will create an isolated environment to interact with a cluster in its own directory. 
+The default location for this is ~/backplane. 
+
+The default session save path can be configured via the backplane config file. 
+```
+{
+   "url": "your-bp-url"
+   "proxy-url": "your-proxy-url"
+   "session-dir":"your-session-dir"
+}
+```
+### How to create new session?
+The following command will create a new session and log in to the cluster.
+```
+## with intractive session name 
+ocm backplane session <session-name> -c <cluster-id>
+
+## only with cluster id
+ocm backplane session <cluster-id> 
+```
+
+Backplane session keeps the session history commands in <your-path>/session-name/.history file.
+
+```
+[ <session-name> (<cluster-info-PS1>)]$ history 
+    1  2023-05-08 15:06:05 oc get nodes
+    2  2023-05-08 15:06:13 oc get co
+    3  2023-05-08 15:06:40 history 
+```
+
+Backpalane session setup following environment variables.
+```
+HISTFILE    = <your-session-path>/<session-name>/.history
+PATH        = <your-os-path>
+KUBECONFIG  = <your-session-path>/<session-name>/<cluster-id>/config
+CLUSTERID   = <cluster-id>
+CLUSTERNAME = <cluster-name>
+```
+
+### How to delete the session?
+Folowing command delete the session
+```
+ocm backplane session --delete <session-name>
+```
 
 
 ## Debugging issues

--- a/cmd/ocm-backplane/root.go
+++ b/cmd/ocm-backplane/root.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/logout"
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/managedJob"
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/script"
+	"github.com/openshift/backplane-cli/cmd/ocm-backplane/session"
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/status"
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/testJob"
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/upgrade"
@@ -99,4 +100,6 @@ func init() {
 	rootCmd.AddCommand(testJob.NewTestJobCommand())
 	rootCmd.AddCommand(managedJob.NewManagedJobCmd())
 	rootCmd.AddCommand(console.ConsoleCmd)
+	rootCmd.AddCommand(session.NewCmdSession())
+
 }

--- a/cmd/ocm-backplane/session/session.go
+++ b/cmd/ocm-backplane/session/session.go
@@ -18,7 +18,7 @@ func NewCmdSession() *cobra.Command {
 	}
 	sessionCmd := &cobra.Command{
 		Use:               "session [flags] [session-alias]",
-		Short:             "Create an environment to interact with a cluster",
+		Short:             "Create an isolated environment to interact with a cluster in its own directory.",
 		Args:              cobra.MaximumNArgs(1),
 		DisableAutoGenTag: true,
 		RunE:              session.RunCommand,

--- a/cmd/ocm-backplane/session/session.go
+++ b/cmd/ocm-backplane/session/session.go
@@ -1,0 +1,57 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/openshift/backplane-cli/pkg/cli/session"
+	"github.com/openshift/backplane-cli/pkg/info"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdSession() *cobra.Command {
+	options := session.Options{}
+
+	session := session.BackplaneSession{
+		Options: &options,
+	}
+	sessionCmd := &cobra.Command{
+		Use:               "session [flags] [session-alias]",
+		Short:             "Create an environment to interact with a cluster",
+		Args:              cobra.MaximumNArgs(1),
+		DisableAutoGenTag: true,
+		RunE:              session.RunCommand,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			validEnvs := []string{}
+			files, err := os.ReadDir(filepath.Join(os.Getenv("HOME"), info.BACKPLANE_DEFAULT_SESSION_DIRECTORY))
+			if err != nil {
+				return validEnvs, cobra.ShellCompDirectiveNoFileComp
+			}
+			for _, f := range files {
+				if f.IsDir() && strings.HasPrefix(f.Name(), toComplete) {
+					validEnvs = append(validEnvs, f.Name())
+				}
+			}
+
+			return validEnvs, cobra.ShellCompDirectiveNoFileComp
+		},
+	}
+	sessionCmd.Flags().BoolVarP(
+		&options.DeleteSession,
+		"delete",
+		"d",
+		false,
+		"Delete session",
+	)
+
+	sessionCmd.Flags().StringVarP(
+		&options.ClusterId,
+		"cluster-id",
+		"c",
+		"",
+		"The cluster to create the session for",
+	)
+
+	return sessionCmd
+}

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -9,8 +9,9 @@ import (
 )
 
 type BackplaneConfiguration struct {
-	URL      string
-	ProxyURL string
+	URL              string
+	ProxyURL         string
+	SessionDirectory string
 }
 
 // getConfigFilePath returns the default config path
@@ -68,6 +69,7 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 
 	bpConfig.URL = viper.GetString("url")
 	bpConfig.ProxyURL = viper.GetString("proxy-url")
+	bpConfig.SessionDirectory = viper.GetString("session-dir")
 
 	return bpConfig, nil
 }

--- a/pkg/cli/session/session.go
+++ b/pkg/cli/session/session.go
@@ -1,0 +1,445 @@
+package session
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+
+	"github.com/openshift/backplane-cli/cmd/ocm-backplane/login"
+	"github.com/openshift/backplane-cli/pkg/cli/config"
+	"github.com/openshift/backplane-cli/pkg/info"
+	"github.com/openshift/backplane-cli/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+// BackplaneSessionInterface abstract backplane session functions
+type BackplaneSessionInterface interface {
+	RunCommand(cmd *cobra.Command, args []string) error
+	Setup() error
+	Start() error
+	Delete() error
+}
+
+// BackplaneSession struct for default Backplane session
+type BackplaneSession struct {
+	Path    string
+	Exists  bool
+	Options *Options
+}
+
+// Options define deafult backplane session options
+type Options struct {
+	DeleteSession bool
+
+	Alias string
+
+	ClusterId   string
+	ClusterName string
+}
+
+var (
+	DefaultBackplaneSession BackplaneSessionInterface = &BackplaneSession{}
+)
+
+// RunCommand setup session and allows to execute commands
+func (e *BackplaneSession) RunCommand(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		e.Options.Alias = args[0]
+	}
+	if e.Options.ClusterId == "" && e.Options.Alias == "" {
+		err := cmd.Help()
+		if err != nil {
+			return fmt.Errorf("could not print help")
+		}
+		return fmt.Errorf("ClusterId or Alias required")
+	}
+
+	if e.Options.Alias == "" {
+		log.Println("No Alias set, using cluster ID")
+		e.Options.Alias = e.Options.ClusterId
+	}
+
+	sessionPath, err := e.sessionPath()
+	if err != nil {
+		return fmt.Errorf("could not init session path")
+	}
+	e.Path = sessionPath
+
+	if e.Options.DeleteSession {
+		fmt.Printf("Cleaning up Backplane session %s\n", e.Options.Alias)
+		err = e.Delete()
+		if err != nil {
+			return fmt.Errorf("could not delete the session. error: %v", err)
+		}
+		return nil
+	}
+
+	err = e.Setup()
+	if err != nil {
+		return fmt.Errorf("could not setup session. error: %v", err)
+	}
+
+	// Init cluster login via cluster ID or Alias
+	err = e.initClusterLogin(cmd)
+	if err != nil {
+		return fmt.Errorf("could not login to the cluster. error: %v", err)
+	}
+
+	err = e.Start()
+	if err != nil {
+		return fmt.Errorf("could not start session. error: %v", err)
+	}
+	return nil
+}
+
+// Setup intitate the sessoion environment
+func (e *BackplaneSession) Setup() error {
+	// Delete session if exist
+	err := e.Delete()
+	if err != nil {
+		return fmt.Errorf("error deleting session. error: %v", err)
+	}
+
+	// Setup clusterID and clusterName
+	clusterKey := e.Options.Alias
+	if e.Options.ClusterId != "" {
+		clusterKey = e.Options.ClusterId
+	}
+
+	clusterId, clusterName, err := utils.DefaultOCMInterface.GetTargetCluster(clusterKey)
+
+	if err == nil {
+		// set cluster options
+		e.Options.ClusterName = clusterName
+		e.Options.ClusterId = clusterId
+	}
+
+	err = e.ensureEnvDir()
+	if err != nil {
+		return fmt.Errorf("error validating env directory. error: %v", err)
+	}
+
+	e.printSesionHeader()
+
+	// Create session Bins
+	err = e.createBins()
+	if err != nil {
+		return fmt.Errorf("error creating bins. error: %v", err)
+	}
+
+	// Creating history files
+	err = e.createHistoryFile()
+	if err != nil {
+		return fmt.Errorf("error creating history files. error: %v", err)
+	}
+
+	// Validaing env variables
+	err = e.ensureEnvVariables()
+	if err != nil {
+		return fmt.Errorf("error setting env vars. error: %v", err)
+	}
+
+	return nil
+}
+
+// Start trigger the session start
+func (e *BackplaneSession) Start() error {
+	shell := os.Getenv("SHELL")
+
+	fmt.Print("Switching to Backplane session " + e.Options.Alias + "\n")
+	cmd := exec.Command(shell)
+
+	path := filepath.Clean(e.Path + "/.ocenv")
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			fmt.Println("Error closing file: ", path)
+			return
+		}
+	}()
+	scanner := bufio.NewScanner(file)
+	cmd.Env = os.Environ()
+	for scanner.Scan() {
+		line := scanner.Text()
+		cmd.Env = append(cmd.Env, line)
+	}
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Dir = e.Path
+	_ = cmd.Run() // add error checking
+
+	err = e.killChildren()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Exited Backplane session \n")
+
+	return nil
+}
+
+// killChildren delete all pds in .killpds file
+func (e *BackplaneSession) killChildren() error {
+	path := filepath.Join(e.Path, "/.killpds")
+
+	if _, err := os.Stat(path); err == nil {
+		file, err := os.Open(path)
+
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				fmt.Println("Nothing to kill")
+			}
+			//return fmt.Errorf("failed to read file .killpids: %v", err)
+		}
+		defer func(file *os.File) {
+			err := file.Close()
+			if err != nil {
+				fmt.Println("Error while closing file: ", path)
+				return
+			}
+		}(file)
+
+		scanner := bufio.NewScanner(file)
+
+		scanner.Split(bufio.ScanLines)
+		var text []string
+
+		for scanner.Scan() {
+			text = append(text, scanner.Text())
+		}
+
+		for _, pid := range text {
+			fmt.Printf("Stopping process %s\n", pid)
+			pidNum, err := strconv.Atoi(pid)
+			if err != nil {
+				return fmt.Errorf("failed to read PID %s, you may need to clean up manually: %v", pid, err)
+			}
+			err = syscall.Kill(pidNum, syscall.SIGTERM)
+			if err != nil {
+				return fmt.Errorf("failed to stop child processes %s, you may need to clean up manually: %v", pid, err)
+			}
+		}
+
+		err = os.Remove(path)
+		if err != nil {
+			return fmt.Errorf("failed to delete .killpids, you may need to clean it up manually: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// Delete cleanup the backplane session
+func (e *BackplaneSession) Delete() error {
+	err := os.RemoveAll(e.Path)
+	if err != nil {
+		fmt.Println("error while calling os.RemoveAll", err.Error())
+
+	}
+	return nil
+}
+
+// ensureEnvDir create session dirs if it's not exist
+func (e *BackplaneSession) ensureEnvDir() error {
+	if _, err := os.Stat(e.Path); errors.Is(err, os.ErrNotExist) {
+		err := os.MkdirAll(e.Path, os.ModePerm)
+		if err != nil {
+			return err
+		}
+	}
+	e.Exists = true
+	return nil
+}
+
+// ensureEnvDir intiate session env vars
+func (e *BackplaneSession) ensureEnvVariables() error {
+	envContent := `
+HISTFILE=` + e.Path + `/.history
+PATH=` + e.Path + `/bin:` + os.Getenv("PATH") + `
+`
+
+	if e.Options.ClusterId != "" {
+		clusterEnvContent := "KUBECONFIG=" + filepath.Join(e.Path, e.Options.ClusterId, "config") + "\n"
+		clusterEnvContent = clusterEnvContent + "CLUSTERID=" + e.Options.ClusterId + "\n"
+		clusterEnvContent = clusterEnvContent + "CLUSTERNAME=" + e.Options.ClusterName + "\n"
+		envContent = envContent + clusterEnvContent
+	}
+	direnvfile, err := e.ensureFile(e.Path + "/.ocenv")
+	if err != nil {
+		return err
+	}
+	_, err = direnvfile.WriteString(envContent)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func(direnvfile *os.File) {
+		direnvfile.Close()
+	}(direnvfile)
+
+	zshenvfile, err := e.ensureFile(e.Path + "/.zshenv")
+	if err != nil {
+		return err
+	}
+	_, err = zshenvfile.WriteString("source .ocenv")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func(direnvfile *os.File) {
+		err := direnvfile.Close()
+		if err != nil {
+			fmt.Println("Error while calling direnvFile.Close(): ", err.Error())
+			return
+		}
+	}(direnvfile)
+	return nil
+}
+
+func (e *BackplaneSession) createHistoryFile() error {
+	historyFile := filepath.Join(e.Path, "/.history")
+	scriptfile, err := e.ensureFile(historyFile)
+	if err != nil {
+		return err
+	}
+	defer func(scriptfile *os.File) {
+		err := scriptfile.Close()
+		if err != nil {
+			fmt.Println("Error closing file: ", historyFile)
+			return
+		}
+	}(scriptfile)
+	return nil
+}
+
+// createBins create bins inside the session folder bin dir
+func (e *BackplaneSession) createBins() error {
+	if _, err := os.Stat(e.binPath()); errors.Is(err, os.ErrNotExist) {
+		err := os.Mkdir(e.binPath(), os.ModePerm)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+	err := e.createBin("ocd", "ocm describe cluster "+e.Options.ClusterId)
+	if err != nil {
+		return err
+	}
+	ocb := `
+#!/bin/bash
+
+set -euo pipefail
+
+`
+	err = e.createBin("ocb", ocb)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// createBin create bin file with given content
+func (e *BackplaneSession) createBin(cmd string, content string) error {
+	path := filepath.Join(e.binPath(), cmd)
+	scriptfile, err := e.ensureFile(path)
+	if err != nil {
+		return err
+	}
+	defer func(scriptfile *os.File) {
+		err := scriptfile.Close()
+		if err != nil {
+			fmt.Println("Error closing file: ", path)
+			return
+		}
+	}(scriptfile)
+	_, err = scriptfile.WriteString(content)
+	if err != nil {
+		return fmt.Errorf("error writing to file %s: %v", path, err)
+	}
+	err = os.Chmod(path, 0700)
+	if err != nil {
+		return fmt.Errorf("can't update permissions on file %s: %v", path, err)
+	}
+	return nil
+}
+
+// ensureFile check the existance of file in session path
+func (e *BackplaneSession) ensureFile(filename string) (file *os.File, err error) {
+	filename = filepath.Clean(filename)
+	if _, err := os.Stat(filename); errors.Is(err, os.ErrNotExist) {
+		file, err = os.Create(filename)
+		if err != nil {
+			return nil, fmt.Errorf("can't create file %s: %v", filename, err)
+		}
+	}
+	return file, nil
+}
+
+// binPath returns the session bin path
+func (e *BackplaneSession) binPath() string {
+	return e.Path + "/bin"
+}
+
+// sessionPath returns the session saving path
+func (e *BackplaneSession) sessionPath() (string, error) {
+	bpConfig, err := config.GetBackplaneConfiguration()
+	if err != nil {
+		return "", err
+	}
+	sessionDir := info.BACKPLANE_DEFAULT_SESSION_DIRECTORY
+
+	// Get the session directory name via config
+	if bpConfig.SessionDirectory != "" {
+		sessionDir = bpConfig.SessionDirectory
+	}
+
+	UserHomeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	configFilePath := filepath.Join(UserHomeDir, sessionDir, e.Options.Alias)
+	return configFilePath, nil
+}
+
+// initCluster login to cluster and save kube config into session for valid clusters
+func (e *BackplaneSession) initClusterLogin(cmd *cobra.Command) error {
+
+	if e.Options.ClusterId != "" {
+
+		// Setting up the flags
+		err := login.LoginCmd.Flags().Set("multi", "true")
+		if err != nil {
+			return fmt.Errorf("error occered when setting multi flag %v", err)
+		}
+		err = login.LoginCmd.Flags().Set("kube-path", e.Path)
+		if err != nil {
+			return fmt.Errorf("error occered when kube-path flag %v", err)
+		}
+
+		// Execute login command
+		err = login.LoginCmd.RunE(cmd, []string{e.Options.ClusterId})
+		if err != nil {
+			return fmt.Errorf("error occered when login to the cluster %v", err)
+		}
+	}
+
+	return nil
+}
+
+func (e *BackplaneSession) printSesionHeader() {
+	fmt.Println("====================================================")
+	fmt.Println("*          Backplane Session                       *")
+	fmt.Println("*                                                  *")
+	fmt.Println("*Help:                                             *")
+	fmt.Println("* exit will terminate this session                 *")
+	fmt.Println("* You can use oc commands to interact with cluster *")
+	fmt.Println("====================================================")
+}

--- a/pkg/cli/session/session.go
+++ b/pkg/cli/session/session.go
@@ -176,7 +176,10 @@ func (e *BackplaneSession) Start() error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Dir = e.Path
-	_ = cmd.Run() // add error checking
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("error while running cmd. error %v", err)
+	}
 
 	err = e.killChildren()
 	if err != nil {
@@ -199,7 +202,6 @@ func (e *BackplaneSession) killChildren() error {
 			if errors.Is(err, os.ErrNotExist) {
 				fmt.Println("Nothing to kill")
 			}
-			//return fmt.Errorf("failed to read file .killpids: %v", err)
 		}
 		defer func(file *os.File) {
 			err := file.Close()

--- a/pkg/cli/session/session_suite_test.go
+++ b/pkg/cli/session/session_suite_test.go
@@ -1,0 +1,13 @@
+package session
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestIt(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Session Test Suite")
+}

--- a/pkg/cli/session/session_test.go
+++ b/pkg/cli/session/session_test.go
@@ -1,0 +1,1 @@
+package session

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -17,6 +17,9 @@ const (
 	BACKPLANE_CONFIG_DEFAULT_FILE_PATH = ".config/backplane"
 	BACKPLANE_CONFIG_DEFAULT_FILE_NAME = "config.json"
 
+	// Session
+	BACKPLANE_DEFAULT_SESSION_DIRECTORY = "backplane"
+
 	// GitHub API get fetch the latest tag
 	UpstreamReleaseAPI = "https://api.github.com/repos/openshift/backplane-cli/releases/latest"
 

--- a/pkg/login/kubeConfig.go
+++ b/pkg/login/kubeConfig.go
@@ -81,13 +81,24 @@ func RemoveClusterKubeConfig(clusterId string) error {
 }
 
 // SaveKubeConfig modify Kube config based on user setting
-func SaveKubeConfig(clusterId string, config api.Config, isMulti bool) error {
+func SaveKubeConfig(clusterId string, config api.Config, isMulti bool, kubePath string) error {
 
 	if isMulti {
+		//update path
+		if kubePath != "" {
+			err := SetKubeConfigBasePath(kubePath)
+			if err != nil {
+				return err
+			}
+		}
 		//save config to current session
 		path, err := CreateClusterKubeConfig(clusterId, config)
-		fmt.Printf("Execute the following command to log into the cluster %s \n", clusterId)
-		fmt.Println("export " + info.BACKPLANE_KUBECONFIG_ENV_NAME + "=" + path)
+
+		if kubePath == "" {
+			// Inform how to setup kube config
+			fmt.Printf("Execute the following command to log into the cluster %s \n", clusterId)
+			fmt.Println("export " + info.BACKPLANE_KUBECONFIG_ENV_NAME + "=" + path)
+		}
 
 		if err != nil {
 			return err


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / Why we need it?
#### Create a New Backplane session 
```
ocm backplane session test-session -c <cluster-id>
Setting up environment...
INFO[0002] Target cluster                                ID=<cluster-id>
[test-session (<cluster-info-PS1>)]$
```
you can directly login via cluster id 

```
ocm backplane session <cluster-id>
Setting up environment...
INFO[0002] Target cluster                                ID=<cluster-id>
[test-session (<cluster-info-PS1>)]$
```

#### Delete backplane session 
```
ocm backplane  session --delete test-session 
Cleaning up Backplane session test-session
```

#### Get cluster session history 
```
[ <session-alias-orcluster-id> (<cluster-info-PS1>]$ history 
    1  2023-05-08 15:06:05 oc get nodes
    2  2023-05-08 15:06:13 oc get co
    3  2023-05-08 15:06:40 history 
```

### How to change backplane session save path 
By default all session will save into ~/backplane directory 
You can change the dir path via config 
```
{
   "url": "your-bp-url"
    "proxy-url": "your-proxy-url"
   "session-dir":"your-session-dir"
}
```

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_
https://issues.redhat.com/browse/OSD-16162
### Special notes for your reviewer

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
