### PR TITLE
Config subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ To setup the PS1(prompt) for bash/zsh, please follow [these instructions](https:
 | Command                                                                     | Description                                                                              |
 | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
 | `ocm backplane login <CLUSTERID/EXTERNAL_ID/CLUSTER_NAME>`                  | Login to the target cluster                                                              |
-| `ocm backplane logout <CLUSTERID/EXTERNAL_ID/CLUSTER_NAME>`                 | Logout from the target cluster                                                             |
+| `ocm backplane logout <CLUSTERID/EXTERNAL_ID/CLUSTER_NAME>`                 | Logout from the target cluster                                                           |
+| `ocm backplane config get [flags]`                                          | Retrieve Backplane CLI configuration variables                                           |
+| `ocm backplane config set [flags]`                                          | Set Backplane CLI configuration variables                                                |
 | `ocm backplane console [flags]`                                             | Launch the OpenShift console of the current logged in cluster                            |
 | `ocm backplane cloud console`                                               | Launch the current logged in cluster's cloud provider console                            |
 | `ocm backplane cloud credentials [flags]`                                   | Retrieve a set of temporary cloud credentials for the cluster's cloud provider           |

--- a/cmd/ocm-backplane/config/config.go
+++ b/cmd/ocm-backplane/config/config.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"github.com/spf13/cobra"
+)
+
+const (
+	ProxyURLConfigVar = "proxy-url"
+	URLConfigVar      = "url"
+)
+
+func NewConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Get or set backplane-cli configuration",
+		Long: `Get or set backplane-cli configuration variables.
+The location of the configuration file is gleaned from ~/.config/backplane/config.json or the 'BACKPLANE_CONFIG' environment variable if set.
+
+The following variables are supported:
+url         Backplane API URL
+proxy-url   Squid proxy URL
+`,
+		SilenceUsage: true,
+	}
+
+	cmd.AddCommand(newGetCmd())
+	cmd.AddCommand(newSetCmd())
+	return cmd
+}

--- a/cmd/ocm-backplane/config/config.go
+++ b/cmd/ocm-backplane/config/config.go
@@ -7,6 +7,7 @@ import (
 const (
 	ProxyURLConfigVar = "proxy-url"
 	URLConfigVar      = "url"
+	SessionConfigVar  = "session-dir"
 )
 
 func NewConfigCmd() *cobra.Command {
@@ -19,6 +20,7 @@ The location of the configuration file is gleaned from ~/.config/backplane/confi
 The following variables are supported:
 url         Backplane API URL
 proxy-url   Squid proxy URL
+session-dir Backplane CLI session directory
 `,
 		SilenceUsage: true,
 	}

--- a/cmd/ocm-backplane/config/get.go
+++ b/cmd/ocm-backplane/config/get.go
@@ -14,7 +14,7 @@ func newGetCmd() *cobra.Command {
 		Short:        "Get Backplane CLI configuration variables",
 		Example:      "ocm backplane config get url",
 		SilenceUsage: true,
-		Args:         cobra.MinimumNArgs(1),
+		Args:         cobra.ExactArgs(1),
 		RunE:         getConfig,
 	}
 	return cmd
@@ -31,11 +31,14 @@ func getConfig(cmd *cobra.Command, args []string) error {
 		fmt.Printf("%s: %s\n", URLConfigVar, config.URL)
 	case ProxyURLConfigVar:
 		fmt.Printf("%s: %s\n", ProxyURLConfigVar, config.ProxyURL)
+	case SessionConfigVar:
+		fmt.Printf("%s: %s\n", SessionConfigVar, config.SessionDirectory)
 	case "all":
 		fmt.Printf("%s: %s\n", URLConfigVar, config.URL)
 		fmt.Printf("%s: %s\n", ProxyURLConfigVar, config.ProxyURL)
+		fmt.Printf("%s: %s\n", SessionConfigVar, config.SessionDirectory)
 	default:
-		return fmt.Errorf("supported config variables are %s and %s", URLConfigVar, ProxyURLConfigVar)
+		return fmt.Errorf("supported config variables are %s, %s & %s", URLConfigVar, ProxyURLConfigVar, SessionConfigVar)
 	}
 
 	return nil

--- a/cmd/ocm-backplane/config/get.go
+++ b/cmd/ocm-backplane/config/get.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/backplane-cli/pkg/cli/config"
+)
+
+func newGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "get",
+		Short:        "Get Backplane CLI configuration variables",
+		Example:      "ocm backplane config get url",
+		SilenceUsage: true,
+		Args:         cobra.MinimumNArgs(1),
+		RunE:         getConfig,
+	}
+	return cmd
+}
+
+func getConfig(cmd *cobra.Command, args []string) error {
+	config, err := config.GetBackplaneConfiguration()
+	if err != nil {
+		return err
+	}
+
+	switch args[0] {
+	case URLConfigVar:
+		fmt.Printf("%s: %s\n", URLConfigVar, config.URL)
+	case ProxyURLConfigVar:
+		fmt.Printf("%s: %s\n", ProxyURLConfigVar, config.ProxyURL)
+	case "all":
+		fmt.Printf("%s: %s\n", URLConfigVar, config.URL)
+		fmt.Printf("%s: %s\n", ProxyURLConfigVar, config.ProxyURL)
+	default:
+		return fmt.Errorf("supported config variables are %s and %s", URLConfigVar, ProxyURLConfigVar)
+	}
+
+	return nil
+}

--- a/cmd/ocm-backplane/config/set.go
+++ b/cmd/ocm-backplane/config/set.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/openshift/backplane-cli/pkg/cli/config"
+)
+
+var configFlags struct {
+	url      string
+	proxyURL string
+}
+
+func newSetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "set",
+		Short:        "Set Backplane CLI configuration variables",
+		Example:      "ocm backplane config set --proxy-url <proxy> --url <url>",
+		SilenceUsage: true,
+		RunE:         setConfig,
+	}
+
+	cmd.Flags().StringVar(
+		&configFlags.proxyURL,
+		ProxyURLConfigVar,
+		"",
+		"Squid proxy URL",
+	)
+
+	cmd.Flags().StringVar(
+		&configFlags.url,
+		URLConfigVar,
+		"",
+		"Backplane API URL",
+	)
+
+	return cmd
+}
+
+func setConfig(cmd *cobra.Command, args []string) error {
+	// Retrieve default Backplane CLI config path, $HOME/.config/backplane/config.json
+	configPath, err := config.GetConfigFilePath()
+	if err != nil {
+		return err
+	}
+
+	if configFlags.proxyURL == "" {
+		return fmt.Errorf("%s should not be empty", ProxyURLConfigVar)
+	}
+
+	if configFlags.url == "" {
+		return fmt.Errorf("%s should not be empty", URLConfigVar)
+	}
+
+	viper.Set(ProxyURLConfigVar, configFlags.proxyURL)
+	viper.Set(URLConfigVar, configFlags.url)
+
+	err = viper.WriteConfigAs(configPath)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Configuration file created at " + configPath)
+
+	return nil
+}

--- a/cmd/ocm-backplane/config/set.go
+++ b/cmd/ocm-backplane/config/set.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -9,60 +10,60 @@ import (
 	"github.com/openshift/backplane-cli/pkg/cli/config"
 )
 
-var configFlags struct {
-	url      string
-	proxyURL string
-}
-
 func newSetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "set",
 		Short:        "Set Backplane CLI configuration variables",
-		Example:      "ocm backplane config set --proxy-url <proxy> --url <url>",
+		Example:      "ocm backplane config set url https://example.com",
 		SilenceUsage: true,
+		Args:         cobra.ExactArgs(2),
 		RunE:         setConfig,
 	}
-
-	cmd.Flags().StringVar(
-		&configFlags.proxyURL,
-		ProxyURLConfigVar,
-		"",
-		"Squid proxy URL",
-	)
-
-	cmd.Flags().StringVar(
-		&configFlags.url,
-		URLConfigVar,
-		"",
-		"Backplane API URL",
-	)
 
 	return cmd
 }
 
 func setConfig(cmd *cobra.Command, args []string) error {
+	bpConfig := &config.BackplaneConfiguration{}
+
 	// Retrieve default Backplane CLI config path, $HOME/.config/backplane/config.json
 	configPath, err := config.GetConfigFilePath()
 	if err != nil {
 		return err
 	}
 
-	if configFlags.proxyURL == "" {
-		return fmt.Errorf("%s should not be empty", ProxyURLConfigVar)
+	if _, err = os.Stat(configPath); err == nil {
+		viper.SetConfigFile(configPath)
+		if err := viper.ReadInConfig(); err != nil {
+			return err
+		}
+
+		bpConfig.URL = viper.GetString("url")
+		bpConfig.ProxyURL = viper.GetString("proxy-url")
+		bpConfig.SessionDirectory = viper.GetString("session-dir")
 	}
 
-	if configFlags.url == "" {
-		return fmt.Errorf("%s should not be empty", URLConfigVar)
+	switch args[0] {
+	case URLConfigVar:
+		bpConfig.URL = args[1]
+	case ProxyURLConfigVar:
+		bpConfig.ProxyURL = args[1]
+	case SessionConfigVar:
+		bpConfig.SessionDirectory = args[1]
+	default:
+		return fmt.Errorf("supported config variables are %s, %s & %s", URLConfigVar, ProxyURLConfigVar, SessionConfigVar)
 	}
 
-	viper.Set(ProxyURLConfigVar, configFlags.proxyURL)
-	viper.Set(URLConfigVar, configFlags.url)
+	viper.SetConfigType("json")
+	viper.Set(URLConfigVar, bpConfig.URL)
+	viper.Set(ProxyURLConfigVar, bpConfig.ProxyURL)
+	viper.Set(SessionConfigVar, bpConfig.SessionDirectory)
 
 	err = viper.WriteConfigAs(configPath)
 	if err != nil {
 		return err
 	}
-	fmt.Println("Configuration file created at " + configPath)
+	fmt.Println("Configuration file updated at " + configPath)
 
 	return nil
 }

--- a/cmd/ocm-backplane/root.go
+++ b/cmd/ocm-backplane/root.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/cloud"
+	"github.com/openshift/backplane-cli/cmd/ocm-backplane/config"
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/console"
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/elevate"
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/login"
@@ -89,17 +90,17 @@ func init() {
 	logLevelFlag.NoOptDefVal = log.InfoLevel.String()
 
 	// Register sub-commands
-	rootCmd.AddCommand(login.LoginCmd)
-	rootCmd.AddCommand(upgrade.UpgradeCmd)
-	rootCmd.AddCommand(elevate.ElevateCmd)
+	rootCmd.AddCommand(console.ConsoleCmd)
+	rootCmd.AddCommand(config.NewConfigCmd())
 	rootCmd.AddCommand(cloud.CloudCmd)
+	rootCmd.AddCommand(elevate.ElevateCmd)
+	rootCmd.AddCommand(login.LoginCmd)
 	rootCmd.AddCommand(logout.LogoutCmd)
+	rootCmd.AddCommand(managedJob.NewManagedJobCmd())
 	rootCmd.AddCommand(script.NewScriptCmd())
 	rootCmd.AddCommand(status.StatusCmd)
-	rootCmd.AddCommand(version.VersionCmd)
-	rootCmd.AddCommand(testJob.NewTestJobCommand())
-	rootCmd.AddCommand(managedJob.NewManagedJobCmd())
-	rootCmd.AddCommand(console.ConsoleCmd)
 	rootCmd.AddCommand(session.NewCmdSession())
-
+	rootCmd.AddCommand(testJob.NewTestJobCommand())
+	rootCmd.AddCommand(upgrade.UpgradeCmd)
+	rootCmd.AddCommand(version.VersionCmd)
 }

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -14,8 +14,14 @@ type BackplaneConfiguration struct {
 	SessionDirectory string
 }
 
-// getConfigFilePath returns the default config path
+// GetConfigFilePath returns the Backplane CLI configuration filepath
 func GetConfigFilePath() (string, error) {
+	// Check if user has explicitly defined backplane config path
+	path, found := os.LookupEnv(info.BACKPLANE_CONFIG_PATH_ENV_NAME)
+	if found {
+		return path, nil
+	}
+
 	UserHomeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
@@ -28,18 +34,9 @@ func GetConfigFilePath() (string, error) {
 
 // GetBackplaneConfiguration parses and returns the given backplane configuration
 func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
-	var filepath string
-
-	// Check if user has explicitly defined backplane config path
-	path, bpConfigFound := os.LookupEnv(info.BACKPLANE_CONFIG_PATH_ENV_NAME)
-
-	if bpConfigFound {
-		filepath = path
-	} else {
-		filepath, err = GetConfigFilePath()
-		if err != nil {
-			return bpConfig, err
-		}
+	filepath, err := GetConfigFilePath()
+	if err != nil {
+		return bpConfig, err
 	}
 
 	viper.AutomaticEnv()

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -15,7 +15,7 @@ type BackplaneConfiguration struct {
 }
 
 // getConfigFilePath returns the default config path
-func getConfigFilePath() (string, error) {
+func GetConfigFilePath() (string, error) {
 	UserHomeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
@@ -36,7 +36,7 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 	if bpConfigFound {
 		filepath = path
 	} else {
-		filepath, err = getConfigFilePath()
+		filepath, err = GetConfigFilePath()
 		if err != nil {
 			return bpConfig, err
 		}


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / Why we need it?
This PR adds a new `config` command to Backplane CLI making configuration management easy.

- `ocm backplane config get [url/proxy-url/all]` retrieves the Backplane CLI configuration variables.
- `ocm backplane config set url https://example.com` sets the Backplane CLI configuration.

Uses [viper](https://github.com/spf13/viper) in the backend.

### Which Jira/Github issue(s) does this PR fix?
Resolves: https://issues.redhat.com/browse/OSD-15878

### Special notes for your reviewer
Unit tests will be followed with another PR

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [x] Included documentation changes with PR
