### PR TITLE
Add command to get STS credentials for a role from an ocm token

### DIFF
--- a/cmd/ocm-backplane/cloud/cloud.go
+++ b/cmd/ocm-backplane/cloud/cloud.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var CloudCmd *cobra.Command = &cobra.Command{
+var CloudCmd = &cobra.Command{
 	Use:               "cloud",
 	Short:             "Cloud Access and Subcommands",
 	Args:              cobra.NoArgs,
@@ -15,6 +15,7 @@ var CloudCmd *cobra.Command = &cobra.Command{
 func init() {
 	CloudCmd.AddCommand(CredentialsCmd)
 	CloudCmd.AddCommand(ConsoleCmd)
+	CloudCmd.AddCommand(TokenCmd)
 }
 
 func help(cmd *cobra.Command, _ []string) {

--- a/cmd/ocm-backplane/cloud/token.go
+++ b/cmd/ocm-backplane/cloud/token.go
@@ -1,0 +1,88 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"github.com/openshift/backplane-cli/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+var tokenArgs struct {
+	roleArn string
+}
+
+var TokenCmd = &cobra.Command{
+	Use:   "token",
+	Short: "Generates a session token for the given role ARN",
+	Long: `Generates a session token for the given role ARN.
+
+This command is the equivalent of running "aws sts assume-role-with-web-identity --role-arn [role-arn] --web-identity-token [ocm token] --role-session-name [email from OCM token]" behind the scenes,
+where the ocm token used is the result of running "ocm token".
+
+This command will output the "Credentials" property of that call in formatted JSON.`,
+	Example: "backplane cloud token --role-arn arn:aws:iam::1234567890:role/read-only",
+	Args:    cobra.NoArgs,
+	RunE:    runToken,
+}
+
+func init() {
+	flags := TokenCmd.Flags()
+	flags.StringVar(&tokenArgs.roleArn, "role-arn", "", "")
+}
+
+func runToken(*cobra.Command, []string) error {
+	ocmToken, err := utils.DefaultOCMInterface.GetOCMAccessToken()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve OCM token: %w", err)
+	}
+
+	svc, err := MakeStsService()
+	if err != nil {
+		return fmt.Errorf("unable to create aws session: %w", err)
+	}
+
+	result, err := GetStsCredentials(*ocmToken, tokenArgs.roleArn, svc)
+	if err != nil {
+		return err
+	}
+
+	marshalledResult, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error formatting result: %w", err)
+	}
+
+	fmt.Println(string(marshalledResult))
+	return nil
+}
+
+func MakeStsService() (*sts.Client, error) {
+	// IAM is global, but this config needs a region. Give it any valid region.
+	return sts.NewFromConfig(aws.Config{Region: "us-east-1"}), nil
+}
+
+type STSRoleAssumer interface {
+	AssumeRoleWithWebIdentity(ctx context.Context, params *sts.AssumeRoleWithWebIdentityInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleWithWebIdentityOutput, error)
+}
+
+func GetStsCredentials(ocmToken string, roleArn string, svc STSRoleAssumer) (*types.Credentials, error) {
+	email, err := utils.GetFieldFromJWT(ocmToken, "email")
+	if err != nil {
+		return nil, fmt.Errorf("unable to extract email from given token: %w", err)
+	}
+	input := &sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          aws.String(roleArn),
+		RoleSessionName:  aws.String(email),
+		WebIdentityToken: aws.String(ocmToken),
+	}
+
+	result, err := svc.AssumeRoleWithWebIdentity(context.TODO(), input)
+	if err != nil {
+		return nil, fmt.Errorf("unable to assume the given role with the token provided: %w", err)
+	}
+
+	return result.Credentials, nil
+}

--- a/cmd/ocm-backplane/cloud/token_test.go
+++ b/cmd/ocm-backplane/cloud/token_test.go
@@ -1,0 +1,97 @@
+package cloud
+
+import (
+	"context"
+	"errors"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"reflect"
+	"testing"
+)
+
+type STSRoleAssumerMock struct {
+	mockResult *sts.AssumeRoleWithWebIdentityOutput
+	mockErr    error
+}
+
+func (s STSRoleAssumerMock) AssumeRoleWithWebIdentity(context.Context, *sts.AssumeRoleWithWebIdentityInput, ...func(*sts.Options)) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+	return s.mockResult, s.mockErr
+}
+
+func makeMockSTSClient(mockResult *sts.AssumeRoleWithWebIdentityOutput, mockErr error) STSRoleAssumerMock {
+	return STSRoleAssumerMock{
+		mockResult: mockResult,
+		mockErr:    mockErr,
+	}
+}
+
+func TestGetStsToken(t *testing.T) {
+	type args struct {
+		ocmToken string
+		roleArn  string
+		svc      STSRoleAssumer
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *types.Credentials
+		wantErr bool
+	}{
+		{
+			name: "No email field on token",
+			args: args{
+				ocmToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+				roleArn:  "arn:aws:iam::1234567890:role/read-only",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Failed call to AWS",
+			args: args{
+				ocmToken: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2ODQ4NjM2NzksImV4cCI6MTcxNjM5OTY3OSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoiZm9vQGJhci5jb20iLCJFbWFpbCI6ImZvb0BleGFtcGxlLmNvbSJ9.cND4hWI_Wd-AGP0BM4G7jqWfYnuz4Jl7RWLEfZ-AU_0",
+				roleArn:  "arn:aws:iam::1234567890:role/read-only",
+				svc:      makeMockSTSClient(nil, errors.New("oops")),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Successfully returns credentials",
+			args: args{
+				ocmToken: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2ODQ4NjM2NzksImV4cCI6MTcxNjM5OTY3OSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoiZm9vQGJhci5jb20iLCJlbWFpbCI6ImZvb0BleGFtcGxlLmNvbSJ9.0AhwDFDEtsqOvoJhqvDm9_Vb588GhnfUVGcsN4JFw9o",
+				roleArn:  "arn:aws:iam::1234567890:role/read-only",
+				svc: makeMockSTSClient(&sts.AssumeRoleWithWebIdentityOutput{
+					AssumedRoleUser: &types.AssumedRoleUser{
+						Arn:           aws.String("arn:aws:sts::123456789:assumed-role/read-only/foo@example.com"),
+						AssumedRoleId: aws.String("ABCDEFG1234567:foo@example.com"),
+					},
+					Audience: aws.String("sample-audience"),
+					Credentials: &types.Credentials{
+						AccessKeyId:     aws.String("test-access-key-id"),
+						SecretAccessKey: aws.String("test-secret-access-key"),
+						SessionToken:    aws.String("test-session-token"),
+					},
+					Provider:                    aws.String("arn:aws:iam::123456789:oidc-provider/foo.example.com/auth/"),
+					SubjectFromWebIdentityToken: aws.String("f:123abc-45de-67fg-8hi9-abcde12345:foo"),
+				}, nil),
+			},
+			want: &types.Credentials{
+				AccessKeyId:     aws.String("test-access-key-id"),
+				SecretAccessKey: aws.String("test-secret-access-key"),
+				SessionToken:    aws.String("test-session-token"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetStsCredentials(tt.args.ocmToken, tt.args.roleArn, tt.args.svc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetStsCredentials() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetStsCredentials() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/Masterminds/semver v1.5.0
+	github.com/aws/aws-sdk-go v1.44.110
 	github.com/aws/aws-sdk-go-v2 v1.18.0
 	github.com/aws/aws-sdk-go-v2/config v1.18.25
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.24
@@ -71,6 +72,7 @@ require (
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/yaml v0.1.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
+github.com/aws/aws-sdk-go v1.44.110 h1:unno3l2FYQo6p0wYCp9gUk8YNzhOxqSktM0Y1vukl9k=
+github.com/aws/aws-sdk-go v1.44.110/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go-v2 v1.18.0 h1:882kkTpSFhdgYRKVZ/VCgf7sd0ru57p2JCxz4/oN5RY=
 github.com/aws/aws-sdk-go-v2 v1.18.0/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2/config v1.18.25 h1:JuYyZcnMPBiFqn87L2cRppo+rNwgah6YwD3VuyvaW6Q=
@@ -316,6 +318,7 @@ github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0f
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.2.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/pkg/utils/jwt.go
+++ b/pkg/utils/jwt.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// GetFieldFromJWT Returns the value of a field from a given JWT.
+//
+// WARNING: This function does not verify the token.
+//
+// Only use this function in cases where you know the signature is valid and want to extract values from it.
+func GetFieldFromJWT(token string, field string) (string, error) {
+	var jwtToken *jwt.Token
+	var err error
+
+	parser := new(jwt.Parser)
+	jwtToken, _, err = parser.ParseUnverified(token, jwt.MapClaims{})
+	if err != nil {
+		return "", err
+	}
+
+	claims, ok := jwtToken.Claims.(jwt.MapClaims)
+	if !ok {
+		return "", err
+	}
+
+	claim, ok := claims[field]
+	if !ok {
+		return "", fmt.Errorf("no field %v on given token", field)
+	}
+
+	return claim.(string), nil
+}

--- a/pkg/utils/jwt_test.go
+++ b/pkg/utils/jwt_test.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestGetFieldFromJWT(t *testing.T) {
+	tests := []struct {
+		name    string
+		token   string
+		field   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Get field",
+			token:   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+			field:   "sub",
+			want:    "1234567890",
+			wantErr: false,
+		},
+		{
+			name:    "Get field that doesn't exist",
+			token:   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+			field:   "foo",
+			wantErr: true,
+		},
+		{
+			name:    "Invalid token",
+			token:   "abcdefg",
+			field:   "foo",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetFieldFromJWT(tt.token, tt.field)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetFieldFromJWT() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetFieldFromJWT() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / Why we need it?
Adds a command to fetch STS credentials for given role

### Which Jira/Github issue(s) does this PR fix?
[OSD-16489](https://issues.redhat.com//browse/OSD-16489)

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [ ] ~Validated the changes in a cluster~
- [x] Included documentation changes with PR

To test locally:
In an AWS account, create a role with the trust policy in the attached ticket. Run this command with the arn for that role passed in as `--role-arn`, i.e. `backplane cloud token --role-arn [role arn]`. If successful, the command should output AWS STS Credentials as a JSON payload.