### PR TITLE
OSD-14573-warn-user-for-old-cli

### DIFF
--- a/cmd/ocm-backplane/cloud/console.go
+++ b/cmd/ocm-backplane/cloud/console.go
@@ -81,6 +81,8 @@ func init() {
 func runConsole(cmd *cobra.Command, argv []string) (err error) {
 	var clusterKey string
 
+	utils.CheckBackplaneVersion(cmd)
+
 	err = validateParams(argv)
 
 	if err != nil {

--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -91,6 +91,8 @@ func init() {
 func runLogin(cmd *cobra.Command, argv []string) (err error) {
 	var clusterKey string
 
+	utils.CheckBackplaneVersion(cmd)
+
 	// Get The cluster ID
 	if len(argv) == 1 {
 		// if explicitly one cluster key given, use it to log in.


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / Why we need it?

In order to help users identify version related issue faster, this PR adds a warning message when they attempt to login to a cluster.

### Which Jira/Github issue(s) does this PR fix?

[OSD-14573](https://issues.redhat.com//browse/OSD-14573)

### Special notes for your reviewer

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
