### PR TITLE
Add commands to get an STS token for a role from an ocm token, and to assume roles through a chain of ARNs

### DIFF
--- a/cmd/ocm-backplane/cloud/assume.go
+++ b/cmd/ocm-backplane/cloud/assume.go
@@ -1,0 +1,140 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/openshift/backplane-cli/pkg/awsUtil"
+	"github.com/openshift/backplane-cli/pkg/cli/config"
+	"github.com/openshift/backplane-cli/pkg/utils"
+	"github.com/spf13/cobra"
+	"io"
+)
+
+const (
+	DefaultRoleArn = "arn:aws:iam::922711891673:role/SRE-Support-Role"
+)
+
+var assumeArgs struct {
+	roleArn string
+	output  string
+}
+
+var AssumeCmd = &cobra.Command{
+	Use:   "assume [CLUSTERID|EXTERNAL_ID|CLUSTER_NAME|CLUSTER_NAME_SEARCH]",
+	Short: "Performs the assume role chaining necessary to generate temporary access to the customer's AWS account",
+	Long: `Performs the assume role chaining necessary to generate temporary access to the customer's AWS account
+
+This command is the equivalent of running "aws sts assume-role-with-web-identity --role-arn [role-arn] --web-identity-token [ocm token] --role-session-name [email from OCM token]" behind the scenes,
+where the ocm token used is the result of running "ocm token". Then, the command makes a call to the backplane API to get the necessary jump roles for the cluster's account. It then calls the
+equivalent of "aws sts assume-role --role-arn [role-arn] --role-session-name [email from OCM token]" repeatedly for each role arn in the chain, using the previous role's credentials to assume the next
+role in the chain.
+
+This command will output sts credentials for the target role in the given cluster in formatted JSON. If no "role-arn" is provided, a default role will be used.
+`,
+	Example: `With default role:
+backplane cloud assume e3b2fdc5-d9a7-435e-8870-312689cfb29c -oenv
+
+With given role:
+backplane cloud assume e3b2fdc5-d9a7-435e-8870-312689cfb29c --role-arn arn:aws:iam::1234567890:role/read-only -oenv`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAssume,
+}
+
+func init() {
+	flags := AssumeCmd.Flags()
+	flags.StringVar(&assumeArgs.roleArn, "role-arn", DefaultRoleArn, "The arn of the role for which to start the role assume process.")
+	flags.StringVarP(&assumeArgs.output, "output", "o", "env", "Format the output of the console response.")
+}
+
+type assumeChainResponse struct {
+	AssumptionSequence []namedRoleArn `json:"assumption_sequence"`
+}
+
+type namedRoleArn struct {
+	Name string `json:"name"`
+	Arn  string `json:"arn"`
+}
+
+func runAssume(_ *cobra.Command, args []string) error {
+	ocmToken, err := utils.DefaultOCMInterface.GetOCMAccessToken()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve OCM token: %w", err)
+	}
+
+	bpConfig, err := config.GetBackplaneConfiguration()
+	if err != nil {
+		return fmt.Errorf("error retrieving backplane configuration: %w", err)
+	}
+
+	initialClient, err := awsUtil.StsClientWithProxy(bpConfig.ProxyURL)
+	if err != nil {
+		return fmt.Errorf("failed to create sts client: %w", err)
+	}
+	seedCredentials, err := awsUtil.AssumeRoleWithJWT(*ocmToken, assumeArgs.roleArn, initialClient)
+	if err != nil {
+		return fmt.Errorf("failed to assume role using JWT: %w", err)
+	}
+
+	clusterId, _, err := utils.DefaultOCMInterface.GetTargetCluster(args[0])
+	if err != nil {
+		return fmt.Errorf("failed to get target cluster: %w", err)
+	}
+
+	backplaneClient, err := utils.DefaultClientUtils.MakeRawBackplaneAPIClientWithAccessToken(bpConfig.URL, *ocmToken)
+	if err != nil {
+		return fmt.Errorf("failed to create backplane client with access token: %w", err)
+	}
+
+	response, err := backplaneClient.GetAssumeRoleSequence(context.TODO(), clusterId)
+	if err != nil {
+		return fmt.Errorf("failed to fetch arn sequence: %w", err)
+	}
+
+	bytes, err := io.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read backplane API response body: %w", err)
+	}
+
+	roleChainResponse := &assumeChainResponse{}
+	err = json.Unmarshal(bytes, roleChainResponse)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	roleAssumeSequence := make([]string, 0, len(roleChainResponse.AssumptionSequence))
+	for _, namedRoleArn := range roleChainResponse.AssumptionSequence {
+		roleAssumeSequence = append(roleAssumeSequence, namedRoleArn.Arn)
+	}
+
+	email, err := utils.GetStringFieldFromJWT(*ocmToken, "email")
+	if err != nil {
+		return fmt.Errorf("unable to extract email from given token: %w", err)
+	}
+
+	seedClient := sts.NewFromConfig(aws.Config{
+		Region:      "us-east-1",
+		Credentials: credentials.NewStaticCredentialsProvider(*seedCredentials.AccessKeyId, *seedCredentials.SecretAccessKey, *seedCredentials.SessionToken),
+	})
+	targetCredentials, err := awsUtil.AssumeRoleSequence(email, seedClient, roleAssumeSequence, bpConfig.ProxyURL, awsUtil.DefaultSTSClientProviderFunc)
+	if err != nil {
+		return fmt.Errorf("failed to assume role sequence: %w", err)
+	}
+
+	credsResponse := awsUtil.AWSCredentialsResponse{
+		AccessKeyId:     *targetCredentials.AccessKeyId,
+		SecretAccessKey: *targetCredentials.SecretAccessKey,
+		SessionToken:    *targetCredentials.SessionToken,
+		Expiration:      targetCredentials.Expiration.String(),
+	}
+	formattedResult, err := credsResponse.RenderOutput(assumeArgs.output)
+	if err != nil {
+		return fmt.Errorf("failed to format output correctly: %w", err)
+	}
+
+	fmt.Println(formattedResult)
+	return nil
+}

--- a/cmd/ocm-backplane/cloud/cloud.go
+++ b/cmd/ocm-backplane/cloud/cloud.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var CloudCmd *cobra.Command = &cobra.Command{
+var CloudCmd = &cobra.Command{
 	Use:               "cloud",
 	Short:             "Cloud Access and Subcommands",
 	Args:              cobra.NoArgs,
@@ -15,6 +15,8 @@ var CloudCmd *cobra.Command = &cobra.Command{
 func init() {
 	CloudCmd.AddCommand(CredentialsCmd)
 	CloudCmd.AddCommand(ConsoleCmd)
+	CloudCmd.AddCommand(TokenCmd)
+	CloudCmd.AddCommand(AssumeCmd)
 }
 
 func help(cmd *cobra.Command, _ []string) {

--- a/cmd/ocm-backplane/cloud/token.go
+++ b/cmd/ocm-backplane/cloud/token.go
@@ -1,0 +1,70 @@
+package cloud
+
+import (
+	"fmt"
+	"github.com/openshift/backplane-cli/pkg/awsUtil"
+	"github.com/openshift/backplane-cli/pkg/cli/config"
+	"github.com/openshift/backplane-cli/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+var tokenArgs struct {
+	roleArn string
+	output  string
+}
+
+var TokenCmd = &cobra.Command{
+	Use:   "token",
+	Short: "Generates a session token for the given role ARN",
+	Long: `Generates a session token for the given role ARN.
+
+This command is the equivalent of running "aws sts assume-role-with-web-identity --role-arn [role-arn] --web-identity-token [ocm token] --role-session-name [email from OCM token]" behind the scenes,
+where the ocm token used is the result of running "ocm token".
+
+This command will output the "Credentials" property of that call in formatted JSON.`,
+	Example: "backplane cloud token --role-arn arn:aws:iam::1234567890:role/read-only -oenv",
+	Args:    cobra.NoArgs,
+	RunE:    runToken,
+}
+
+func init() {
+	flags := TokenCmd.Flags()
+	flags.StringVar(&tokenArgs.roleArn, "role-arn", "", "The arn of the role for which to get credentials.")
+	flags.StringVarP(&tokenArgs.output, "output", "o", "env", "Format the output of the console response.")
+}
+
+func runToken(*cobra.Command, []string) error {
+	ocmToken, err := utils.DefaultOCMInterface.GetOCMAccessToken()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve OCM token: %w", err)
+	}
+
+	bpConfig, err := config.GetBackplaneConfiguration()
+	if err != nil {
+		return fmt.Errorf("error retrieving backplane configuration: %w", err)
+	}
+	svc, err := awsUtil.StsClientWithProxy(bpConfig.ProxyURL)
+	if err != nil {
+		return fmt.Errorf("error creating STS client: %w", err)
+	}
+
+	result, err := awsUtil.AssumeRoleWithJWT(*ocmToken, tokenArgs.roleArn, svc)
+	if err != nil {
+		return fmt.Errorf("failed to assume role with JWT: %w", err)
+	}
+
+	credsResponse := awsUtil.AWSCredentialsResponse{
+		AccessKeyId:     *result.AccessKeyId,
+		SecretAccessKey: *result.SecretAccessKey,
+		SessionToken:    *result.SessionToken,
+		Expiration:      result.Expiration.String(),
+	}
+
+	formattedResult, err := credsResponse.RenderOutput(tokenArgs.output)
+	if err != nil {
+		return fmt.Errorf("failed to format output correctly: %w", err)
+	}
+
+	fmt.Println(formattedResult)
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.18.1
 	github.com/aws/aws-sdk-go-v2/config v1.18.27
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.26
+	github.com/aws/aws-sdk-go-v2/service/sts v1.19.2
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/golang/mock v1.6.0
 	github.com/mitchellh/go-homedir v1.1.0
@@ -15,7 +16,7 @@ require (
 	github.com/onsi/gomega v1.27.8
 	github.com/openshift-online/ocm-cli v0.1.66
 	github.com/openshift-online/ocm-sdk-go v0.1.348
-	github.com/openshift/backplane-api v0.0.0-20230203044845-10f2b341bf54
+	github.com/openshift/backplane-api v0.0.0-20230615010608-391cd2c4bbd8
 	github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/sirupsen/logrus v1.9.3
@@ -39,7 +40,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.28 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.12.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.12 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.19.2 // indirect
 	github.com/aws/smithy-go v1.13.5 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -433,8 +433,8 @@ github.com/openshift-online/ocm-sdk-go v0.1.348 h1:7SOso8odkYEQ2mXfoWbj2ulQY6WOM
 github.com/openshift-online/ocm-sdk-go v0.1.348/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
 github.com/openshift/api v0.0.0-20221018124113-7edcfe3c76cb h1:QsBjYe5UfHIZi/3SMzQBIjYDKnWqZxq50eQkBp9eUew=
 github.com/openshift/api v0.0.0-20221018124113-7edcfe3c76cb/go.mod h1:JRz+ZvTqu9u7t6suhhPTacbFl5K65Y6rJbNM7HjWA3g=
-github.com/openshift/backplane-api v0.0.0-20230203044845-10f2b341bf54 h1:EFl+q3LxF1zmzruS7KvHzfUJxFOdExQF0WRe1Na3lvY=
-github.com/openshift/backplane-api v0.0.0-20230203044845-10f2b341bf54/go.mod h1:Mjfac1NyfztoqJKzD6Juya4IzP8r8BCy5ZldVXndlB0=
+github.com/openshift/backplane-api v0.0.0-20230615010608-391cd2c4bbd8 h1:SPGOXH1l1Cy0Q3dboU1e/OX3KN29bRy/DbHfA9eq090=
+github.com/openshift/backplane-api v0.0.0-20230615010608-391cd2c4bbd8/go.mod h1:RuJZpJy45AJnkp7A0ZPTZhLOVkCGDLI6cGknKvp65LE=
 github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c h1:CV76yFOTXmq9VciBR3Bve5ZWzSxdft7gaMVB3kS0rwg=
 github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c/go.mod h1:lFMO8mLHXWFzSdYvGNo8ivF9SfF6zInA8ZGw4phRnUE=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=

--- a/pkg/awsUtil/credentials.go
+++ b/pkg/awsUtil/credentials.go
@@ -1,0 +1,44 @@
+package awsUtil
+
+import (
+	"encoding/json"
+	"fmt"
+	"sigs.k8s.io/yaml"
+)
+
+const awsExportFormat = `export AWS_ACCESS_KEY_ID=%s
+export AWS_SECRET_ACCESS_KEY=%s
+export AWS_SESSION_TOKEN=%s`
+
+type AWSCredentialsResponse struct {
+	AccessKeyId     string `json:"AccessKeyId" yaml:"AccessKeyId"`
+	SecretAccessKey string `json:"SecretAccessKey" yaml:"SecretAccessKey"`
+	SessionToken    string `json:"SessionToken" yaml:"SessionToken"`
+	Region          string `json:"Region,omitempty" yaml:"Region,omitempty"`
+	Expiration      string `json:"Expiration,omitempty" yaml:"Expiration,omitempty"`
+}
+
+func (r AWSCredentialsResponse) EnvFormat() string {
+	return fmt.Sprintf(awsExportFormat, r.AccessKeyId, r.SecretAccessKey, r.SessionToken)
+}
+
+func (r AWSCredentialsResponse) RenderOutput(outputFormat string) (string, error) {
+	switch outputFormat {
+	case "env":
+		return r.EnvFormat(), nil
+	case "json":
+		jsonBytes, err := json.Marshal(r)
+		if err != nil {
+			return "", fmt.Errorf("failed to render output as %v: %w", outputFormat, err)
+		}
+		return string(jsonBytes), nil
+	case "yaml":
+		yamlBytes, err := yaml.Marshal(r)
+		if err != nil {
+			return "", fmt.Errorf("failed to render output as %v: %w", outputFormat, err)
+		}
+		return string(yamlBytes), nil
+	default:
+		return "", fmt.Errorf("unsupported format %v", outputFormat)
+	}
+}

--- a/pkg/awsUtil/credentials_test.go
+++ b/pkg/awsUtil/credentials_test.go
@@ -1,0 +1,148 @@
+package awsUtil
+
+import (
+	"encoding/json"
+	"fmt"
+	"sigs.k8s.io/yaml"
+	"testing"
+)
+
+func TestAWSCredentialsResponse_EnvFormat(t *testing.T) {
+	type fields struct {
+		AccessKeyId     string
+		SecretAccessKey string
+		SessionToken    string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "Contains no values",
+			want: fmt.Sprintf(awsExportFormat, "", "", ""),
+		},
+		{
+			name:   "Contains Access Key Id only",
+			fields: fields{AccessKeyId: "test-key"},
+			want:   fmt.Sprintf(awsExportFormat, "test-key", "", ""),
+		},
+		{
+			name:   "Contains Secret Access Key only",
+			fields: fields{SecretAccessKey: "test-secret-key"},
+			want:   fmt.Sprintf(awsExportFormat, "", "test-secret-key", ""),
+		},
+		{
+			name:   "Contains Session Token only",
+			fields: fields{SessionToken: "test-session-token"},
+			want:   fmt.Sprintf(awsExportFormat, "", "", "test-session-token"),
+		},
+		{
+			name:   "Contains Access Key Id and Secret Access Key",
+			fields: fields{AccessKeyId: "test-key", SecretAccessKey: "test-secret-key"},
+			want:   fmt.Sprintf(awsExportFormat, "test-key", "test-secret-key", ""),
+		},
+		{
+			name:   "Contains Access Key Id and Session Token",
+			fields: fields{AccessKeyId: "test-key", SessionToken: "test-session-token"},
+			want:   fmt.Sprintf(awsExportFormat, "test-key", "", "test-session-token"),
+		},
+		{
+			name:   "Contains Secret Access Key and Session Token",
+			fields: fields{SecretAccessKey: "test-secret-key", SessionToken: "test-session-token"},
+			want:   fmt.Sprintf(awsExportFormat, "", "test-secret-key", "test-session-token"),
+		},
+		{
+			name:   "Contains Access Key Id, Secret Access Key, and Session Token",
+			fields: fields{AccessKeyId: "test-key", SecretAccessKey: "test-secret-key", SessionToken: "test-session-token"},
+			want:   fmt.Sprintf(awsExportFormat, "test-key", "test-secret-key", "test-session-token"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := AWSCredentialsResponse{
+				AccessKeyId:     tt.fields.AccessKeyId,
+				SecretAccessKey: tt.fields.SecretAccessKey,
+				SessionToken:    tt.fields.SessionToken,
+			}
+			if got := r.EnvFormat(); got != tt.want {
+				t.Errorf("EnvFormat() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAWSCredentialsResponse_RenderOutput(t *testing.T) {
+	type fields struct {
+		AccessKeyId     string
+		SecretAccessKey string
+		SessionToken    string
+		Region          string
+		Expiration      string
+	}
+	type args struct {
+		outputFormat string
+	}
+	credentials := fields{
+		AccessKeyId:     "1",
+		SecretAccessKey: "2",
+		SessionToken:    "3",
+		Region:          "4",
+		Expiration:      "5",
+	}
+	jsonOutput, _ := json.Marshal(credentials)
+	yamlOutput, _ := yaml.Marshal(credentials)
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			"Render JSON", credentials, args{
+				outputFormat: "json",
+			},
+			string(jsonOutput),
+			false,
+		},
+		{
+			"Render YAML",
+			credentials,
+			args{
+				outputFormat: "yaml",
+			},
+			string(yamlOutput),
+			false,
+		},
+		{
+			"Render Invalid",
+			credentials,
+			args{
+				outputFormat: "invalid",
+			},
+			"",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := AWSCredentialsResponse{
+				AccessKeyId:     tt.fields.AccessKeyId,
+				SecretAccessKey: tt.fields.SecretAccessKey,
+				SessionToken:    tt.fields.SessionToken,
+				Region:          tt.fields.Region,
+				Expiration:      tt.fields.Expiration,
+			}
+			got, err := r.RenderOutput(tt.args.outputFormat)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AWSCredentialsResponse.RenderOutput() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("AWSCredentialsResponse.RenderOutput() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/awsUtil/sts.go
+++ b/pkg/awsUtil/sts.go
@@ -1,0 +1,119 @@
+package awsUtil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"github.com/openshift/backplane-cli/pkg/utils"
+	"net/http"
+	"net/url"
+)
+
+func StsClientWithProxy(proxyUrl string) (*sts.Client, error) {
+	cfg, err := config.LoadDefaultConfig(context.TODO(),
+		config.WithRegion("us-east-1"), // We don't care about region here, but the API still wants to see one set
+		config.WithHTTPClient(&http.Client{
+			Transport: &http.Transport{
+				Proxy: func(*http.Request) (*url.URL, error) {
+					return url.Parse(proxyUrl)
+				},
+			},
+		}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load default AWS config: %w", err)
+	}
+
+	return sts.NewFromConfig(cfg), nil
+}
+
+type STSRoleAssumer interface {
+	AssumeRole(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error)
+}
+
+type STSRoleWithWebIdentityAssumer interface {
+	AssumeRoleWithWebIdentity(ctx context.Context, params *sts.AssumeRoleWithWebIdentityInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleWithWebIdentityOutput, error)
+}
+
+func AssumeRoleWithJWT(jwt string, roleArn string, stsClient STSRoleWithWebIdentityAssumer) (*types.Credentials, error) {
+	email, err := utils.GetStringFieldFromJWT(jwt, "email")
+	if err != nil {
+		return nil, fmt.Errorf("unable to extract email from given token: %w", err)
+	}
+	input := &sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          aws.String(roleArn),
+		RoleSessionName:  aws.String(email),
+		WebIdentityToken: aws.String(jwt),
+	}
+
+	result, err := stsClient.AssumeRoleWithWebIdentity(context.TODO(), input)
+	if err != nil {
+		return nil, fmt.Errorf("unable to assume the given role with the token provided: %w", err)
+	}
+
+	return result.Credentials, nil
+}
+
+func AssumeRole(roleSessionName string, stsClient STSRoleAssumer, roleArn string) (*types.Credentials, error) {
+	input := &sts.AssumeRoleInput{
+		RoleArn:         aws.String(roleArn),
+		RoleSessionName: aws.String(roleSessionName),
+	}
+	result, err := stsClient.AssumeRole(context.TODO(), input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to assume role %v: %w", roleArn, err)
+	}
+
+	return result.Credentials, nil
+}
+
+type STSClientProviderFunc func(optFns ...func(*config.LoadOptions) error) (STSRoleAssumer, error)
+
+var DefaultSTSClientProviderFunc STSClientProviderFunc = func(optnFns ...func(options *config.LoadOptions) error) (STSRoleAssumer, error) {
+	cfg, err := config.LoadDefaultConfig(context.TODO(), optnFns...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load default AWS config: %w", err)
+	}
+	return sts.NewFromConfig(cfg), nil
+}
+
+func AssumeRoleSequence(roleSessionName string, seedClient STSRoleAssumer, roleArnSequence []string, proxyUrl string, stsClientProviderFunc STSClientProviderFunc) (*types.Credentials, error) {
+	if len(roleArnSequence) == 0 {
+		return nil, errors.New("role ARN sequence cannot be empty")
+	}
+
+	nextClient := seedClient
+	var lastCredentials *types.Credentials
+
+	for i, roleArn := range roleArnSequence {
+		result, err := AssumeRole(roleSessionName, nextClient, roleArn)
+		if err != nil {
+			return nil, fmt.Errorf("failed to assume role %v: %w", roleArn, err)
+		}
+		lastCredentials = result
+
+		if i < len(roleArnSequence)-1 {
+			nextClient, err = stsClientProviderFunc(
+				config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(*lastCredentials.AccessKeyId, *lastCredentials.SecretAccessKey, *lastCredentials.SessionToken)),
+				config.WithHTTPClient(&http.Client{
+					Transport: &http.Transport{
+						Proxy: func(*http.Request) (*url.URL, error) {
+							return url.Parse(proxyUrl)
+						},
+					},
+				}),
+				config.WithRegion("us-east-1"), // We don't care about region here, but the API still wants to see one set
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create client with credentials from role %v: %w", roleArn, err)
+			}
+		}
+	}
+
+	return lastCredentials, nil
+}

--- a/pkg/awsUtil/sts_test.go
+++ b/pkg/awsUtil/sts_test.go
@@ -1,0 +1,203 @@
+package awsUtil
+
+import (
+	"context"
+	"errors"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"reflect"
+	"testing"
+)
+
+type STSRoleAssumerMock struct {
+	mockResult            *sts.AssumeRoleOutput
+	mockWebIdentityResult *sts.AssumeRoleWithWebIdentityOutput
+	mockErr               error
+}
+
+func (s STSRoleAssumerMock) AssumeRole(context.Context, *sts.AssumeRoleInput, ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+	return s.mockResult, s.mockErr
+}
+
+func (s STSRoleAssumerMock) AssumeRoleWithWebIdentity(context.Context, *sts.AssumeRoleWithWebIdentityInput, ...func(*sts.Options)) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+	return s.mockWebIdentityResult, s.mockErr
+}
+
+func defaultSuccessMockSTSClient() STSRoleAssumerMock {
+	return makeMockSTSClient(&sts.AssumeRoleOutput{
+		Credentials: &types.Credentials{
+			AccessKeyId:     aws.String("test-access-key-id"),
+			SecretAccessKey: aws.String("test-secret-access-key"),
+			SessionToken:    aws.String("test-session-token"),
+		},
+	}, &sts.AssumeRoleWithWebIdentityOutput{
+		Credentials: &types.Credentials{
+			AccessKeyId:     aws.String("test-access-key-id"),
+			SecretAccessKey: aws.String("test-secret-access-key"),
+			SessionToken:    aws.String("test-session-token"),
+		},
+	}, nil)
+}
+
+func defaultErrorMockSTSClient() STSRoleAssumerMock {
+	return makeMockSTSClient(nil, nil, errors.New("oops"))
+}
+
+func makeMockSTSClient(mockResult *sts.AssumeRoleOutput, mockWebIdentityResult *sts.AssumeRoleWithWebIdentityOutput, mockErr error) STSRoleAssumerMock {
+	return STSRoleAssumerMock{
+		mockResult:            mockResult,
+		mockWebIdentityResult: mockWebIdentityResult,
+		mockErr:               mockErr,
+	}
+}
+
+func TestAssumeRoleWithJWT(t *testing.T) {
+	type args struct {
+		jwt       string
+		roleArn   string
+		stsClient STSRoleWithWebIdentityAssumer
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *types.Credentials
+		wantErr bool
+	}{
+		{
+			name: "No email field on token",
+			args: args{
+				jwt:     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+				roleArn: "arn:aws:iam::1234567890:role/read-only",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Failed call to AWS",
+			args: args{
+				jwt:       "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2ODQ4NjM2NzksImV4cCI6MTcxNjM5OTY3OSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoiZm9vQGJhci5jb20iLCJFbWFpbCI6ImZvb0BleGFtcGxlLmNvbSJ9.cND4hWI_Wd-AGP0BM4G7jqWfYnuz4Jl7RWLEfZ-AU_0",
+				roleArn:   "arn:aws:iam::1234567890:role/read-only",
+				stsClient: defaultErrorMockSTSClient(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Successfully returns credentials",
+			args: args{
+				jwt:       "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2ODQ4NjM2NzksImV4cCI6MTcxNjM5OTY3OSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoiZm9vQGJhci5jb20iLCJlbWFpbCI6ImZvb0BleGFtcGxlLmNvbSJ9.0AhwDFDEtsqOvoJhqvDm9_Vb588GhnfUVGcsN4JFw9o",
+				roleArn:   "arn:aws:iam::1234567890:role/read-only",
+				stsClient: defaultSuccessMockSTSClient(),
+			},
+			want: &types.Credentials{
+				AccessKeyId:     aws.String("test-access-key-id"),
+				SecretAccessKey: aws.String("test-secret-access-key"),
+				SessionToken:    aws.String("test-session-token"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := AssumeRoleWithJWT(tt.args.jwt, tt.args.roleArn, tt.args.stsClient)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AssumeRoleWithJWT() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AssumeRoleWithJWT() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAssumeRole(t *testing.T) {
+	tests := []struct {
+		name      string
+		stsClient STSRoleAssumer
+		want      *types.Credentials
+		wantErr   bool
+	}{
+		{
+			name:      "Fails to assume role",
+			stsClient: defaultErrorMockSTSClient(),
+			wantErr:   true,
+		},
+		{
+			name:      "Successfully assumes role",
+			stsClient: defaultSuccessMockSTSClient(),
+			want: &types.Credentials{
+				AccessKeyId:     aws.String("test-access-key-id"),
+				SecretAccessKey: aws.String("test-secret-access-key"),
+				SessionToken:    aws.String("test-session-token"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := AssumeRole("", tt.stsClient, "")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AssumeRole() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AssumeRole() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAssumeRoleSequence(t *testing.T) {
+	type args struct {
+		seedClient            STSRoleAssumer
+		roleArnSequence       []string
+		stsClientProviderFunc STSClientProviderFunc
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *types.Credentials
+		wantErr bool
+	}{
+		{
+			name: "role arn sequence is nil",
+			args: args{
+				roleArnSequence: nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "role arn sequence is empty",
+			args: args{
+				roleArnSequence: []string{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "single role arn in sequence",
+			args: args{
+				seedClient:      defaultSuccessMockSTSClient(),
+				roleArnSequence: []string{"a"},
+				stsClientProviderFunc: func(optFns ...func(*config.LoadOptions) error) (STSRoleAssumer, error) {
+					return defaultSuccessMockSTSClient(), nil
+				},
+			},
+			want: &types.Credentials{
+				AccessKeyId:     aws.String("test-access-key-id"),
+				SecretAccessKey: aws.String("test-secret-access-key"),
+				SessionToken:    aws.String("test-session-token"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := AssumeRoleSequence("", tt.args.seedClient, tt.args.roleArnSequence, "", tt.args.stsClientProviderFunc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AssumeRoleSequence() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AssumeRoleSequence() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/client/mocks/ClientMock.go
+++ b/pkg/client/mocks/ClientMock.go
@@ -177,6 +177,26 @@ func (mr *MockClientInterfaceMockRecorder) GetAllJobs(arg0, arg1 interface{}, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllJobs", reflect.TypeOf((*MockClientInterface)(nil).GetAllJobs), varargs...)
 }
 
+// GetAssumeRoleSequence mocks base method.
+func (m *MockClientInterface) GetAssumeRoleSequence(arg0 context.Context, arg1 string, arg2 ...Openapi.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetAssumeRoleSequence", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAssumeRoleSequence indicates an expected call of GetAssumeRoleSequence.
+func (mr *MockClientInterfaceMockRecorder) GetAssumeRoleSequence(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssumeRoleSequence", reflect.TypeOf((*MockClientInterface)(nil).GetAssumeRoleSequence), varargs...)
+}
+
 // GetBackplaneClusterClusterId mocks base method.
 func (m *MockClientInterface) GetBackplaneClusterClusterId(arg0 context.Context, arg1 string, arg2 ...Openapi.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -295,6 +315,26 @@ func (mr *MockClientInterfaceMockRecorder) GetScripts(arg0, arg1 interface{}, ar
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScripts", reflect.TypeOf((*MockClientInterface)(nil).GetScripts), varargs...)
+}
+
+// GetScriptsByCluster mocks base method.
+func (m *MockClientInterface) GetScriptsByCluster(arg0 context.Context, arg1 string, arg2 *Openapi.GetScriptsByClusterParams, arg3 ...Openapi.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetScriptsByCluster", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetScriptsByCluster indicates an expected call of GetScriptsByCluster.
+func (mr *MockClientInterfaceMockRecorder) GetScriptsByCluster(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScriptsByCluster", reflect.TypeOf((*MockClientInterface)(nil).GetScriptsByCluster), varargs...)
 }
 
 // GetTestScriptRun mocks base method.

--- a/pkg/client/mocks/ClientWithResponsesMock.go
+++ b/pkg/client/mocks/ClientWithResponsesMock.go
@@ -176,6 +176,26 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) GetAllJobsWithResponse(a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllJobsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).GetAllJobsWithResponse), varargs...)
 }
 
+// GetAssumeRoleSequenceWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) GetAssumeRoleSequenceWithResponse(arg0 context.Context, arg1 string, arg2 ...Openapi.RequestEditorFn) (*Openapi.GetAssumeRoleSequenceResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetAssumeRoleSequenceWithResponse", varargs...)
+	ret0, _ := ret[0].(*Openapi.GetAssumeRoleSequenceResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAssumeRoleSequenceWithResponse indicates an expected call of GetAssumeRoleSequenceWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) GetAssumeRoleSequenceWithResponse(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssumeRoleSequenceWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).GetAssumeRoleSequenceWithResponse), varargs...)
+}
+
 // GetBackplaneClusterClusterIdWithResponse mocks base method.
 func (m *MockClientWithResponsesInterface) GetBackplaneClusterClusterIdWithResponse(arg0 context.Context, arg1 string, arg2 ...Openapi.RequestEditorFn) (*Openapi.GetBackplaneClusterClusterIdResponse, error) {
 	m.ctrl.T.Helper()
@@ -274,6 +294,26 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) GetRunWithResponse(arg0,
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).GetRunWithResponse), varargs...)
+}
+
+// GetScriptsByClusterWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) GetScriptsByClusterWithResponse(arg0 context.Context, arg1 string, arg2 *Openapi.GetScriptsByClusterParams, arg3 ...Openapi.RequestEditorFn) (*Openapi.GetScriptsByClusterResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetScriptsByClusterWithResponse", varargs...)
+	ret0, _ := ret[0].(*Openapi.GetScriptsByClusterResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetScriptsByClusterWithResponse indicates an expected call of GetScriptsByClusterWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) GetScriptsByClusterWithResponse(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScriptsByClusterWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).GetScriptsByClusterWithResponse), varargs...)
 }
 
 // GetScriptsWithResponse mocks base method.

--- a/pkg/utils/jwt.go
+++ b/pkg/utils/jwt.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/golang-jwt/jwt/v4"
+)
+
+func GetStringFieldFromJWT(token string, field string) (string, error) {
+	var jwtToken *jwt.Token
+	var err error
+
+	parser := new(jwt.Parser)
+	jwtToken, _, err = parser.ParseUnverified(token, jwt.MapClaims{})
+	if err != nil {
+		return "", fmt.Errorf("failed to parse jwt")
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	claims, ok := jwtToken.Claims.(jwt.MapClaims)
+	if !ok {
+		return "", err
+	}
+
+	claim, ok := claims[field]
+	if !ok {
+		return "", fmt.Errorf("no field %v on given token", field)
+	}
+
+	claimString, ok := claim.(string)
+	if !ok {
+		return "", fmt.Errorf("field %v does not contain a string value", field)
+	}
+
+	return claimString, nil
+}

--- a/pkg/utils/jwt_test.go
+++ b/pkg/utils/jwt_test.go
@@ -1,0 +1,54 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestGetFieldFromJWT(t *testing.T) {
+	type testCase struct {
+		name    string
+		token   string
+		field   string
+		want    string
+		wantErr bool
+	}
+	tests := []testCase{
+		{
+			name:  "Get string field",
+			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+			field: "sub",
+			want:  "1234567890",
+		},
+		{
+			name:    "Get number field",
+			token:   "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjAsImV4cCI6MTcxNjY1MDA3MSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSJ9._CyJxncO4NBOH6a-Q_2oIVelCRZKJh9YiPBm4XEBZgI",
+			field:   "iat",
+			wantErr: true,
+		},
+		{
+			name:    "Get field that doesn't exist",
+			token:   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+			field:   "foo",
+			wantErr: true,
+		},
+		{
+			name:    "Invalid token",
+			token:   "abcdefg",
+			field:   "foo",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetStringFieldFromJWT(tt.token, tt.field)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetStringFieldFromJWT() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetStringFieldFromJWT() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / Why we need it?

Adds one command to fetch STS credentials for given role, and another to assume a chain of roles from a starting point to a cluster's account

### Which Jira/Github issue(s) does this PR fix?
[OSD-16489](https://issues.redhat.com//browse/OSD-16489)
[OSD-16490](https://issues.redhat.com//browse/OSD-16490)

### Special notes for your reviewer
Waiting on [OSD-16494](https://issues.redhat.com//browse/OSD-16494) to finish

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [x] Included documentation changes with PR

To test locally:
In an AWS account, create a role with the trust policy in the attached ticket. Run this command with the arn for that role passed in as --role-arn, i.e. backplane cloud token --role-arn [role arn]. If successful, the command should output AWS STS Credentials as a JSON payload.