### PR TITLE
OSD-15841: Check proxy and API connection if login failed

### DIFF
--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -208,6 +208,12 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 			// Hibernating, print an error
 			return fmt.Errorf("cluster %s is hibernating, login failed", clusterKey)
 		}
+		// Check API connection with configured proxy
+		err = bpConfig.CheckAPIConnection()
+		if err != nil {
+			return fmt.Errorf("cannot connect to backplane API URL,Check if you need to use a proxy/VPN to access backplane. error: %v", err)
+		}
+
 		// Otherwise, return the failure
 		return fmt.Errorf("can't login to cluster: %v", err)
 	}


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / Why we need it?

Check the API connection via HTTP proxy transmission and provide a proper error message to the end user 

### Which Jira/Github issue(s) does this PR fix?

[OSD-15841](https://issues.redhat.com//browse/OSD-15841)


### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [] Included documentation changes with PR
