### PR TITLE
OSD-16244: Add error message if management cluster is not belong to same ocm env

### DIFF
--- a/pkg/utils/ocmWrapper.go
+++ b/pkg/utils/ocmWrapper.go
@@ -111,8 +111,12 @@ func (o *DefaultOCMInterfaceImpl) GetManagingCluster(targetClusterId string) (cl
 			List().
 			Parameter("search", fmt.Sprintf("api.url='%s'", hiveAPI)).
 			Send()
-		if err != nil || mcResp.Items().Len() == 0 {
-			return "", "", fmt.Errorf("failed to find find management cluster for cluster %s: %v", targetClusterId, err)
+
+		if err != nil {
+			return "", "", fmt.Errorf("failed to find management cluster for cluster %s: %v", targetClusterId, err)
+		}
+		if mcResp.Items().Len() == 0 {
+			return "", "", fmt.Errorf("failed to find management cluster for cluster %s in %s env", targetClusterId, connection.URL())
 		}
 		managingCluster = mcResp.Items().Get(0).Name()
 	}


### PR DESCRIPTION

### What type of PR is this?

bug

### What this PR does / Why we need it?
Users can't log into hive cluster if the hive cluster not belong to same ocm env 

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_ [OSD-16244](https://issues.redhat.com//browse/OSD-16244)

### Special notes for your reviewer

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
