### PR TITLE
OSD-17209: Update backplane cli commands default to warning log level

### DIFF
--- a/cmd/ocm-backplane/root.go
+++ b/cmd/ocm-backplane/root.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"os"
-	"strings"
 
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/cloud"
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/config"
@@ -34,34 +33,9 @@ import (
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/testJob"
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/upgrade"
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/version"
+	"github.com/openshift/backplane-cli/pkg/cli/globalflags"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-)
-
-// Created so that multiple inputs can be accepted
-type levelFlag log.Level
-
-func (l *levelFlag) String() string {
-	// change this, this is just can example to satisfy the interface
-	return log.Level(*l).String()
-}
-
-func (l *levelFlag) Set(value string) error {
-	lvl, err := log.ParseLevel(strings.TrimSpace(value))
-	if err == nil {
-		*l = levelFlag(lvl)
-	}
-	return err
-}
-
-func (l *levelFlag) Type() string {
-	return "string"
-}
-
-var (
-	// some defaults for configuration
-	defaultLogLevel = log.WarnLevel.String()
-	logLevel        levelFlag
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -85,10 +59,8 @@ func Execute() {
 }
 
 func init() {
-	// Set default log level
-	_ = logLevel.Set(defaultLogLevel)
-	logLevelFlag := rootCmd.PersistentFlags().VarPF(&logLevel, "verbosity", "v", "Verbosity level: panic, fatal, error, warn, info, debug. Providing no level string will select info.")
-	logLevelFlag.NoOptDefVal = log.InfoLevel.String()
+	// Add Verbosity flag for all commands
+	globalflags.AddVerbosityFlag(rootCmd)
 
 	// Register sub-commands
 	rootCmd.AddCommand(console.ConsoleCmd)

--- a/cmd/ocm-backplane/root_suite_test.go
+++ b/cmd/ocm-backplane/root_suite_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestIt(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Root Test Suite")
+}

--- a/cmd/ocm-backplane/root_test.go
+++ b/cmd/ocm-backplane/root_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Backplane commands", func() {
+	Context("Test root cmd", func() {
+
+		It("Check root cmd help ", func() {
+			err := rootCmd.Help()
+			Expect(err).To(BeNil())
+		})
+
+		It("Check verbosity persistent flag", func() {
+			flagSet := rootCmd.PersistentFlags()
+			verbosityFlag := flagSet.Lookup("verbosity")
+			Expect(verbosityFlag).NotTo(BeNil())
+
+			// check the deafult log level
+			Expect(verbosityFlag.DefValue).To(Equal("warning"))
+
+		})
+	})
+})

--- a/pkg/cli/globalflags/logs.go
+++ b/pkg/cli/globalflags/logs.go
@@ -1,0 +1,49 @@
+package globalflags
+
+import (
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type levelFlag log.Level
+
+var (
+	// some defaults for configuration
+	defaultLogLevel = log.WarnLevel.String()
+	logLevel        levelFlag
+)
+
+// String returns log level string
+func (l *levelFlag) String() string {
+	return log.Level(*l).String()
+}
+
+// Set updates the log level
+func (l *levelFlag) Set(value string) error {
+	lvl, err := log.ParseLevel(strings.TrimSpace(value))
+	if err == nil {
+		*l = levelFlag(lvl)
+	}
+	log.SetLevel(lvl)
+	return err
+}
+
+// Type defines log level type
+func (l *levelFlag) Type() string {
+	return "string"
+}
+
+// AddVerbosityFlag add Persistent verbosity flag
+func AddVerbosityFlag(cmd *cobra.Command) {
+	// Set default log level
+	_ = logLevel.Set(defaultLogLevel)
+	logLevelFlag := cmd.PersistentFlags().VarPF(
+		&logLevel,
+		"verbosity",
+		"v",
+		"Verbosity level: panic, fatal, error, warn, info, debug. Providing no verbosity level will default to info.",
+	)
+	logLevelFlag.NoOptDefVal = log.InfoLevel.String()
+}


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?
Showing warning level as default log level

All commands shows error as follows 
```
ocm backplane <sub-command>  ( shows warn logs )

ocm backplane -v <sub-command>  ( shows info logs )

ocm backplane -v=<log-level> <sub-command>  ( shows <log-level> logs )
```

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_https://issues.redhat.com/browse/OSD-17209

### Special notes for your reviewer

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
