### PR TITLE
DO NOT MERGE - OSD-12531: Replacing GetScripts with GetScriptsByCluster API calls

### DIFF
--- a/cmd/ocm-backplane/script/describeScript.go
+++ b/cmd/ocm-backplane/script/describeScript.go
@@ -64,8 +64,17 @@ func newDescribeScriptCmd() *cobra.Command {
 				return err
 			}
 
+			// ======== Initialize cluster ID from config ========
+			if clusterKey == "" {
+				configCluster, err := utils.DefaultClusterUtils.GetBackplaneCluster(clusterKey, urlFlag)
+				if err != nil {
+					return err
+				}
+				clusterKey = configCluster.ClusterID
+			}
+
 			// ======== Call Endpoint ========
-			resp, err := client.GetScripts(context.TODO(), &bpclient.GetScriptsParams{Scriptname: &args[0]})
+			resp, err := client.GetScriptsByCluster(context.TODO(), clusterKey, &bpclient.GetScriptsByClusterParams{Scriptname: &args[0]})
 
 			if err != nil {
 				return err
@@ -76,7 +85,7 @@ func newDescribeScriptCmd() *cobra.Command {
 			}
 
 			// ======== Print script info ========
-			describeResp, err := bpclient.ParseGetScriptsResponse(resp)
+			describeResp, err := bpclient.ParseGetScriptsByClusterResponse(resp)
 
 			if err != nil {
 				return fmt.Errorf("unable to parse response body from backplane: Status Code: %d", resp.StatusCode)

--- a/cmd/ocm-backplane/script/describeScript_test.go
+++ b/cmd/ocm-backplane/script/describeScript_test.go
@@ -97,7 +97,7 @@ var _ = Describe("describe script command", func() {
 			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterId)).Return(false, nil).AnyTimes()
 			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil).AnyTimes()
 			mockClientUtil.EXPECT().MakeRawBackplaneAPIClient(gomock.Any()).Return(mockClient, nil)
-			mockClient.EXPECT().GetScripts(gomock.Any(), &bpclient.GetScriptsParams{Scriptname: &testScriptName}).Return(fakeResp, nil)
+			mockClient.EXPECT().GetScriptsByCluster(gomock.Any(), testClusterId, &bpclient.GetScriptsByClusterParams{Scriptname: &testScriptName}).Return(fakeResp, nil)
 
 			sut.SetArgs([]string{"describe", testScriptName, "--cluster-id", testClusterId})
 			err := sut.Execute()
@@ -109,7 +109,7 @@ var _ = Describe("describe script command", func() {
 			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterId)).Return(false, nil).AnyTimes()
 			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil).AnyTimes()
 			mockClientUtil.EXPECT().MakeRawBackplaneAPIClient("https://newbackplane.url").Return(mockClient, nil)
-			mockClient.EXPECT().GetScripts(gomock.Any(), &bpclient.GetScriptsParams{Scriptname: &testScriptName}).Return(fakeResp, nil)
+			mockClient.EXPECT().GetScriptsByCluster(gomock.Any(), testClusterId, &bpclient.GetScriptsByClusterParams{Scriptname: &testScriptName}).Return(fakeResp, nil)
 
 			sut.SetArgs([]string{"describe", testScriptName, "--cluster-id", testClusterId, "--url", "https://newbackplane.url"})
 			err := sut.Execute()
@@ -123,7 +123,7 @@ var _ = Describe("describe script command", func() {
 			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq("configcluster")).Return(false, nil).AnyTimes()
 			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil).AnyTimes()
 			mockClientUtil.EXPECT().MakeRawBackplaneAPIClient("https://api-backplane.apps.something.com").Return(mockClient, nil)
-			mockClient.EXPECT().GetScripts(gomock.Any(), &bpclient.GetScriptsParams{Scriptname: &testScriptName}).Return(fakeResp, nil)
+			mockClient.EXPECT().GetScriptsByCluster(gomock.Any(), "configcluster", &bpclient.GetScriptsByClusterParams{Scriptname: &testScriptName}).Return(fakeResp, nil)
 
 			sut.SetArgs([]string{"describe", testScriptName})
 			err = sut.Execute()
@@ -136,7 +136,7 @@ var _ = Describe("describe script command", func() {
 			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterId)).Return(false, nil).AnyTimes()
 			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil).AnyTimes()
 			mockClientUtil.EXPECT().MakeRawBackplaneAPIClient(gomock.Any()).Return(mockClient, nil)
-			mockClient.EXPECT().GetScripts(gomock.Any(), &bpclient.GetScriptsParams{Scriptname: &testScriptName}).Return(nil, errors.New("err"))
+			mockClient.EXPECT().GetScriptsByCluster(gomock.Any(), testClusterId, &bpclient.GetScriptsByClusterParams{Scriptname: &testScriptName}).Return(nil, errors.New("err"))
 
 			sut.SetArgs([]string{"describe", testScriptName, "--cluster-id", testClusterId})
 			err := sut.Execute()
@@ -156,7 +156,7 @@ var _ = Describe("describe script command", func() {
 			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterId)).Return(false, nil).AnyTimes()
 			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil).AnyTimes()
 			mockClientUtil.EXPECT().MakeRawBackplaneAPIClient(gomock.Any()).Return(mockClient, nil)
-			mockClient.EXPECT().GetScripts(gomock.Any(), &bpclient.GetScriptsParams{Scriptname: &testScriptName}).Return(fakeRespBlank, nil)
+			mockClient.EXPECT().GetScriptsByCluster(gomock.Any(), testClusterId, &bpclient.GetScriptsByClusterParams{Scriptname: &testScriptName}).Return(fakeRespBlank, nil)
 
 			sut.SetArgs([]string{"describe", testScriptName, "--cluster-id", testClusterId})
 			err := sut.Execute()
@@ -187,7 +187,7 @@ var _ = Describe("describe script command", func() {
 			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterId)).Return(false, nil).AnyTimes()
 			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil).AnyTimes()
 			mockClientUtil.EXPECT().MakeRawBackplaneAPIClient(gomock.Any()).Return(mockClient, nil)
-			mockClient.EXPECT().GetScripts(gomock.Any(), &bpclient.GetScriptsParams{Scriptname: &testScriptName}).Return(fakeRespNoEnv, nil)
+			mockClient.EXPECT().GetScriptsByCluster(gomock.Any(), testClusterId, &bpclient.GetScriptsByClusterParams{Scriptname: &testScriptName}).Return(fakeRespNoEnv, nil)
 
 			sut.SetArgs([]string{"describe", testScriptName, "--cluster-id", testClusterId})
 			err := sut.Execute()
@@ -201,7 +201,7 @@ var _ = Describe("describe script command", func() {
 			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil).AnyTimes()
 			mockClientUtil.EXPECT().MakeRawBackplaneAPIClient(gomock.Any()).Return(mockClient, nil)
 			fakeResp.Body = MakeIoReader("Sad")
-			mockClient.EXPECT().GetScripts(gomock.Any(), &bpclient.GetScriptsParams{Scriptname: &testScriptName}).Return(fakeResp, nil)
+			mockClient.EXPECT().GetScriptsByCluster(gomock.Any(), testClusterId, &bpclient.GetScriptsByClusterParams{Scriptname: &testScriptName}).Return(fakeResp, nil)
 
 			sut.SetArgs([]string{"describe", testScriptName, "--cluster-id", testClusterId})
 			err := sut.Execute()

--- a/cmd/ocm-backplane/script/listScripts.go
+++ b/cmd/ocm-backplane/script/listScripts.go
@@ -64,8 +64,17 @@ func newListScriptCmd() *cobra.Command {
 				return err
 			}
 
+			// ======== Initialize cluster ID from config ========
+			if clusterKey == "" {
+				configCluster, err := utils.DefaultClusterUtils.GetBackplaneCluster(clusterKey, urlFlag)
+				if err != nil {
+					return err
+				}
+				clusterKey = configCluster.ClusterID
+			}
+
 			// ======== Call Endpoint ========
-			resp, err := client.GetScripts(context.TODO(), &bpclient.GetScriptsParams{})
+			resp, err := client.GetScriptsByCluster(context.TODO(), clusterKey, &bpclient.GetScriptsByClusterParams{})
 
 			if err != nil {
 				return err
@@ -76,7 +85,7 @@ func newListScriptCmd() *cobra.Command {
 			}
 
 			// ======== Render Table ========
-			listResp, err := bpclient.ParseGetScriptsResponse(resp)
+			listResp, err := bpclient.ParseGetScriptsByClusterResponse(resp)
 
 			if err != nil {
 				return fmt.Errorf("unable to parse response body from backplane: Status Code: %d", resp.StatusCode)

--- a/cmd/ocm-backplane/script/listScripts_test.go
+++ b/cmd/ocm-backplane/script/listScripts_test.go
@@ -94,7 +94,7 @@ var _ = Describe("list script command", func() {
 			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterId)).Return(false, nil).AnyTimes()
 			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil).AnyTimes()
 			mockClientUtil.EXPECT().MakeRawBackplaneAPIClient(gomock.Any()).Return(mockClient, nil)
-			mockClient.EXPECT().GetScripts(gomock.Any(), &bpclient.GetScriptsParams{}).Return(fakeResp, nil)
+			mockClient.EXPECT().GetScriptsByCluster(gomock.Any(), testClusterId, &bpclient.GetScriptsByClusterParams{}).Return(fakeResp, nil)
 
 			sut.SetArgs([]string{"list", testJobId, "--cluster-id", testClusterId})
 			err := sut.Execute()
@@ -107,7 +107,7 @@ var _ = Describe("list script command", func() {
 			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterId)).Return(false, nil).AnyTimes()
 			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil).AnyTimes()
 			mockClientUtil.EXPECT().MakeRawBackplaneAPIClient("https://newbackplane.url").Return(mockClient, nil)
-			mockClient.EXPECT().GetScripts(gomock.Any(), &bpclient.GetScriptsParams{}).Return(fakeResp, nil)
+			mockClient.EXPECT().GetScriptsByCluster(gomock.Any(), testClusterId, &bpclient.GetScriptsByClusterParams{}).Return(fakeResp, nil)
 
 			sut.SetArgs([]string{"list", testJobId, "--cluster-id", testClusterId, "--url", "https://newbackplane.url"})
 			err := sut.Execute()
@@ -121,7 +121,7 @@ var _ = Describe("list script command", func() {
 			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq("configcluster")).Return(false, nil).AnyTimes()
 			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil).AnyTimes()
 			mockClientUtil.EXPECT().MakeRawBackplaneAPIClient("https://api-backplane.apps.something.com").Return(mockClient, nil)
-			mockClient.EXPECT().GetScripts(gomock.Any(), &bpclient.GetScriptsParams{}).Return(fakeResp, nil)
+			mockClient.EXPECT().GetScriptsByCluster(gomock.Any(), "configcluster", &bpclient.GetScriptsByClusterParams{}).Return(fakeResp, nil)
 
 			sut.SetArgs([]string{"list", testJobId})
 			err = sut.Execute()
@@ -134,7 +134,7 @@ var _ = Describe("list script command", func() {
 			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterId)).Return(false, nil).AnyTimes()
 			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil).AnyTimes()
 			mockClientUtil.EXPECT().MakeRawBackplaneAPIClient(gomock.Any()).Return(mockClient, nil)
-			mockClient.EXPECT().GetScripts(gomock.Any(), &bpclient.GetScriptsParams{}).Return(nil, errors.New("err"))
+			mockClient.EXPECT().GetScriptsByCluster(gomock.Any(), testClusterId, &bpclient.GetScriptsByClusterParams{}).Return(nil, errors.New("err"))
 
 			sut.SetArgs([]string{"list", testJobId, "--cluster-id", testClusterId})
 			err := sut.Execute()
@@ -148,7 +148,7 @@ var _ = Describe("list script command", func() {
 			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil).AnyTimes()
 			mockClientUtil.EXPECT().MakeRawBackplaneAPIClient(gomock.Any()).Return(mockClient, nil)
 			fakeResp.Body = MakeIoReader("Sad")
-			mockClient.EXPECT().GetScripts(gomock.Any(), &bpclient.GetScriptsParams{}).Return(fakeResp, nil)
+			mockClient.EXPECT().GetScriptsByCluster(gomock.Any(), testClusterId, &bpclient.GetScriptsByClusterParams{}).Return(fakeResp, nil)
 
 			sut.SetArgs([]string{"list", testJobId, "--cluster-id", testClusterId})
 			err := sut.Execute()
@@ -162,7 +162,7 @@ var _ = Describe("list script command", func() {
 			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil).AnyTimes()
 			mockClientUtil.EXPECT().MakeRawBackplaneAPIClient(gomock.Any()).Return(mockClient, nil)
 			fakeResp.Body = MakeIoReader("[]")
-			mockClient.EXPECT().GetScripts(gomock.Any(), &bpclient.GetScriptsParams{}).Return(fakeResp, nil)
+			mockClient.EXPECT().GetScriptsByCluster(gomock.Any(), testClusterId, &bpclient.GetScriptsByClusterParams{}).Return(fakeResp, nil)
 
 			sut.SetArgs([]string{"list", testJobId, "--cluster-id", testClusterId})
 			err := sut.Execute()


### PR DESCRIPTION
### What type of PR is this?
Change to a new API


### What this PR does / Why we need it?
Changing API calls to use GetScriptsByCluster instead of GetScripts due to a bug.
The API call is the same, but with added `clusterId` in the API call.

### Which Jira/Github issue(s) does this PR fix?

Resolves [OSD-12531](https://issues.redhat.com/browse/OSD-12531)

### Special notes for your reviewer
Further testing required

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
