### PR TITLE
Improve error handling for login connection issues

### DIFF
--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -51,7 +51,7 @@ var (
 		SilenceUsage: true,
 	}
 
-	ErrLoginConnection = errors.New("unable to connect to backplane api")
+	errLoginConnection = errors.New("unable to connect to backplane api")
 )
 
 func init() {
@@ -210,7 +210,7 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 			// Hibernating, print an error
 			return fmt.Errorf("cluster %s is hibernating, login failed", clusterKey)
 		}
-		if errors.Is(err, ErrLoginConnection) {
+		if errors.Is(err, errLoginConnection) {
 			return fmt.Errorf("cannot connect to backplane API URL, check if you need to use a proxy/VPN to access backplane: %v", err)
 		}
 
@@ -355,7 +355,7 @@ func doLogin(api, clusterId, accessToken string) (string, error) {
 		// trying to determine the error
 		errBody := err.Error()
 		if strings.Contains(errBody, "dial tcp") || strings.Contains(errBody, "i/o timeout") {
-			return "", fmt.Errorf("%w: %w", ErrLoginConnection, err)
+			return "", fmt.Errorf("%w: %w", errLoginConnection, err)
 		}
 
 		return "", err


### PR DESCRIPTION
### What type of PR is this?

Bug

### What this PR does / Why we need it?
If login returns an authentication issues (4xx), and we don't have a proxy set, the current logic will show the error `cannot connect to backplane API URL, check if you need to use a proxy/VPN to access backplane`.

The PR changes the error handling to only print such error when the error returned from `doLogin` is exactly a network issue. And if the error returned from `doLogin` is a network issue, we don't need to test the connection again, thus removing the `bpConfig.CheckAPIConnection` check. 

### Which Jira/Github issue(s) does this PR fix?
https://issues.redhat.com/browse/OSD-17374

_Resolves #_

### Special notes for your reviewer
Tested locally.  
For connection issue, it will show   
```
./ocm-backplane login xxxxx
ERRO[0006] cannot connect to backplane API URL, check if you need to use a proxy/VPN to access backplane: unable to connect to backplane api: Post "https://localhost:8001/backplane/login/xxxx/": dial tcp [::1]:8001: connect: connection refused 
```

For authentication issue, it will show
```
./ocm-backplane login xxxxx
ERRO[0008] can't login to cluster: error from backplane: 
 Status Code: 403
 Message: no backplane role found for user yyyyy /FakeResource err/BackplaneOsdCeeResource false / 
```

### Pre-checks (if applicable)

- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
