### PR TITLE
Add service and manager flags to backplane session

### DIFF
--- a/cmd/ocm-backplane/session/session.go
+++ b/cmd/ocm-backplane/session/session.go
@@ -37,6 +37,22 @@ func NewCmdSession() *cobra.Command {
 			return validEnvs, cobra.ShellCompDirectiveNoFileComp
 		},
 	}
+
+	// Add login cmd specific flags
+	sessionCmd.Flags().BoolVar(
+		&options.Manager,
+		"manager",
+		false,
+		"Login to management cluster instead of the cluster itself.",
+	)
+
+	sessionCmd.Flags().BoolVar(
+		&options.Service,
+		"service",
+		false,
+		"Login to service cluster for the given hosted cluster or mgmt cluster.",
+	)
+
 	sessionCmd.Flags().BoolVarP(
 		&options.DeleteSession,
 		"delete",

--- a/pkg/cli/session/session.go
+++ b/pkg/cli/session/session.go
@@ -41,6 +41,9 @@ type Options struct {
 
 	ClusterId   string
 	ClusterName string
+
+	Manager bool
+	Service bool
 }
 
 var (
@@ -71,6 +74,26 @@ func (e *BackplaneSession) RunCommand(cmd *cobra.Command, args []string) error {
 
 	if err != nil {
 		return fmt.Errorf("invalid cluster Id %s", clusterKey)
+	}
+
+	if e.Options.Manager {
+		clusterId, clusterName, err = utils.DefaultOCMInterface.GetManagingCluster(clusterId)
+		e.Options.Alias = clusterId
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Switching to management cluster ID: %v, Name: %v\n", clusterId, clusterName)
+	}
+
+	if e.Options.Service {
+		clusterId, clusterName, err = utils.DefaultOCMInterface.GetServiceCluster(clusterId)
+		e.Options.Alias = clusterId
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Switching to service cluster ID: %v, Name: %v\n", clusterId, clusterName)
 	}
 
 	// set cluster options
@@ -373,17 +396,17 @@ func (e *BackplaneSession) initClusterLogin(cmd *cobra.Command) error {
 		// Setting up the flags
 		err := login.LoginCmd.Flags().Set("multi", "true")
 		if err != nil {
-			return fmt.Errorf("error occered when setting multi flag %v", err)
+			return fmt.Errorf("error occurred when setting multi flag %v", err)
 		}
 		err = login.LoginCmd.Flags().Set("kube-path", e.Path)
 		if err != nil {
-			return fmt.Errorf("error occered when kube-path flag %v", err)
+			return fmt.Errorf("error occurred when kube-path flag %v", err)
 		}
 
 		// Execute login command
 		err = login.LoginCmd.RunE(cmd, []string{e.Options.ClusterId})
 		if err != nil {
-			return fmt.Errorf("error occered when login to the cluster %v", err)
+			return fmt.Errorf("error occurred when login to the cluster %v", err)
 		}
 	}
 


### PR DESCRIPTION
### What type of PR is this?

Feature

### What this PR does / Why we need it?

This adds the same `--service` and `--manager` flags to `ocm backplane session` that are already in place for `ocm backplane login` in order to establish a backplane session to the cluster's service or management cluster respectively.

I use `backplane session` almost exclusively these days, but I miss these flags from `backplane login` quite a lot.

### Pre-checks (if applicable)

- [ ] Ran unit tests locally
- [X] Validated the changes in a cluster
- [ ] Included documentation changes with PR
