### PR TITLE
Refactor: Make manager & service flags global

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ To setup the PS1(prompt) for bash/zsh, please follow [these instructions](https:
 | `ocm backplane cloud console`                                               | Launch the current logged in cluster's cloud provider console                            |
 | `ocm backplane cloud credentials [flags]`                                   | Retrieve a set of temporary cloud credentials for the cluster's cloud provider           |
 | `ocm backplane elevate <reason> -- <command>`                               | Elevate privileges to backplane-cluster-admin and add a reason to the api request        |
-| `ocm backplane monitoring <prometheus/alertmanager/thanos/grafana> [flags]` | Launch the specified monitoring UI (Deprecated following v4.11 for cluster monitoring  stack)                          |
+| `ocm backplane monitoring <prometheus/alertmanager/thanos/grafana> [flags]` | Launch the specified monitoring UI (Deprecated following v4.11 for cluster monitoring stack)                          |
 | `ocm backplane script describe <script> [flags]`                            | Describe the given backplane script                                                      |
-| `ocm backplane script list [flags]`                                         | List available backplane scripts                                                         |
+| `ocm backplane script list [flags]`                                         | List available backplane scripts |
+| `ocm backplane session [flags]`                                             | Create a new session and log into the cluster                                            |
 | `ocm backplane status`                                                      | Print essential cluster info                                                             |
 | `ocm backplane managedJob create <script> [flags]`                          | Create a backplane managed job resource                                                  |
 | `ocm backplane managedJob get <job_name> [flags]`                           | Retrieve a backplane managed job resource                                                |

--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -29,8 +29,6 @@ const EnvPs1 = "KUBE_PS1_CLUSTER_FUNCTION"
 
 var (
 	args struct {
-		manager        bool
-		service        bool
 		multiCluster   bool
 		kubeConfigPath string
 	}
@@ -55,23 +53,7 @@ var (
 func init() {
 	flags := LoginCmd.Flags()
 	// Add global flags
-	//globalflags.AddGlobalFlags(flags, globalOpts)
 	globalflags.AddGlobalFlags(LoginCmd, globalOpts)
-
-	// Add login cmd specific flags
-	flags.BoolVar(
-		&args.manager,
-		"manager",
-		false,
-		"Login to management cluster instead of the cluster itself.",
-	)
-
-	flags.BoolVar(
-		&args.service,
-		"service",
-		false,
-		"Login to service cluster for the given hosted cluster or mgmt cluster.",
-	)
 
 	flags.BoolVarP(
 		&args.multiCluster,
@@ -139,7 +121,7 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 		"ID":   clusterId,
 		"Name": clusterName}).Infoln("Target cluster")
 
-	if args.manager {
+	if globalOpts.Manager {
 		logger.WithField("Cluster ID", clusterId).Debugln("Finding managing cluster")
 		clusterId, clusterName, err = utils.DefaultOCMInterface.GetManagingCluster(clusterId)
 		if err != nil {
@@ -151,7 +133,7 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 			"Name": clusterName}).Infoln("Management cluster")
 	}
 
-	if args.service {
+	if globalOpts.Service {
 		logger.WithField("Cluster ID", clusterId).Debugln("Finding service cluster")
 		clusterId, clusterName, err = utils.DefaultOCMInterface.GetServiceCluster(clusterId)
 		if err != nil {

--- a/cmd/ocm-backplane/login/login_test.go
+++ b/cmd/ocm-backplane/login/login_test.go
@@ -80,7 +80,8 @@ var _ = Describe("Login command", func() {
 	})
 
 	AfterEach(func() {
-		args.manager = false
+		globalOpts.Manager = false
+		globalOpts.Service = false
 		globalOpts.BackplaneURL = ""
 		globalOpts.ProxyURL = ""
 		os.Setenv("HTTPS_PROXY", "")
@@ -186,8 +187,8 @@ var _ = Describe("Login command", func() {
 
 	Context("check cluster login", func() {
 		BeforeEach(func() {
-			args.manager = false
-			args.service = false
+			globalOpts.Manager = false
+			globalOpts.Service = false
 		})
 		It("when running with a simple case should work as expected", func() {
 			err := utils.CreateTempKubeConfig(nil)
@@ -222,7 +223,7 @@ var _ = Describe("Login command", func() {
 		})
 
 		It("should return the managing cluster if one is requested", func() {
-			args.manager = true
+			globalOpts.Manager = true
 			mockOcmInterface.EXPECT().GetTargetCluster(testClusterId).Return(trueClusterId, testClusterId, nil)
 			mockOcmInterface.EXPECT().GetManagingCluster(trueClusterId).Return(managingClusterId, managingClusterId, nil)
 			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(managingClusterId)).Return(false, nil).AnyTimes()
@@ -236,7 +237,7 @@ var _ = Describe("Login command", func() {
 		})
 
 		It("should failed if managing cluster not exist in same env", func() {
-			args.manager = true
+			globalOpts.Manager = true
 			mockOcmInterface.EXPECT().GetTargetCluster(testClusterId).Return(trueClusterId, testClusterId, nil)
 			mockOcmInterface.EXPECT().GetManagingCluster(trueClusterId).Return(
 				managingClusterId,
@@ -256,7 +257,7 @@ var _ = Describe("Login command", func() {
 		})
 
 		It("should return the service cluster if hosted cluster is given", func() {
-			args.service = true
+			globalOpts.Service = true
 			mockOcmInterface.EXPECT().GetTargetCluster(testClusterId).Return(trueClusterId, testClusterId, nil)
 			mockOcmInterface.EXPECT().GetServiceCluster(trueClusterId).Return(serviceClusterId, serviceClusterName, nil)
 			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(serviceClusterId)).Return(false, nil).AnyTimes()
@@ -326,7 +327,7 @@ var _ = Describe("Login command", func() {
 		})
 
 		It("Check KUBECONFIG when logging into multiple clusters.", func() {
-			args.manager = false
+			globalOpts.Manager = false
 			args.multiCluster = true
 			err := utils.ModifyTempKubeConfigFileName(trueClusterId)
 			Expect(err).To(BeNil())

--- a/cmd/ocm-backplane/session/session.go
+++ b/cmd/ocm-backplane/session/session.go
@@ -5,10 +5,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/openshift/backplane-cli/pkg/cli/globalflags"
 	"github.com/openshift/backplane-cli/pkg/cli/session"
 	"github.com/openshift/backplane-cli/pkg/info"
 	"github.com/spf13/cobra"
 )
+
+var globalOpts = &globalflags.GlobalOptions{}
 
 func NewCmdSession() *cobra.Command {
 	options := session.Options{}
@@ -38,20 +41,11 @@ func NewCmdSession() *cobra.Command {
 		},
 	}
 
-	// Add login cmd specific flags
-	sessionCmd.Flags().BoolVar(
-		&options.Manager,
-		"manager",
-		false,
-		"Login to management cluster instead of the cluster itself.",
-	)
+	// Initialize global flags
+	globalflags.AddGlobalFlags(sessionCmd, globalOpts)
 
-	sessionCmd.Flags().BoolVar(
-		&options.Service,
-		"service",
-		false,
-		"Login to service cluster for the given hosted cluster or mgmt cluster.",
-	)
+	options.Manager = globalOpts.Manager
+	options.Service = globalOpts.Service
 
 	sessionCmd.Flags().BoolVarP(
 		&options.DeleteSession,

--- a/pkg/cli/globalflags/globalflags.go
+++ b/pkg/cli/globalflags/globalflags.go
@@ -8,6 +8,8 @@ import (
 type GlobalOptions struct {
 	BackplaneURL string
 	ProxyURL     string
+	Manager      bool
+	Service      bool
 }
 
 func AddGlobalFlags(cmd *cobra.Command, opts *GlobalOptions) {
@@ -22,5 +24,17 @@ func AddGlobalFlags(cmd *cobra.Command, opts *GlobalOptions) {
 		"proxy",
 		"",
 		"URL of HTTPS proxy",
+	)
+	cmd.PersistentFlags().BoolVar(
+		&opts.Manager,
+		"manager",
+		false,
+		"Login to management cluster instead of the cluster itself.",
+	)
+	cmd.PersistentFlags().BoolVar(
+		&opts.Service,
+		"service",
+		false,
+		"Login to service cluster for the given hosted cluster or management cluster.",
 	)
 }


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / Why we need it?
This PR makes the `manager` and `service` flags global so multiple commands can access it while maintaining flag consistency.

### Special notes for your reviewer
Please test this locally before you merge

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [x] Included documentation changes with PR
