### PR TITLE
Fix usage of global opts in backplane session

### DIFF
--- a/cmd/ocm-backplane/session/session.go
+++ b/cmd/ocm-backplane/session/session.go
@@ -43,10 +43,9 @@ func NewCmdSession() *cobra.Command {
 
 	// Initialize global flags
 	globalflags.AddGlobalFlags(sessionCmd, globalOpts)
+	options.GlobalOpts = globalOpts
 
-	options.Manager = globalOpts.Manager
-	options.Service = globalOpts.Service
-
+	//
 	sessionCmd.Flags().BoolVarP(
 		&options.DeleteSession,
 		"delete",

--- a/pkg/cli/session/session.go
+++ b/pkg/cli/session/session.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/login"
 	"github.com/openshift/backplane-cli/pkg/cli/config"
+	"github.com/openshift/backplane-cli/pkg/cli/globalflags"
 	"github.com/openshift/backplane-cli/pkg/info"
 	"github.com/openshift/backplane-cli/pkg/utils"
 )
@@ -42,8 +43,7 @@ type Options struct {
 	ClusterId   string
 	ClusterName string
 
-	Manager bool
-	Service bool
+	GlobalOpts *globalflags.GlobalOptions
 }
 
 var (
@@ -76,7 +76,7 @@ func (e *BackplaneSession) RunCommand(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid cluster Id %s", clusterKey)
 	}
 
-	if e.Options.Manager {
+	if e.Options.GlobalOpts.Manager {
 		clusterId, clusterName, err = utils.DefaultOCMInterface.GetManagingCluster(clusterId)
 		e.Options.Alias = clusterId
 		if err != nil {
@@ -86,7 +86,7 @@ func (e *BackplaneSession) RunCommand(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Switching to management cluster ID: %v, Name: %v\n", clusterId, clusterName)
 	}
 
-	if e.Options.Service {
+	if e.Options.GlobalOpts.Service {
 		clusterId, clusterName, err = utils.DefaultOCMInterface.GetServiceCluster(clusterId)
 		e.Options.Alias = clusterId
 		if err != nil {

--- a/pkg/cli/session/session_test.go
+++ b/pkg/cli/session/session_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/backplane-cli/pkg/cli/globalflags"
 	"github.com/openshift/backplane-cli/pkg/client/mocks"
 	"github.com/openshift/backplane-cli/pkg/info"
 	"github.com/openshift/backplane-cli/pkg/utils"
@@ -49,7 +50,9 @@ var _ = Describe("Backplane Session Unit test", func() {
 		mockClientUtil = mocks2.NewMockClientUtils(mockCtrl)
 		utils.DefaultClientUtils = mockClientUtil
 
-		options = Options{}
+		options = Options{
+			GlobalOpts: &globalflags.GlobalOptions{},
+		}
 
 		// create temp session
 		sessionPath, err := os.MkdirTemp("", "bp-session")


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / Why we need it?
PR #148 moved the `--manager` and `--session` flags to global options, but these do not get set in `backplane session` when used. This is because the `session`'s internal options boolean variables are separate to those in the `globalOpts` struct, so they're never going to get set to what gets set in `globalOpts`.

The fix is straightforward, just add the global opts to `session`'s own options struct as a pointer.
