### PR TITLE
fix: nil pointer dereference when getting cloud credentials

### DIFF
--- a/cmd/ocm-backplane/cloud/credentials.go
+++ b/cmd/ocm-backplane/cloud/credentials.go
@@ -177,7 +177,10 @@ func runCredentials(cmd *cobra.Command, argv []string) error {
 	// ======== Call Endpoint ==================================
 	logger.Debugln("Getting Cloud Credentials")
 
-	credsResp, _ := getCloudCredential(bpURL, clusterID)
+	credsResp, err := getCloudCredential(bpURL, clusterID)
+	if err != nil {
+		return err
+	}
 
 	// ======== Render cloud credentials =======================
 	switch cloudProvider {


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

Fixes nil ptr dereference when getting cloud credentials.

Steps to reproduce:
- run `ocm backplane cloud credentials <clusterid>` without running proxy connection

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
