### PR TITLE
add --debug-file flag for 'cloud assume' command

### DIFF
--- a/cmd/ocm-backplane/cloud/assume.go
+++ b/cmd/ocm-backplane/cloud/assume.go
@@ -5,34 +5,40 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
-	"github.com/spf13/cobra"
-
 	"github.com/openshift/backplane-cli/pkg/awsutil"
-	"github.com/openshift/backplane-cli/pkg/cli/config"
 	"github.com/openshift/backplane-cli/pkg/utils"
+	"github.com/spf13/cobra"
 )
 
 const (
-	DefaultRoleArn = "arn:aws:iam::922711891673:role/SRE-Support-Role"
+	DefaultInitialRoleArn = "arn:aws:iam::922711891673:role/SRE-Support-Role"
 )
 
 var assumeArgs struct {
-	roleArn string
-	output  string
+	initialRoleArn string
+	output         string
+	debugFile      string
 }
+
+var StsClientWithProxy = awsutil.StsClientWithProxy
+var AssumeRoleWithJWT = awsutil.AssumeRoleWithJWT
+var NewStaticCredentialsProvider = credentials.NewStaticCredentialsProvider
+var AssumeRoleSequence = awsutil.AssumeRoleSequence
 
 var AssumeCmd = &cobra.Command{
 	Use:   "assume [CLUSTERID|EXTERNAL_ID|CLUSTER_NAME|CLUSTER_NAME_SEARCH]",
 	Short: "Performs the assume role chaining necessary to generate temporary access to the customer's AWS account",
 	Long: `Performs the assume role chaining necessary to generate temporary access to the customer's AWS account
 
-This command is the equivalent of running "aws sts assume-role-with-web-identity --role-arn [role-arn] --web-identity-token [ocm token] --role-session-name [email from OCM token]" behind the scenes,
+This command is the equivalent of running "aws sts assume-role-with-web-identity --initial-role-arn [role-arn] --web-identity-token [ocm token] --role-session-name [email from OCM token]" behind the scenes,
 where the ocm token used is the result of running "ocm token". Then, the command makes a call to the backplane API to get the necessary jump roles for the cluster's account. It then calls the
-equivalent of "aws sts assume-role --role-arn [role-arn] --role-session-name [email from OCM token]" repeatedly for each role arn in the chain, using the previous role's credentials to assume the next
+equivalent of "aws sts assume-role --initial-role-arn [role-arn] --role-session-name [email from OCM token]" repeatedly for each role arn in the chain, using the previous role's credentials to assume the next
 role in the chain.
 
 This command will output sts credentials for the target role in the given cluster in formatted JSON. If no "role-arn" is provided, a default role will be used.
@@ -41,15 +47,19 @@ This command will output sts credentials for the target role in the given cluste
 backplane cloud assume e3b2fdc5-d9a7-435e-8870-312689cfb29c -oenv
 
 With given role:
-backplane cloud assume e3b2fdc5-d9a7-435e-8870-312689cfb29c --role-arn arn:aws:iam::1234567890:role/read-only -oenv`,
-	Args: cobra.ExactArgs(1),
+backplane cloud assume e3b2fdc5-d9a7-435e-8870-312689cfb29c --initial-role-arn arn:aws:iam::1234567890:role/read-only -oenv
+
+With a debug file:
+backplane cloud assume e3b2fdc5-d9a7-435e-8870-312689cfb29c --debug-file test_arns`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: runAssume,
 }
 
 func init() {
 	flags := AssumeCmd.Flags()
-	flags.StringVar(&assumeArgs.roleArn, "role-arn", DefaultRoleArn, "The arn of the role for which to start the role assume process.")
+	flags.StringVar(&assumeArgs.initialRoleArn, "initial-role-arn", DefaultInitialRoleArn, "The arn of the role for which to start the role assume process.")
 	flags.StringVarP(&assumeArgs.output, "output", "o", "env", "Format the output of the console response.")
+	flags.StringVar(&assumeArgs.debugFile, "debug-file", "", "A file containing the list of ARNs to assume in order, not including the initial role ARN. Providing this flag will bypass calls to the backplane API to retrieve the assume role chain. The file should be a plain text file with each ARN on a new line.")
 }
 
 type assumeChainResponse struct {
@@ -62,54 +72,27 @@ type namedRoleArn struct {
 }
 
 func runAssume(_ *cobra.Command, args []string) error {
+	if len(args) == 0 && assumeArgs.debugFile == "" {
+		return fmt.Errorf("must provide either cluster ID as an argument, or --debug-file as a flag")
+	}
+
 	ocmToken, err := utils.DefaultOCMInterface.GetOCMAccessToken()
 	if err != nil {
 		return fmt.Errorf("failed to retrieve OCM token: %w", err)
 	}
 
-	bpConfig, err := config.GetBackplaneConfiguration()
+	bpConfig, err := GetBackplaneConfiguration()
 	if err != nil {
 		return fmt.Errorf("error retrieving backplane configuration: %w", err)
 	}
 
-	initialClient, err := awsutil.StsClientWithProxy(bpConfig.ProxyURL)
+	initialClient, err := StsClientWithProxy(bpConfig.ProxyURL)
 	if err != nil {
 		return fmt.Errorf("failed to create sts client: %w", err)
 	}
-	seedCredentials, err := awsutil.AssumeRoleWithJWT(*ocmToken, assumeArgs.roleArn, initialClient)
+	seedCredentials, err := AssumeRoleWithJWT(*ocmToken, assumeArgs.initialRoleArn, initialClient)
 	if err != nil {
 		return fmt.Errorf("failed to assume role using JWT: %w", err)
-	}
-
-	clusterID, _, err := utils.DefaultOCMInterface.GetTargetCluster(args[0])
-	if err != nil {
-		return fmt.Errorf("failed to get target cluster: %w", err)
-	}
-
-	backplaneClient, err := utils.DefaultClientUtils.MakeRawBackplaneAPIClientWithAccessToken(bpConfig.URL, *ocmToken)
-	if err != nil {
-		return fmt.Errorf("failed to create backplane client with access token: %w", err)
-	}
-
-	response, err := backplaneClient.GetAssumeRoleSequence(context.TODO(), clusterID)
-	if err != nil {
-		return fmt.Errorf("failed to fetch arn sequence: %w", err)
-	}
-
-	bytes, err := io.ReadAll(response.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read backplane API response body: %w", err)
-	}
-
-	roleChainResponse := &assumeChainResponse{}
-	err = json.Unmarshal(bytes, roleChainResponse)
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal response: %w", err)
-	}
-
-	roleAssumeSequence := make([]string, 0, len(roleChainResponse.AssumptionSequence))
-	for _, namedRoleArn := range roleChainResponse.AssumptionSequence {
-		roleAssumeSequence = append(roleAssumeSequence, namedRoleArn.Arn)
 	}
 
 	email, err := utils.GetStringFieldFromJWT(*ocmToken, "email")
@@ -119,9 +102,54 @@ func runAssume(_ *cobra.Command, args []string) error {
 
 	seedClient := sts.NewFromConfig(aws.Config{
 		Region:      "us-east-1",
-		Credentials: credentials.NewStaticCredentialsProvider(*seedCredentials.AccessKeyId, *seedCredentials.SecretAccessKey, *seedCredentials.SessionToken),
+		Credentials: NewStaticCredentialsProvider(*seedCredentials.AccessKeyId, *seedCredentials.SecretAccessKey, *seedCredentials.SessionToken),
 	})
-	targetCredentials, err := awsutil.AssumeRoleSequence(email, seedClient, roleAssumeSequence, bpConfig.ProxyURL, awsutil.DefaultSTSClientProviderFunc)
+
+	var roleAssumeSequence []string
+	if assumeArgs.debugFile == "" {
+		clusterID, _, err := utils.DefaultOCMInterface.GetTargetCluster(args[0])
+		if err != nil {
+			return fmt.Errorf("failed to get target cluster: %w", err)
+		}
+
+		backplaneClient, err := utils.DefaultClientUtils.MakeRawBackplaneAPIClientWithAccessToken(bpConfig.URL, *ocmToken)
+		if err != nil {
+			return fmt.Errorf("failed to create backplane client with access token: %w", err)
+		}
+
+		response, err := backplaneClient.GetAssumeRoleSequence(context.TODO(), clusterID)
+		if err != nil {
+			return fmt.Errorf("failed to fetch arn sequence: %w", err)
+		}
+		if response.StatusCode != 200 {
+			return fmt.Errorf("failed to fetch arn sequence: %v", response.Status)
+		}
+
+		bytes, err := io.ReadAll(response.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read backplane API response body: %w", err)
+		}
+
+		roleChainResponse := &assumeChainResponse{}
+		err = json.Unmarshal(bytes, roleChainResponse)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal response: %w", err)
+		}
+
+		roleAssumeSequence = make([]string, 0, len(roleChainResponse.AssumptionSequence))
+		for _, namedRoleArn := range roleChainResponse.AssumptionSequence {
+			roleAssumeSequence = append(roleAssumeSequence, namedRoleArn.Arn)
+		}
+	} else {
+		arnBytes, err := os.ReadFile(assumeArgs.debugFile)
+		if err != nil {
+			return fmt.Errorf("failed to read file %v: %w", assumeArgs.debugFile, err)
+		}
+
+		roleAssumeSequence = append(roleAssumeSequence, strings.Split(string(arnBytes), "\n")...)
+	}
+
+	targetCredentials, err := AssumeRoleSequence(email, seedClient, roleAssumeSequence, bpConfig.ProxyURL, awsutil.DefaultSTSClientProviderFunc)
 	if err != nil {
 		return fmt.Errorf("failed to assume role sequence: %w", err)
 	}

--- a/cmd/ocm-backplane/cloud/assume_test.go
+++ b/cmd/ocm-backplane/cloud/assume_test.go
@@ -1,0 +1,353 @@
+package cloud
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/backplane-cli/pkg/awsutil"
+	"github.com/openshift/backplane-cli/pkg/cli/config"
+	"github.com/openshift/backplane-cli/pkg/client/mocks"
+	"github.com/openshift/backplane-cli/pkg/utils"
+	mocks2 "github.com/openshift/backplane-cli/pkg/utils/mocks"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+//nolint:gosec
+var _ = Describe("Cloud assume command", func() {
+
+	var (
+		mockCtrl         *gomock.Controller
+		mockOcmInterface *mocks2.MockOCMInterface
+		mockClientUtil   *mocks2.MockClientUtils
+		mockClient       *mocks.MockClientInterface
+
+		testOcmToken        string
+		testClusterID       string
+		testAccessKeyID     string
+		testSecretAccessKey string
+		testSessionToken    string
+		testClusterName     string
+		testExpiration      time.Time
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+
+		mockClient = mocks.NewMockClientInterface(mockCtrl)
+
+		mockOcmInterface = mocks2.NewMockOCMInterface(mockCtrl)
+		utils.DefaultOCMInterface = mockOcmInterface
+
+		mockClientUtil = mocks2.NewMockClientUtils(mockCtrl)
+		utils.DefaultClientUtils = mockClientUtil
+
+		testOcmToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZW1haWwiOiJ0ZXN0QGZvby5jb20iLCJpYXQiOjE1MTYyMzkwMjJ9.5NG4wFhitEKZyzftSwU67kx4JVTEWcEoKhCl_AFp8T4"
+		testClusterID = "test123"
+		testAccessKeyID = "test-access-key-id"
+		testSecretAccessKey = "test-secret-access-key"
+		testSessionToken = "test-session-token"
+		testClusterName = "test-cluster"
+		testExpiration = time.UnixMilli(1691606228384)
+	})
+
+	Context("Execute cloud assume command", func() {
+		It("should return AWS STS credentials", func() {
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testOcmToken, nil).Times(1)
+			GetBackplaneConfiguration = func() (bpConfig config.BackplaneConfiguration, err error) {
+				return config.BackplaneConfiguration{
+					URL:      "testUrl.com",
+					ProxyURL: "testProxyUrl.com",
+				}, nil
+			}
+			StsClientWithProxy = func(proxyURL string) (*sts.Client, error) {
+				return &sts.Client{}, nil
+			}
+			AssumeRoleWithJWT = func(jwt string, roleArn string, stsClient awsutil.STSRoleWithWebIdentityAssumer) (*types.Credentials, error) {
+				return &types.Credentials{
+					AccessKeyId:     &testAccessKeyID,
+					SecretAccessKey: &testSecretAccessKey,
+					SessionToken:    &testSessionToken,
+				}, nil
+			}
+			NewStaticCredentialsProvider = func(key, secret, session string) credentials.StaticCredentialsProvider {
+				return credentials.StaticCredentialsProvider{}
+			}
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(testClusterID, testClusterName, nil).Times(1)
+			mockClientUtil.EXPECT().MakeRawBackplaneAPIClientWithAccessToken("testUrl.com", testOcmToken).Return(mockClient, nil).Times(1)
+			mockClient.EXPECT().GetAssumeRoleSequence(context.TODO(), testClusterID).Return(&http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader(`{"assumption_sequence":[{"name": "name_one", "arn": "arn_one"},{"name": "name_two", "arn": "arn_two"}]}`)),
+			}, nil).Times(1)
+			AssumeRoleSequence = func(roleSessionName string, seedClient awsutil.STSRoleAssumer, roleArnSequence []string, proxyURL string, stsClientProviderFunc awsutil.STSClientProviderFunc) (*types.Credentials, error) {
+				return &types.Credentials{
+					AccessKeyId:     &testAccessKeyID,
+					SecretAccessKey: &testSecretAccessKey,
+					SessionToken:    &testSessionToken,
+					Expiration:      &testExpiration,
+				}, nil
+			}
+
+			err := runAssume(nil, []string{testClusterID})
+			Expect(err).To(BeNil())
+		})
+		It("should fail if no argument or debug file is provided", func() {
+			err := runAssume(nil, []string{})
+			Expect(err).To(Equal(fmt.Errorf("must provide either cluster ID as an argument, or --debug-file as a flag")))
+		})
+		It("should fail if cannot retrieve OCM token", func() {
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(nil, errors.New("foo")).Times(1)
+
+			err := runAssume(nil, []string{testClusterID})
+			Expect(err.Error()).To(Equal("failed to retrieve OCM token: foo"))
+		})
+		It("should fail if cannot retrieve backplane configuration", func() {
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testOcmToken, nil).Times(1)
+			GetBackplaneConfiguration = func() (bpConfig config.BackplaneConfiguration, err error) {
+				return config.BackplaneConfiguration{}, errors.New("oops")
+			}
+
+			err := runAssume(nil, []string{testClusterID})
+			Expect(err.Error()).To(Equal("error retrieving backplane configuration: oops"))
+		})
+		It("should fail if cannot create create sts client with proxy", func() {
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testOcmToken, nil).Times(1)
+			GetBackplaneConfiguration = func() (bpConfig config.BackplaneConfiguration, err error) {
+				return config.BackplaneConfiguration{
+					URL:      "testUrl.com",
+					ProxyURL: "testProxyUrl.com",
+				}, nil
+			}
+			StsClientWithProxy = func(proxyURL string) (*sts.Client, error) {
+				return nil, errors.New(":(")
+			}
+
+			err := runAssume(nil, []string{testClusterID})
+			Expect(err.Error()).To(Equal("failed to create sts client: :("))
+		})
+		It("should fail if initial role cannot be assumed with JWT", func() {
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testOcmToken, nil).Times(1)
+			GetBackplaneConfiguration = func() (bpConfig config.BackplaneConfiguration, err error) {
+				return config.BackplaneConfiguration{
+					URL:      "testUrl.com",
+					ProxyURL: "testProxyUrl.com",
+				}, nil
+			}
+			StsClientWithProxy = func(proxyURL string) (*sts.Client, error) {
+				return &sts.Client{}, nil
+			}
+			AssumeRoleWithJWT = func(jwt string, roleArn string, stsClient awsutil.STSRoleWithWebIdentityAssumer) (*types.Credentials, error) {
+				return nil, errors.New("failure")
+			}
+
+			err := runAssume(nil, []string{testClusterID})
+			Expect(err.Error()).To(Equal("failed to assume role using JWT: failure"))
+		})
+		It("should fail if email cannot be pulled off JWT", func() {
+			testOcmToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testOcmToken, nil).Times(1)
+			GetBackplaneConfiguration = func() (bpConfig config.BackplaneConfiguration, err error) {
+				return config.BackplaneConfiguration{
+					URL:      "testUrl.com",
+					ProxyURL: "testProxyUrl.com",
+				}, nil
+			}
+			StsClientWithProxy = func(proxyURL string) (*sts.Client, error) {
+				return &sts.Client{}, nil
+			}
+			AssumeRoleWithJWT = func(jwt string, roleArn string, stsClient awsutil.STSRoleWithWebIdentityAssumer) (*types.Credentials, error) {
+				return &types.Credentials{
+					AccessKeyId:     &testAccessKeyID,
+					SecretAccessKey: &testSecretAccessKey,
+					SessionToken:    &testSessionToken,
+				}, nil
+			}
+
+			err := runAssume(nil, []string{testClusterID})
+			Expect(err.Error()).To(Equal("unable to extract email from given token: no field email on given token"))
+		})
+		It("should fail if cluster cannot be retrieved from OCM", func() {
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testOcmToken, nil).Times(1)
+			GetBackplaneConfiguration = func() (bpConfig config.BackplaneConfiguration, err error) {
+				return config.BackplaneConfiguration{
+					URL:      "testUrl.com",
+					ProxyURL: "testProxyUrl.com",
+				}, nil
+			}
+			StsClientWithProxy = func(proxyURL string) (*sts.Client, error) {
+				return &sts.Client{}, nil
+			}
+			AssumeRoleWithJWT = func(jwt string, roleArn string, stsClient awsutil.STSRoleWithWebIdentityAssumer) (*types.Credentials, error) {
+				return &types.Credentials{
+					AccessKeyId:     &testAccessKeyID,
+					SecretAccessKey: &testSecretAccessKey,
+					SessionToken:    &testSessionToken,
+				}, nil
+			}
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return("", "", errors.New("oh no")).Times(1)
+
+			err := runAssume(nil, []string{testClusterID})
+			Expect(err.Error()).To(Equal("failed to get target cluster: oh no"))
+		})
+		It("should fail if error creating backplane api client", func() {
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testOcmToken, nil).Times(1)
+			GetBackplaneConfiguration = func() (bpConfig config.BackplaneConfiguration, err error) {
+				return config.BackplaneConfiguration{
+					URL:      "testUrl.com",
+					ProxyURL: "testProxyUrl.com",
+				}, nil
+			}
+			StsClientWithProxy = func(proxyURL string) (*sts.Client, error) {
+				return &sts.Client{}, nil
+			}
+			AssumeRoleWithJWT = func(jwt string, roleArn string, stsClient awsutil.STSRoleWithWebIdentityAssumer) (*types.Credentials, error) {
+				return &types.Credentials{
+					AccessKeyId:     &testAccessKeyID,
+					SecretAccessKey: &testSecretAccessKey,
+					SessionToken:    &testSessionToken,
+				}, nil
+			}
+			NewStaticCredentialsProvider = func(key, secret, session string) credentials.StaticCredentialsProvider {
+				return credentials.StaticCredentialsProvider{}
+			}
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(testClusterID, testClusterName, nil).Times(1)
+			mockClientUtil.EXPECT().MakeRawBackplaneAPIClientWithAccessToken("testUrl.com", testOcmToken).Return(nil, errors.New("foo")).Times(1)
+
+			err := runAssume(nil, []string{testClusterID})
+			Expect(err.Error()).To(Equal("failed to create backplane client with access token: foo"))
+		})
+		It("should fail if cannot retrieve role sequence", func() {
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testOcmToken, nil).Times(1)
+			GetBackplaneConfiguration = func() (bpConfig config.BackplaneConfiguration, err error) {
+				return config.BackplaneConfiguration{
+					URL:      "testUrl.com",
+					ProxyURL: "testProxyUrl.com",
+				}, nil
+			}
+			StsClientWithProxy = func(proxyURL string) (*sts.Client, error) {
+				return &sts.Client{}, nil
+			}
+			AssumeRoleWithJWT = func(jwt string, roleArn string, stsClient awsutil.STSRoleWithWebIdentityAssumer) (*types.Credentials, error) {
+				return &types.Credentials{
+					AccessKeyId:     &testAccessKeyID,
+					SecretAccessKey: &testSecretAccessKey,
+					SessionToken:    &testSessionToken,
+				}, nil
+			}
+			NewStaticCredentialsProvider = func(key, secret, session string) credentials.StaticCredentialsProvider {
+				return credentials.StaticCredentialsProvider{}
+			}
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(testClusterID, testClusterName, nil).Times(1)
+			mockClientUtil.EXPECT().MakeRawBackplaneAPIClientWithAccessToken("testUrl.com", testOcmToken).Return(mockClient, nil).Times(1)
+			mockClient.EXPECT().GetAssumeRoleSequence(context.TODO(), testClusterID).Return(nil, errors.New("error")).Times(1)
+
+			err := runAssume(nil, []string{testClusterID})
+			Expect(err.Error()).To(Equal("failed to fetch arn sequence: error"))
+		})
+		It("should fail if fetching assume role sequence doesn't return a 200 status code", func() {
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testOcmToken, nil).Times(1)
+			GetBackplaneConfiguration = func() (bpConfig config.BackplaneConfiguration, err error) {
+				return config.BackplaneConfiguration{
+					URL:      "testUrl.com",
+					ProxyURL: "testProxyUrl.com",
+				}, nil
+			}
+			StsClientWithProxy = func(proxyURL string) (*sts.Client, error) {
+				return &sts.Client{}, nil
+			}
+			AssumeRoleWithJWT = func(jwt string, roleArn string, stsClient awsutil.STSRoleWithWebIdentityAssumer) (*types.Credentials, error) {
+				return &types.Credentials{
+					AccessKeyId:     &testAccessKeyID,
+					SecretAccessKey: &testSecretAccessKey,
+					SessionToken:    &testSessionToken,
+				}, nil
+			}
+			NewStaticCredentialsProvider = func(key, secret, session string) credentials.StaticCredentialsProvider {
+				return credentials.StaticCredentialsProvider{}
+			}
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(testClusterID, testClusterName, nil).Times(1)
+			mockClientUtil.EXPECT().MakeRawBackplaneAPIClientWithAccessToken("testUrl.com", testOcmToken).Return(mockClient, nil).Times(1)
+			mockClient.EXPECT().GetAssumeRoleSequence(context.TODO(), testClusterID).Return(&http.Response{
+				StatusCode: 401,
+				Status:     "Unauthorized",
+				Body:       io.NopCloser(strings.NewReader(`{"assumption_sequence":[{"name": "name_one", "arn": "arn_one"},{"name": "name_two", "arn": "arn_two"}]}`)),
+			}, nil).Times(1)
+
+			err := runAssume(nil, []string{testClusterID})
+			Expect(err.Error()).To(Equal("failed to fetch arn sequence: Unauthorized"))
+		})
+		It("should fail if it cannot unmarshal backplane API response", func() {
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testOcmToken, nil).Times(1)
+			GetBackplaneConfiguration = func() (bpConfig config.BackplaneConfiguration, err error) {
+				return config.BackplaneConfiguration{
+					URL:      "testUrl.com",
+					ProxyURL: "testProxyUrl.com",
+				}, nil
+			}
+			StsClientWithProxy = func(proxyURL string) (*sts.Client, error) {
+				return &sts.Client{}, nil
+			}
+			AssumeRoleWithJWT = func(jwt string, roleArn string, stsClient awsutil.STSRoleWithWebIdentityAssumer) (*types.Credentials, error) {
+				return &types.Credentials{
+					AccessKeyId:     &testAccessKeyID,
+					SecretAccessKey: &testSecretAccessKey,
+					SessionToken:    &testSessionToken,
+				}, nil
+			}
+			NewStaticCredentialsProvider = func(key, secret, session string) credentials.StaticCredentialsProvider {
+				return credentials.StaticCredentialsProvider{}
+			}
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(testClusterID, testClusterName, nil).Times(1)
+			mockClientUtil.EXPECT().MakeRawBackplaneAPIClientWithAccessToken("testUrl.com", testOcmToken).Return(mockClient, nil).Times(1)
+			mockClient.EXPECT().GetAssumeRoleSequence(context.TODO(), testClusterID).Return(&http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil).Times(1)
+
+			err := runAssume(nil, []string{testClusterID})
+			Expect(err.Error()).To(Equal("failed to unmarshal response: unexpected end of JSON input"))
+		})
+		It("should fail if it cannot assume the role sequence", func() {
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testOcmToken, nil).Times(1)
+			GetBackplaneConfiguration = func() (bpConfig config.BackplaneConfiguration, err error) {
+				return config.BackplaneConfiguration{
+					URL:      "testUrl.com",
+					ProxyURL: "testProxyUrl.com",
+				}, nil
+			}
+			StsClientWithProxy = func(proxyURL string) (*sts.Client, error) {
+				return &sts.Client{}, nil
+			}
+			AssumeRoleWithJWT = func(jwt string, roleArn string, stsClient awsutil.STSRoleWithWebIdentityAssumer) (*types.Credentials, error) {
+				return &types.Credentials{
+					AccessKeyId:     &testAccessKeyID,
+					SecretAccessKey: &testSecretAccessKey,
+					SessionToken:    &testSessionToken,
+				}, nil
+			}
+			NewStaticCredentialsProvider = func(key, secret, session string) credentials.StaticCredentialsProvider {
+				return credentials.StaticCredentialsProvider{}
+			}
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(testClusterID, testClusterName, nil).Times(1)
+			mockClientUtil.EXPECT().MakeRawBackplaneAPIClientWithAccessToken("testUrl.com", testOcmToken).Return(mockClient, nil).Times(1)
+			mockClient.EXPECT().GetAssumeRoleSequence(context.TODO(), testClusterID).Return(&http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader(`{"assumption_sequence":[{"name": "name_one", "arn": "arn_one"},{"name": "name_two", "arn": "arn_two"}]}`)),
+			}, nil).Times(1)
+			AssumeRoleSequence = func(roleSessionName string, seedClient awsutil.STSRoleAssumer, roleArnSequence []string, proxyURL string, stsClientProviderFunc awsutil.STSClientProviderFunc) (*types.Credentials, error) {
+				return nil, errors.New("oops")
+			}
+
+			err := runAssume(nil, []string{testClusterID})
+			Expect(err.Error()).To(Equal("failed to assume role sequence: oops"))
+		})
+	})
+})

--- a/cmd/ocm-backplane/cloud/cloud.go
+++ b/cmd/ocm-backplane/cloud/cloud.go
@@ -1,8 +1,11 @@
 package cloud
 
 import (
+	bpconfig "github.com/openshift/backplane-cli/pkg/cli/config"
 	"github.com/spf13/cobra"
 )
+
+var GetBackplaneConfiguration = bpconfig.GetBackplaneConfiguration
 
 var CloudCmd = &cobra.Command{
 	Use:               "cloud",

--- a/cmd/ocm-backplane/cloud/credentials.go
+++ b/cmd/ocm-backplane/cloud/credentials.go
@@ -16,12 +16,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	BackplaneApi "github.com/openshift/backplane-api/pkg/client"
 
-	bpconfig "github.com/openshift/backplane-cli/pkg/cli/config"
 	"github.com/openshift/backplane-cli/pkg/utils"
 )
 
 var GetBackplaneClusterFromConfig = utils.DefaultClusterUtils.GetBackplaneClusterFromConfig
-var GetBackplaneConfiguration = bpconfig.GetBackplaneConfiguration
 
 var credentialArgs struct {
 	backplaneURL string


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / Why we need it?
Adds the ability to manually provide the role assume sequence to the `cloud assume` command. This is intended to allow test of changes in stage and integration environments.

### Which Jira/Github issue(s) does this PR fix?
[OSD-17196](https://issues.redhat.com//browse/OSD-17196)

### Special notes for your reviewer

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [x] Included documentation changes with PR