### PR TITLE
Add govulnerability check to bp-cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,10 @@ build-image:
 lint-in-container: build-image
 	$(RUN_IN_CONTAINER_CMD) "go mod download && make lint"
 
+.PHONY: scan
+scan: 
+	govulncheck ./...
+
 image:
 	$(CONTAINER_ENGINE) build --pull --platform linux/amd64 -t $(IMAGE_URI_VERSION) .
 	$(CONTAINER_ENGINE) tag $(IMAGE_URI_VERSION) $(IMAGE_URI_LATEST)

--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,7 @@ require (
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/xlab/treeprint v1.1.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
-	golang.org/x/net v0.12.0 // indirect
+	golang.org/x/net v0.13.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect
 	golang.org/x/text v0.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -658,6 +658,8 @@ golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.12.0 h1:cfawfvKITfUsFCeJIHJrbSxpeu/E81khclypR0GVT50=
 golang.org/x/net v0.12.0/go.mod h1:zEVYFnQC7m/vmpQFELhcD1EWkZlX69l4oqgmer6hfKA=
+golang.org/x/net v0.13.0 h1:Nvo8UFsZ8X3BhAC9699Z1j7XQ3rsZnUUm7jfBEk1ueY=
+golang.org/x/net v0.13.0/go.mod h1:zEVYFnQC7m/vmpQFELhcD1EWkZlX69l4oqgmer6hfKA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=


### PR DESCRIPTION
### What type of PR is this?

_feature_

### What this PR does / Why we need it?
It scans the code and dependencies against known security vulnerabilities.

### Which Jira/Github issue(s) does this PR fix?

_Resolves_ #[OSD-17895](https://issues.redhat.com/browse/OSD-17895)  

### Special notes for your reviewer
I ran `govulncheck./...` in go version 1.21.0 and fixed the vulnerabilities. If you'll install gvulncheck and check it using some lower version of go then you might get lots of compatible issues which will eventually mess up `go.mod` and `go.sum` file. 
- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
