### PR TITLE
TestJob to use base64 for library import

### DIFF
--- a/cmd/ocm-backplane/testJob/createTestJob.go
+++ b/cmd/ocm-backplane/testJob/createTestJob.go
@@ -235,15 +235,8 @@ func createTestScriptFromFiles() (*backplaneApi.CreateTestScriptRunJSONRequestBo
 //
 // Inline into function before source definition of example.sh
 // #!/bin/bash
-// cat << EOF > lib.sh
-// #!/bin/bash
-//
-//	function echo_foo () {
-//		echo $1
-//	}
-//
-// EOF
-// source lib.sh
+// base64 -d <<< (based64 encoded lib.sh) > ./lib.sh
+// source ./lib.sh
 //
 // echo_foo "Hello"
 func inlineLibrarySourceFiles(script string, scriptPath string) (string, error) {
@@ -280,9 +273,9 @@ func inlineLibrarySourceFiles(script string, scriptPath string) (string, error) 
 	if err != nil {
 		return "", err
 	}
-	library := string(fileBody)
+	libraryEncoded := base64.StdEncoding.EncodeToString([]byte(fileBody))
 
-	inlinedFunction := "cat << EOF > ./lib.sh\n" + library + "\nEOF\n" + "source ./lib.sh\n"
+	inlinedFunction := "base64 -d <<< " + libraryEncoded + " > ./lib.sh\nsource ./lib.sh\n"
 
 	inlinedScript := strings.Replace(script, match, inlinedFunction, 1)
 


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?
For testjob having library import, the current workflow will wrap the library file into a string, use a cat command to put the library content to lib.sh inline, then replace the `source /path/to/lib.sh` to `source ./lib.sh`

In some cases, the `cat << EOF` may cause strange issues if the library content has special characters or special formats. For example, the lib in https://github.com/openshift/managed-scripts/pull/137 may result in error `unbound variable`.

This PR encode the library file to base64, and decode the file inline, so that we don't need to worry about the format inside the library. 

### Special notes for your reviewer
We can use the existing `lib-sourcer` example for testing, the behavior remains unchanged.
```
[managed-scripts/scripts/examples/lib-sourcer] $ ocm.stg backplane testjob logs openshift-job-dev-p9jjt 
This is an imported library being used in a managed script.
```

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
