### PR TITLE
Bump backplane API version and regenerate mocks

### DIFF
--- a/cmd/ocm-backplane/managedJob/createManagedJob.go
+++ b/cmd/ocm-backplane/managedJob/createManagedJob.go
@@ -175,9 +175,7 @@ func createJob(client BackplaneApi.ClientInterface) (*BackplaneApi.Job, error) {
 	// create job request
 	createJob := BackplaneApi.CreateJobJSONRequestBody{
 		CanonicalName: &options.canonicalName,
-		Parameters: &BackplaneApi.CreateJob_Parameters{
-			AdditionalProperties: jobParams,
-		},
+		Parameters: &jobParams,
 	}
 
 	// call create end point

--- a/cmd/ocm-backplane/testJob/createTestJob.go
+++ b/cmd/ocm-backplane/testJob/createTestJob.go
@@ -149,7 +149,7 @@ func runCreateTestJob(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	cj.Parameters = &backplaneApi.CreateTestJob_Parameters{AdditionalProperties: parsedParams}
+	cj.Parameters = &parsedParams
 
 	// ======== Call Endpoint ========
 	resp, err := client.CreateTestScriptRun(context.TODO(), clusterID, *cj)

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/gomega v1.27.10
 	github.com/openshift-online/ocm-cli v0.1.66
 	github.com/openshift-online/ocm-sdk-go v0.1.364
-	github.com/openshift/backplane-api v0.0.0-20230615010608-391cd2c4bbd8
+	github.com/openshift/backplane-api v0.0.0-20230919035427-a52e4ae498fb
 	github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,11 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8 h1:xzYJEypr/85nBpB11F9br+3HUrpgb+fcm5iADzXXYEw=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8/go.mod h1:oX5x61PbNXchhh0oikYAH+4Pcfw5LKv21+Jnpr6r6Pc=
+github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
+github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -52,6 +55,7 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
+github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go-v2 v1.21.0 h1:gMT0IW+03wtYJhRqTVYn0wLzwdnK9sRMcxmtfGzRdJc=
 github.com/aws/aws-sdk-go-v2 v1.21.0/go.mod h1:/RfNgGmRxI+iFOB1OeJUyxiU+9s88k3pfHvDagGEp0M=
 github.com/aws/aws-sdk-go-v2/config v1.18.37 h1:RNAfbPqw1CstCooHaTPhScz7z1PyocQj0UL+l95CgzI=
@@ -445,6 +449,8 @@ github.com/openshift/api v0.0.0-20221018124113-7edcfe3c76cb h1:QsBjYe5UfHIZi/3SM
 github.com/openshift/api v0.0.0-20221018124113-7edcfe3c76cb/go.mod h1:JRz+ZvTqu9u7t6suhhPTacbFl5K65Y6rJbNM7HjWA3g=
 github.com/openshift/backplane-api v0.0.0-20230615010608-391cd2c4bbd8 h1:SPGOXH1l1Cy0Q3dboU1e/OX3KN29bRy/DbHfA9eq090=
 github.com/openshift/backplane-api v0.0.0-20230615010608-391cd2c4bbd8/go.mod h1:RuJZpJy45AJnkp7A0ZPTZhLOVkCGDLI6cGknKvp65LE=
+github.com/openshift/backplane-api v0.0.0-20230919035427-a52e4ae498fb h1:hs/QQB+1gHpFozwc0lXIy+V7iMkzkkJSKdCaCumjw8Q=
+github.com/openshift/backplane-api v0.0.0-20230919035427-a52e4ae498fb/go.mod h1:RuJZpJy45AJnkp7A0ZPTZhLOVkCGDLI6cGknKvp65LE=
 github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c h1:CV76yFOTXmq9VciBR3Bve5ZWzSxdft7gaMVB3kS0rwg=
 github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c/go.mod h1:lFMO8mLHXWFzSdYvGNo8ivF9SfF6zInA8ZGw4phRnUE=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=

--- a/pkg/client/mocks/ClientMock.go
+++ b/pkg/client/mocks/ClientMock.go
@@ -38,7 +38,7 @@ func (m *MockClientInterface) EXPECT() *MockClientInterfaceMockRecorder {
 }
 
 // CreateJob mocks base method.
-func (m *MockClientInterface) CreateJob(arg0 context.Context, arg1 string, arg2 Openapi.CreateJobJSONRequestBody, arg3 ...Openapi.RequestEditorFn) (*http.Response, error) {
+func (m *MockClientInterface) CreateJob(arg0 context.Context, arg1 string, arg2 Openapi.CreateJob, arg3 ...Openapi.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -78,7 +78,7 @@ func (mr *MockClientInterfaceMockRecorder) CreateJobWithBody(arg0, arg1, arg2, a
 }
 
 // CreateTestScriptRun mocks base method.
-func (m *MockClientInterface) CreateTestScriptRun(arg0 context.Context, arg1 string, arg2 Openapi.CreateTestScriptRunJSONRequestBody, arg3 ...Openapi.RequestEditorFn) (*http.Response, error) {
+func (m *MockClientInterface) CreateTestScriptRun(arg0 context.Context, arg1 string, arg2 Openapi.CreateTestJob, arg3 ...Openapi.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -295,26 +295,6 @@ func (mr *MockClientInterfaceMockRecorder) GetRun(arg0, arg1, arg2 interface{}, 
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRun", reflect.TypeOf((*MockClientInterface)(nil).GetRun), varargs...)
-}
-
-// GetScripts mocks base method.
-func (m *MockClientInterface) GetScripts(arg0 context.Context, arg1 *Openapi.GetScriptsParams, arg2 ...Openapi.RequestEditorFn) (*http.Response, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "GetScripts", varargs...)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetScripts indicates an expected call of GetScripts.
-func (mr *MockClientInterfaceMockRecorder) GetScripts(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScripts", reflect.TypeOf((*MockClientInterface)(nil).GetScripts), varargs...)
 }
 
 // GetScriptsByCluster mocks base method.

--- a/pkg/client/mocks/ClientWithResponsesMock.go
+++ b/pkg/client/mocks/ClientWithResponsesMock.go
@@ -57,7 +57,7 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) CreateJobWithBodyWithRes
 }
 
 // CreateJobWithResponse mocks base method.
-func (m *MockClientWithResponsesInterface) CreateJobWithResponse(arg0 context.Context, arg1 string, arg2 Openapi.CreateJobJSONRequestBody, arg3 ...Openapi.RequestEditorFn) (*Openapi.CreateJobResponse, error) {
+func (m *MockClientWithResponsesInterface) CreateJobWithResponse(arg0 context.Context, arg1 string, arg2 Openapi.CreateJob, arg3 ...Openapi.RequestEditorFn) (*Openapi.CreateJobResponse, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -97,7 +97,7 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) CreateTestScriptRunWithB
 }
 
 // CreateTestScriptRunWithResponse mocks base method.
-func (m *MockClientWithResponsesInterface) CreateTestScriptRunWithResponse(arg0 context.Context, arg1 string, arg2 Openapi.CreateTestScriptRunJSONRequestBody, arg3 ...Openapi.RequestEditorFn) (*Openapi.CreateTestScriptRunResponse, error) {
+func (m *MockClientWithResponsesInterface) CreateTestScriptRunWithResponse(arg0 context.Context, arg1 string, arg2 Openapi.CreateTestJob, arg3 ...Openapi.RequestEditorFn) (*Openapi.CreateTestScriptRunResponse, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -314,26 +314,6 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) GetScriptsByClusterWithR
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScriptsByClusterWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).GetScriptsByClusterWithResponse), varargs...)
-}
-
-// GetScriptsWithResponse mocks base method.
-func (m *MockClientWithResponsesInterface) GetScriptsWithResponse(arg0 context.Context, arg1 *Openapi.GetScriptsParams, arg2 ...Openapi.RequestEditorFn) (*Openapi.GetScriptsResponse, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "GetScriptsWithResponse", varargs...)
-	ret0, _ := ret[0].(*Openapi.GetScriptsResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetScriptsWithResponse indicates an expected call of GetScriptsWithResponse.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) GetScriptsWithResponse(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScriptsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).GetScriptsWithResponse), varargs...)
 }
 
 // GetTestScriptRunLogsWithResponse mocks base method.


### PR DESCRIPTION
### What type of PR is this?

_(cleanup)_

### What this PR does / Why we need it?
- Bumps backplane api to accommodate https://github.com/openshift/backplane-api/pull/12 and https://github.com/openshift/backplane-api/pull/13.
- Regenerate mocks
### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
