### PR TITLE
OSD-18058 : Adding a new interactive shell session when we do debug with elevate command 

### DIFF
--- a/pkg/elevate/elevate.go
+++ b/pkg/elevate/elevate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	logger "github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -61,12 +62,19 @@ func RunElevate(argv []string) error {
 
 	logger.Debug("Adding impersonation RBAC allow permissions to kubeconfig")
 
-	elevateCmd := argv[1:]
+	elevateCmd := "oc " + strings.Join(argv[1:], " ")
+
+	shell := "/bin/bash"
+
+	if len(argv) > 3 {
+		shell = argv[4]
+	}
 
 	logger.Debugln("Executing command with temporary kubeconfig as backplane-cluster-admin")
-	ocCmd := ExecCmd("oc", elevateCmd...)
 
+	ocCmd := ExecCmd(shell, "-c", elevateCmd)
 	ocCmd.Env = append(ocCmd.Env, os.Environ()...)
+	ocCmd.Stdin = os.Stdin
 	ocCmd.Stderr = os.Stderr
 	ocCmd.Stdout = os.Stdout
 
@@ -75,6 +83,7 @@ func RunElevate(argv []string) error {
 	}
 
 	err = ocCmd.Run()
+
 	kubeconfigPath, _ := os.LookupEnv("KUBECONFIG")
 	defer func() {
 		logger.Debugln("Command error; Cleaning up temporary kubeconfig")

--- a/pkg/elevate/elevate_test.go
+++ b/pkg/elevate/elevate_test.go
@@ -109,7 +109,7 @@ func TestAddElevationReasonToRawKubeconfig(t *testing.T) {
 }
 
 func TestRunElevate(t *testing.T) {
-	t.Run("It errors if we cannot load the kubeconfig", func(t *testing.T) {
+	t.Run("It returns an error if we cannot load the kubeconfig", func(t *testing.T) {
 		ExecCmd = exec.Command
 		OsRemove = os.Remove
 		ReadKubeConfigRaw = func() (api.Config, error) {
@@ -120,7 +120,7 @@ func TestRunElevate(t *testing.T) {
 		}
 	})
 
-	t.Run("It errors if kubeconfig has no current context", func(t *testing.T) {
+	t.Run("It returns an error if kubeconfig has no current context", func(t *testing.T) {
 		ExecCmd = exec.Command
 		OsRemove = os.Remove
 		ReadKubeConfigRaw = func() (api.Config, error) {
@@ -131,7 +131,7 @@ func TestRunElevate(t *testing.T) {
 		}
 	})
 
-	t.Run("It errors if the exec command errors", func(t *testing.T) {
+	t.Run("It returns an error if the exec command has errors", func(t *testing.T) {
 		ExecCmd = fakeExecCommandError
 		OsRemove = os.Remove
 		ReadKubeConfigRaw = func() (api.Config, error) {


### PR DESCRIPTION
### What type of PR is this?

_bug_

### What does this PR do / Why do we need it?
It fixes a bug that occurs when someone attempts to run `ocm backplane elevate "[OHSS-1111]" -- debug node/[nodename]`. This PR will help open a new interactive shell whenever one tries to run and no longer it will just spin up the debug command and instantly exits.

### Which Jira/Github issue(s) does this PR fix?

_Resolves_ #[OSD-18058](https://issues.redhat.com/browse/OSD-18058)

### Special notes for your reviewer
It works exactly as the `oc debug` command and might lag while running in the first attempt and throw a timeout error but this is nothing to worry about `oc debug` does the same.

### Pre-checks (if applicable)

- [X] Ran unit tests locally
- [X] Validated the changes in a cluster
- [ ] Included documentation changes with PR
