### PR TITLE
[OSD-18938] Workaround the CI failed for govulncheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ ensure-govulncheck:
 	@ls $(GOPATH)/bin/govulncheck 1>/dev/null || go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
 
 scan: ensure-govulncheck
-	-govulncheck ./...
+	-govulncheck ./... 2>&1
 	@echo "Note: Vulnerabilities were checked, but failures are currently non-blocking."
 
 image:

--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,12 @@ ensure-govulncheck:
 	@ls $(GOPATH)/bin/govulncheck 1>/dev/null || go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
 
 scan: ensure-govulncheck
-	-govulncheck ./... 2>&1
-	@echo "Note: Vulnerabilities were checked, but failures are currently non-blocking."
+	@output=$$(govulncheck ./... 2>&1); \
+	echo "$$output"; \
+	if echo "$$output" | grep -q "Vulnerability"; then \
+		echo "Note: Vulnerabilities were detected but are non-blocking."; \
+	fi; \
+	exit 0
 
 image:
 	$(CONTAINER_ENGINE) build --pull --platform linux/amd64 -t $(IMAGE_URI_VERSION) .

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,8 @@ ensure-govulncheck:
 	@ls $(GOPATH)/bin/govulncheck 1>/dev/null || go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
 
 scan: ensure-govulncheck
-	govulncheck ./...
+	-govulncheck ./...
+	@echo "Note: Vulnerabilities were checked, but failures are currently non-blocking."
 
 image:
 	$(CONTAINER_ENGINE) build --pull --platform linux/amd64 -t $(IMAGE_URI_VERSION) .

--- a/Makefile
+++ b/Makefile
@@ -129,9 +129,9 @@ scan: ensure-govulncheck
 	@output=$$(govulncheck ./... 2>&1); \
 	echo "$$output"; \
 	if echo "$$output" | grep -q "Vulnerability"; then \
-		echo "Note: Vulnerabilities were detected but are non-blocking."; \
-	fi; \
-	exit 0
+		echo "Note: Detected vulnerabilities (non-blocking for now). Consider updating vulnerable Go packages to their fixed versions."; \
+		exit 0; \
+	fi
 
 image:
 	$(CONTAINER_ENGINE) build --pull --platform linux/amd64 -t $(IMAGE_URI_VERSION) .


### PR DESCRIPTION
### What type of PR is this?
workaround

### What does this PR do?
This PR modifies the `scan` target in the Makefile. If `govulncheck` detects any vulnerabilities, it will display a notification message but will still return a successful exit code, ensuring that the `ci/prow/scan-optional` CI job passes.

Even though `govulncheck` will continue to run, any detected vulnerabilities will be recorded in the `CI build logs`. This allows us to keep track and plan for the necessary updates to the vulnerable Go library packages at a later time.
