### PR TITLE
When specifying image on macOS, force linux/amd64 platform

### DIFF
--- a/cmd/ocm-backplane/console/console.go
+++ b/cmd/ocm-backplane/console/console.go
@@ -355,9 +355,11 @@ func runConsole(cmd *cobra.Command, argv []string) (err error) {
 	if containerEngine == PODMAN {
 		engPullArgs = append(engPullArgs,
 			"--authfile", configFilename,
+			"--platform=linux/amd64", // always run linux/amd64 image; fix for podman for macOS
 		)
 		engRunArgs = append(engRunArgs,
 			"--authfile", configFilename,
+			"--platform=linux/amd64", // always run linux/amd64 image; fix for podman for macOS
 		)
 	}
 

--- a/cmd/ocm-backplane/console/console_test.go
+++ b/cmd/ocm-backplane/console/console_test.go
@@ -148,10 +148,10 @@ var _ = Describe("console command", func() {
 		authFile := filepath.Join(configDir, "config.json")
 
 		Expect(capturedCommands[1]).To(Equal([]string{
-			"podman", "pull", "--quiet", "--authfile", authFile, "testrepo.com/test/console:latest",
+			"podman", "pull", "--quiet", "--authfile", authFile, "--platform=linux/amd64", "testrepo.com/test/console:latest",
 		}))
 		Expect(capturedCommands[2]).To(Equal([]string{
-			"podman", "run", "--rm", "--name", "console-cluster123", "-p", "127.0.0.1:12345:12345", "--authfile", authFile,
+			"podman", "run", "--rm", "--name", "console-cluster123", "-p", "127.0.0.1:12345:12345", "--authfile", authFile, "--platform=linux/amd64",
 			"--env", "HTTPS_PROXY=" + proxyURL, "testrepo.com/test/console:latest", "/opt/bridge/bin/bridge", "--public-dir=/opt/bridge/static", "-base-address", "http://127.0.0.1:12345", "-branding", "dedicated",
 			"-documentation-base-url", "https://docs.openshift.com/dedicated/4/", "-user-settings-location", "localstorage", "-user-auth", "disabled", "-k8s-mode",
 			"off-cluster", "-k8s-auth", "bearer-token", "-k8s-mode-off-cluster-endpoint", "https://api-backplane.apps.something.com/backplane/cluster/cluster123",


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / Why we need it?
When using the `--image` flag on a non `linux/amd64` platform, the pull/run will fail due to a platform/architecture mismatch. This comes up in particular when running on an arm64 based mac with podman.

This forces the `--platform linux/amd64` flag on all podman image pulls. If you're running on a linux/amd64 platform, then this is a noop. But if you are using podman for mac, this will ensure you are always running the linux/amd64 version of the console image.

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
