### PR TITLE
Implement retry for eventual consistency in IAM updates

### DIFF
--- a/cmd/ocm-backplane/cloud/token.go
+++ b/cmd/ocm-backplane/cloud/token.go
@@ -56,10 +56,10 @@ func runToken(*cobra.Command, []string) error {
 	}
 
 	credsResponse := awsutil.AWSCredentialsResponse{
-		AccessKeyID:     *result.AccessKeyId,
-		SecretAccessKey: *result.SecretAccessKey,
-		SessionToken:    *result.SessionToken,
-		Expiration:      result.Expiration.String(),
+		AccessKeyID:     result.AccessKeyID,
+		SecretAccessKey: result.SecretAccessKey,
+		SessionToken:    result.SessionToken,
+		Expiration:      result.Expires.String(),
 	}
 
 	formattedResult, err := credsResponse.RenderOutput(tokenArgs.output)

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -16,6 +16,7 @@ type BackplaneConfiguration struct {
 	URL              string
 	ProxyURL         string
 	SessionDirectory string
+	AssumeInitialArn string
 }
 
 // GetConfigFilePath returns the Backplane CLI configuration filepath
@@ -71,6 +72,7 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 	bpConfig.URL = viper.GetString("url")
 	bpConfig.ProxyURL = viper.GetString("proxy-url")
 	bpConfig.SessionDirectory = viper.GetString("session-dir")
+	bpConfig.AssumeInitialArn = viper.GetString("assume-initial-arn")
 
 	return bpConfig, nil
 }


### PR DESCRIPTION
### What type of PR is this?
feature/bug fix

### What this PR does / Why we need it?
The retry mechanism built into the `sts.Client` from the AWS SDK doesn't properly handle issues of IAM updates requiring a few seconds to resolve, so we have to roll our own retry that recreates the client on every failure. See https://github.com/aws/aws-sdk-go-v2/issues/2332

### Which Jira/Github issue(s) does this PR fix?
[OSD-18992](https://issues.redhat.com//browse/OSD-18992)

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [x] Included documentation changes with PR
