### PR TITLE
[OSD-19019] Enable bp-cli to consume warning header from bp API's response

### DIFF
--- a/cmd/ocm-backplane/managedJob/createManagedJob.go
+++ b/cmd/ocm-backplane/managedJob/createManagedJob.go
@@ -175,7 +175,7 @@ func createJob(client BackplaneApi.ClientInterface) (*BackplaneApi.Job, error) {
 	// create job request
 	createJob := BackplaneApi.CreateJobJSONRequestBody{
 		CanonicalName: &options.canonicalName,
-		Parameters: &jobParams,
+		Parameters:    &jobParams,
 	}
 
 	// call create end point
@@ -183,6 +183,11 @@ func createJob(client BackplaneApi.ClientInterface) (*BackplaneApi.Job, error) {
 
 	if err != nil {
 		return nil, err
+	}
+
+	// Check for the warning header and display it if found.
+	if warningMsg := resp.Header.Get("Backplane-Warning"); warningMsg != "" {
+		fmt.Fprintln(os.Stderr, warningMsg)
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/cmd/ocm-backplane/managedJob/createManagedJob.go
+++ b/cmd/ocm-backplane/managedJob/createManagedJob.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	BackplaneApi "github.com/openshift/backplane-api/pkg/client"
+	logger "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -187,7 +188,7 @@ func createJob(client BackplaneApi.ClientInterface) (*BackplaneApi.Job, error) {
 
 	// Check for the warning header and display it if found.
 	if warningMsg := resp.Header.Get("Backplane-Warning"); warningMsg != "" {
-		fmt.Fprintln(os.Stderr, warningMsg)
+		logger.Warnf("warning: %s", warningMsg)
 	}
 
 	if resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
### What type of PR is this?

_feature_

### What does this PR do / Why we need it?
To have bp-cli enabled to consume the warning header from bp-API's response, so that, when running managed-script with `ocm-backplane`, it can post warnings if the `clusterVersions` is not specified in the metadata.yaml but still allow the script continue execute.

It's interdependent with the [MR-303](https://gitlab.cee.redhat.com/service/backplane-api/-/merge_requests/303)

