### PR TITLE
Make sure region is always present for credentials and console links

### DIFF
--- a/cmd/ocm-backplane/cloud/console.go
+++ b/cmd/ocm-backplane/cloud/console.go
@@ -149,12 +149,13 @@ func runConsole(cmd *cobra.Command, argv []string) (err error) {
 		if err != nil {
 			return fmt.Errorf("failed to get cloud credentials for cluster %v: %w", clusterID, err)
 		}
-		resp, err := awsutil.GetSigninToken(targetCredentials)
+
+		resp, err := awsutil.GetSigninToken(targetCredentials, cluster.Region().ID())
 		if err != nil {
 			return fmt.Errorf("failed to get signin token: %w", err)
 		}
 
-		signinFederationURL, err := awsutil.GetConsoleURL(resp.SigninToken)
+		signinFederationURL, err := awsutil.GetConsoleURL(resp.SigninToken, cluster.Region().ID())
 		if err != nil {
 			return fmt.Errorf("failed to generate console url: %w", err)
 		}

--- a/pkg/awsutil/sts_test.go
+++ b/pkg/awsutil/sts_test.go
@@ -226,6 +226,7 @@ func TestGetSigninToken(t *testing.T) {
 		SecretAccessKey: "testSecretAccessKey",
 		SessionToken:    "testSessionToken",
 	}
+	region := "us-east-1"
 	tests := []struct {
 		name        string
 		httpGetFunc func(url string) (resp *http.Response, err error)
@@ -276,7 +277,7 @@ func TestGetSigninToken(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			httpGetFunc = tt.httpGetFunc
-			got, err := GetSigninToken(awsCredentials)
+			got, err := GetSigninToken(awsCredentials, region)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetSigninToken() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -300,7 +301,7 @@ func TestGetConsoleUrl(t *testing.T) {
 			signinToken: "the_token",
 			want: &url.URL{
 				Scheme:   "https",
-				Host:     "signin.aws.amazon.com",
+				Host:     "us-east-1.signin.aws.amazon.com",
 				Path:     "/federation",
 				RawQuery: "Action=login&Destination=https%3A%2F%2Fconsole.aws.amazon.com%2F&Issuer=Red+Hat+SRE&SigninToken=the_token",
 			},
@@ -308,7 +309,7 @@ func TestGetConsoleUrl(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetConsoleURL(tt.signinToken)
+			got, err := GetConsoleURL(tt.signinToken, "us-east-1")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetConsoleURL() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
### What type of PR is this?

_bug_

### What this PR does / Why we need it?

Changes for the new flow made it so that "region" wasn't being set when requesting credentials for old and new clusters, or a console link for new clusters.

### Which Jira/Github issue(s) does this PR fix?

_Resolves OSD-19492_

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
