### PR TITLE
fall back to old flow if new flow fails

### DIFF
--- a/cmd/ocm-backplane/cloud/console.go
+++ b/cmd/ocm-backplane/cloud/console.go
@@ -147,19 +147,25 @@ func runConsole(cmd *cobra.Command, argv []string) (err error) {
 	if isolatedBackplane {
 		targetCredentials, err := getIsolatedCredentials(clusterID)
 		if err != nil {
-			return fmt.Errorf("failed to get cloud credentials for cluster %v: %w", clusterID, err)
-		}
+			// itn-2023-00143 handle case where customer's org is on the isolated flow,
+			// but they have not yet migrated their account roles
+			fmt.Println("Cluster's org is using new flow but cluster has not migrated to new account roles. Trying old flow...")
+			consoleResponse, err = getCloudConsole(bpURL, clusterID)
+			if err != nil {
+				return err
+			}
+		} else {
+			resp, err := awsutil.GetSigninToken(targetCredentials, cluster.Region().ID())
+			if err != nil {
+				return fmt.Errorf("failed to get signin token: %w", err)
+			}
 
-		resp, err := awsutil.GetSigninToken(targetCredentials, cluster.Region().ID())
-		if err != nil {
-			return fmt.Errorf("failed to get signin token: %w", err)
+			signinFederationURL, err := awsutil.GetConsoleURL(resp.SigninToken, cluster.Region().ID())
+			if err != nil {
+				return fmt.Errorf("failed to generate console url: %w", err)
+			}
+			consoleResponse = &ConsoleResponse{ConsoleLink: signinFederationURL.String()}
 		}
-
-		signinFederationURL, err := awsutil.GetConsoleURL(resp.SigninToken, cluster.Region().ID())
-		if err != nil {
-			return fmt.Errorf("failed to generate console url: %w", err)
-		}
-		consoleResponse = &ConsoleResponse{ConsoleLink: signinFederationURL.String()}
 	} else {
 		consoleResponse, err = getCloudConsole(bpURL, clusterID)
 		if err != nil {

--- a/pkg/awsutil/sts.go
+++ b/pkg/awsutil/sts.go
@@ -22,7 +22,7 @@ const (
 	AwsConsoleURL                      = "https://console.aws.amazon.com/"
 	DefaultIssuer                      = "Red Hat SRE"
 
-	assumeRoleMaxRetries   = 5
+	assumeRoleMaxRetries   = 3
 	assumeRoleRetryBackoff = 5 * time.Second
 )
 


### PR DESCRIPTION
Hotfix for incident itn-2023-00143

Steps taken to test:
1. On a cluster that was known to be affected by this incident, run `ocm backplane cloud console` and `ocm backplane cloud credentials`
2. See that the isolated flow was attempted, failed, and fell back to the old flow as evidenced by a message printed to the console.
3. Take a new cluster that should in fact be using the new flow, run `ocm backplane cloud console` and `ocm backplane cloud credentials`
4. See that the isolated flow was attempted and succeeded without falling back to the old flow.