### PR TITLE
Reimplement a way to retrieve an aws-sdk-go-v2 config from backplane

### DIFF
--- a/cmd/ocm-backplane/cloud/credentials_test.go
+++ b/cmd/ocm-backplane/cloud/credentials_test.go
@@ -8,24 +8,23 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"testing"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/clientcmd/api"
-	"sigs.k8s.io/yaml"
-
 	"github.com/openshift/backplane-cli/pkg/cli/config"
 	"github.com/openshift/backplane-cli/pkg/client/mocks"
 	bpCredentials "github.com/openshift/backplane-cli/pkg/credentials"
 	"github.com/openshift/backplane-cli/pkg/info"
 	"github.com/openshift/backplane-cli/pkg/utils"
 	mocks2 "github.com/openshift/backplane-cli/pkg/utils/mocks"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 //nolint:gosec
@@ -33,13 +32,11 @@ var _ = Describe("Cloud console command", func() {
 
 	var (
 		mockCtrl           *gomock.Controller
-		mockClient         *mocks.MockClientInterface
 		mockClientWithResp *mocks.MockClientWithResponsesInterface
 		mockOcmInterface   *mocks2.MockOCMInterface
 		mockClientUtil     *mocks2.MockClientUtils
 		mockClusterUtils   *mocks2.MockClusterUtils
 
-		trueClusterID string
 		proxyURI      string
 		credentialAWS string
 		credentialGcp string
@@ -53,7 +50,6 @@ var _ = Describe("Cloud console command", func() {
 
 	BeforeEach(func() {
 		mockCtrl = gomock.NewController(GinkgoT())
-		mockClient = mocks.NewMockClientInterface(mockCtrl)
 		mockClientWithResp = mocks.NewMockClientWithResponsesInterface(mockCtrl)
 
 		mockOcmInterface = mocks2.NewMockOCMInterface(mockCtrl)
@@ -66,7 +62,6 @@ var _ = Describe("Cloud console command", func() {
 		utils.DefaultClusterUtils = mockClusterUtils
 		utils.DefaultClientUtils = mockClientUtil
 
-		trueClusterID = "trueID123"
 		proxyURI = "https://shard.apps"
 		credentialAWS = "fake aws credential"
 		credentialGcp = "fake gcp credential"
@@ -83,7 +78,7 @@ var _ = Describe("Cloud console command", func() {
 		}
 		fakeAWSResp.Header.Add("Content-Type", "json")
 
-		// Define fake AWS response
+		// Define fake GCP response
 		fakeGCloudResp = &http.Response{
 			Body: MakeIoReader(
 				fmt.Sprintf(`{"proxy_uri":"proxy", "message":"msg", "JSON200":"%s"}`, credentialGcp),
@@ -145,67 +140,6 @@ var _ = Describe("Cloud console command", func() {
 		mockCtrl.Finish()
 	})
 
-	Context("test get Cloud Credential", func() {
-
-		It("should return AWS cloud credential", func() {
-
-			mockClientUtil.EXPECT().GetBackplaneClient(proxyURI).Return(mockClient, nil).AnyTimes()
-			mockClient.EXPECT().GetCloudCredentials(gomock.Any(), trueClusterID).Return(fakeAWSResp, nil)
-
-			crdentialResponse, err := GetCloudCredentials(proxyURI, trueClusterID)
-			Expect(err).To(BeNil())
-
-			Expect(crdentialResponse.JSON200).NotTo(BeNil())
-
-		})
-
-		It("should fail when AWS Unavailable", func() {
-			fakeAWSResp.StatusCode = http.StatusInternalServerError
-
-			mockClientUtil.EXPECT().GetBackplaneClient(proxyURI).Return(mockClient, nil).AnyTimes()
-			mockClient.EXPECT().GetCloudCredentials(gomock.Any(), trueClusterID).Return(fakeAWSResp, nil)
-			_, err := GetCloudCredentials(proxyURI, trueClusterID)
-			Expect(err).NotTo(BeNil())
-
-			Expect(err.Error()).To(ContainSubstring("error from backplane: \n Status Code: 500\n"))
-
-		})
-
-		It("should fail when GCP Unavailable", func() {
-			fakeGCloudResp.StatusCode = http.StatusInternalServerError
-
-			mockClientUtil.EXPECT().GetBackplaneClient(proxyURI).Return(mockClient, nil).AnyTimes()
-			mockClient.EXPECT().GetCloudCredentials(gomock.Any(), trueClusterID).Return(fakeGCloudResp, nil)
-			_, err := GetCloudCredentials(proxyURI, trueClusterID)
-			Expect(err).NotTo(BeNil())
-
-			Expect(err.Error()).To(ContainSubstring("error from backplane: \n Status Code: 500\n"))
-
-		})
-
-		It("should fail when we can't parse the response from backplane", func() {
-			mockClientUtil.EXPECT().GetBackplaneClient(proxyURI).Return(mockClient, nil).AnyTimes()
-			mockClient.EXPECT().GetCloudCredentials(gomock.Any(), trueClusterID).Return(fakeMalformedJSONResp, nil)
-			_, err := GetCloudCredentials(proxyURI, trueClusterID)
-			Expect(err).NotTo(BeNil())
-
-			Expect(err.Error()).To(ContainSubstring(fmt.Errorf("unable to parse response body from backplane:\n  Status Code: %d", 200).Error()))
-
-		})
-
-		It("should fail for unauthorized BP-API", func() {
-			fakeAWSResp.StatusCode = http.StatusUnauthorized
-
-			mockClientUtil.EXPECT().GetBackplaneClient(proxyURI).Return(mockClient, nil).AnyTimes()
-			mockClient.EXPECT().GetCloudCredentials(gomock.Any(), trueClusterID).Return(fakeAWSResp, nil)
-			_, err := GetCloudCredentials(proxyURI, trueClusterID)
-			Expect(err).NotTo(BeNil())
-
-			Expect(err.Error()).Should(ContainSubstring("error from backplane: \n Status Code: 401\n"))
-
-		})
-	})
-
 	Context("test runCredentials", func() {
 		Context("one argument is given", func() {
 			It("returns an error if GetTargetCluster returns an error", func() {
@@ -227,8 +161,6 @@ var _ = Describe("Cloud console command", func() {
 
 				}
 
-				mockClusterUtils.EXPECT().GetCloudProvider(gomock.Any())
-
 				mockOcmInterface.EXPECT().GetTargetCluster(gomock.Any()).Return("foo", "bar", nil).AnyTimes()
 				mockOcmInterface.EXPECT().GetClusterInfoByID(gomock.Any()).Return(&cmv1.Cluster{}, nil).AnyTimes()
 				Expect(runCredentials(&cobra.Command{}, []string{"cluster-key"})).To(Equal(
@@ -236,174 +168,98 @@ var _ = Describe("Cloud console command", func() {
 				))
 			})
 
-			It("returns an error if we can't umarshal the cloud credentials response on aws", func() {
-				GetBackplaneConfiguration = func() (bpConfig config.BackplaneConfiguration, err error) {
-					return config.BackplaneConfiguration{
-						URL: "https://foo.bar",
-					}, nil
-				}
+			Context("no arguments are given", func() {
+				It("returns the clusterinfo from GetBackplaneClusterFromConfig", func() {
+					GetBackplaneClusterFromConfig = func() (utils.BackplaneCluster, error) {
+						return utils.BackplaneCluster{
+							ClusterID: "mockcluster",
+						}, nil
+					}
 
-				mockOcmInterface.EXPECT().GetTargetCluster(gomock.Any()).Return("foo", "bar", nil).AnyTimes()
-				mockClusterUtils.EXPECT().GetCloudProvider(gomock.Any()).Return("aws").AnyTimes()
-				mockClientUtil.EXPECT().GetBackplaneClient("https://foo.bar").Return(mockClient, nil).Times(1)
+					mockOcmInterface.EXPECT().GetClusterInfoByID(gomock.Any()).Return(&cmv1.Cluster{}, errors.New("error")).AnyTimes()
+					mockOcmInterface.EXPECT().GetTargetCluster("mockcluster").Times(1)
 
-				mockClient.EXPECT().GetCloudCredentials(gomock.Any(), "foo").Return(fakeBrokenAWSResp, nil).Times(1)
-				mockOcmInterface.EXPECT().GetClusterInfoByID(gomock.Any()).Return(&cmv1.Cluster{}, nil).AnyTimes()
-				Expect(runCredentials(&cobra.Command{}, []string{"foo"}).Error()).To(ContainSubstring("unable to unmarshal AWS credentials response from backplane"))
+					_ = runCredentials(&cobra.Command{}, []string{})
+				})
+
+				It("returns an error from GetBackplaneClusterFromConfig", func() {
+					GetBackplaneClusterFromConfig = func() (utils.BackplaneCluster, error) {
+						return utils.BackplaneCluster{}, errors.New("bp error")
+					}
+
+					Expect(runCredentials(&cobra.Command{}, []string{})).To(Equal(errors.New("bp error")))
+				})
 			})
 
-			It("returns an error if we can't umarshal the cloud credentials response on gcp", func() {
-				GetBackplaneConfiguration = func() (bpConfig config.BackplaneConfiguration, err error) {
-					return config.BackplaneConfiguration{
-						URL: "https://foo.bar",
-					}, nil
-				}
-
-				mockOcmInterface.EXPECT().GetTargetCluster(gomock.Any()).Return("foo", "bar", nil).AnyTimes()
-				mockClusterUtils.EXPECT().GetCloudProvider(gomock.Any()).Return("gcp").AnyTimes()
-				mockClientUtil.EXPECT().GetBackplaneClient("https://foo.bar").Return(mockClient, nil).Times(1)
-
-				mockClient.EXPECT().GetCloudCredentials(gomock.Any(), "foo").Return(fakeBrokenGCPResp, nil).Times(1)
-				mockOcmInterface.EXPECT().GetClusterInfoByID(gomock.Any()).Return(&cmv1.Cluster{}, nil).AnyTimes()
-				Expect(runCredentials(&cobra.Command{}, []string{"foo"}).Error()).To(ContainSubstring("unable to unmarshal GCP credentials response from backplane"))
+			It("errors if more than one cluster keys are given", func() {
+				err := runCredentials(&cobra.Command{}, []string{"two", "cluster-keys"})
+				Expect(err).To(Equal(fmt.Errorf("expected exactly one cluster")))
 			})
-
-			It("returns an error if there is an unknown cloud provider", func() {
-				GetBackplaneConfiguration = func() (bpConfig config.BackplaneConfiguration, err error) {
-					return config.BackplaneConfiguration{
-						URL: "https://foo.bar",
-					}, nil
-				}
-				mockClient.EXPECT().GetCloudCredentials(gomock.Any(), "foo").Return(fakeBrokenGCPResp, nil).Times(1)
-				mockClientUtil.EXPECT().GetBackplaneClient("https://foo.bar").Return(mockClient, nil).Times(1)
-				mockOcmInterface.EXPECT().GetTargetCluster(gomock.Any()).Return("foo", "bar", nil).AnyTimes()
-				mockOcmInterface.EXPECT().GetClusterInfoByID(gomock.Any()).Return(&cmv1.Cluster{}, nil).AnyTimes()
-				mockClusterUtils.EXPECT().GetCloudProvider(gomock.Any()).Return("azure").AnyTimes()
-
-				Expect(runCredentials(&cobra.Command{}, []string{"cluster-key"})).To(Equal(
-					fmt.Errorf("unsupported cloud provider: %s", "azure"),
-				))
-			})
-		})
-
-		Context("no arguments are given", func() {
-			It("returns the clusterinfo from GetBackplaneClusterFromConfig", func() {
-				GetBackplaneClusterFromConfig = func() (utils.BackplaneCluster, error) {
-					return utils.BackplaneCluster{
-						ClusterID: "mockcluster",
-					}, nil
-				}
-
-				mockOcmInterface.EXPECT().GetClusterInfoByID(gomock.Any()).Return(&cmv1.Cluster{}, errors.New("error")).AnyTimes()
-				mockOcmInterface.EXPECT().GetTargetCluster("mockcluster").Times(1)
-
-				_ = runCredentials(&cobra.Command{}, []string{})
-			})
-
-			It("returns an error from GetBackplaneClusterFromConfig", func() {
-				GetBackplaneClusterFromConfig = func() (utils.BackplaneCluster, error) {
-					return utils.BackplaneCluster{}, errors.New("bp error")
-				}
-
-				Expect(runCredentials(&cobra.Command{}, []string{})).To(Equal(errors.New("bp error")))
-			})
-		})
-
-		It("errors if more than one cluster keys are given", func() {
-			err := runCredentials(&cobra.Command{}, []string{"two", "cluster-keys"})
-			Expect(err).To(Equal(fmt.Errorf("expected exactly one cluster")))
-		})
-	})
-
-	Context("test renderCloudCredentials", func() {
-		creds := bpCredentials.AWSCredentialsResponse{
-			AccessKeyID:     "foo",
-			SecretAccessKey: "bar",
-			SessionToken:    "baz",
-			Region:          "quux",
-		}
-
-		It("prints the format export if the env output flag is supplied", func() {
-			export := creds.FmtExport()
-
-			Expect(renderCloudCredentials("env", &creds)).To(Equal(export))
-		})
-
-		It("prints the yaml export if the env output flag is supplied", func() {
-			yamlBytes, _ := yaml.Marshal(creds)
-			Expect(renderCloudCredentials("yaml", &creds)).To(ContainSubstring(string(yamlBytes)))
-		})
-
-		It("prints the yaml export if the env output flag is supplied", func() {
-			yamlBytes, _ := yaml.Marshal(creds)
-			Expect(renderCloudCredentials("yaml", &creds)).To(ContainSubstring(string(yamlBytes)))
-		})
-
-		It("prints the json export if the json output flagis supplied", func() {
-			jsonBytes, _ := json.Marshal(creds)
-			Expect(renderCloudCredentials("json", &creds)).To(ContainSubstring(string(jsonBytes)))
-		})
-
-		It("prints the default string export if no output flag is supplied", func() {
-			Expect(renderCloudCredentials("", &creds)).To(ContainSubstring(creds.String()))
-		})
-	})
-	Context("TestAWSCredentialsResponseString(", func() {
-		It("It formats the output correctly", func() {
-			r := &bpCredentials.AWSCredentialsResponse{
-				AccessKeyID:     "12345",
-				SecretAccessKey: "56789",
-				SessionToken:    "sessiontoken",
-				Region:          "region",
-				Expiration:      "expir",
-			}
-
-			formattedcreds := `Temporary Credentials:
-  AccessKeyID: 12345
-  SecretAccessKey: 56789
-  SessionToken: sessiontoken
-  Region: region
-  Expires: expir`
-			Expect(formattedcreds).To(Equal(r.String()))
-		})
-	})
-	Context("TestGCPCredentialsResponseString", func() {
-		It("It formats the output correctly", func() {
-			r := &bpCredentials.GCPCredentialsResponse{
-				ProjectID: "foo",
-			}
-			expect := `If this is your first time, run "gcloud auth login" and then
-gcloud config set project foo`
-
-			Expect(expect).To(Equal(r.String()))
-		})
-	})
-	Context("TestAWSCredentialsResponseFmtEformattedcredsxport", func() {
-		It("It formats the output correctly", func() {
-			r := &bpCredentials.AWSCredentialsResponse{
-				AccessKeyID:     "foo",
-				SecretAccessKey: "bar",
-				SessionToken:    "baz",
-				Region:          "quux",
-				Expiration:      "now",
-			}
-
-			awsExportOut := `export AWS_ACCESS_KEY_ID=foo
-export AWS_SECRET_ACCESS_KEY=bar
-export AWS_SESSION_TOKEN=baz
-export AWS_DEFAULT_REGION=quux`
-			Expect(awsExportOut).To(Equal(r.FmtExport()))
-		})
-	})
-	Context("TestGCPCredentialsResponseFmtExport", func() {
-		It("It formats the output correctly", func() {
-			r := &bpCredentials.GCPCredentialsResponse{
-				ProjectID: "foo",
-			}
-
-			gcpExportFormatOut := `export CLOUDSDK_CORE_PROJECT=foo`
-
-			Expect(gcpExportFormatOut).To(Equal(r.FmtExport()))
 		})
 	})
 })
+
+func TestRenderCloudCredentials(t *testing.T) {
+	fakeAWSCredentialsResponse := &bpCredentials.AWSCredentialsResponse{
+		AccessKeyID:     "foo",
+		SecretAccessKey: "bar",
+		SessionToken:    "baz",
+		Region:          "quux",
+	}
+
+	fakeGCPCredentialsResponse := &bpCredentials.GCPCredentialsResponse{
+		ProjectID: "foo",
+	}
+
+	tests := []struct {
+		name         string
+		outputFormat string
+		creds        bpCredentials.Response
+		expected     string
+	}{
+		{
+			name:         "AWS empty",
+			outputFormat: "",
+			creds:        fakeAWSCredentialsResponse,
+			expected:     fakeAWSCredentialsResponse.String(),
+		},
+		{
+			name:         "AWS env",
+			outputFormat: "env",
+			creds:        fakeAWSCredentialsResponse,
+			expected:     fakeAWSCredentialsResponse.FmtExport(),
+		},
+		{
+			name:         "AWS json",
+			outputFormat: "json",
+			creds:        fakeAWSCredentialsResponse,
+			expected:     `{"AccessKeyID":"foo","SecretAccessKey":"bar","SessionToken":"baz","Region":"quux","Expiration":""}`,
+		},
+		{
+			name:         "AWS yaml",
+			outputFormat: "yaml",
+			creds:        fakeAWSCredentialsResponse,
+			expected: `AccessKeyID: foo
+Expiration: ""
+Region: quux
+SecretAccessKey: bar
+SessionToken: baz
+`,
+		},
+		{
+			name:         "GCP env",
+			outputFormat: "env",
+			creds:        fakeGCPCredentialsResponse,
+			expected:     fakeGCPCredentialsResponse.FmtExport(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, _ := renderCloudCredentials(test.outputFormat, test.creds)
+			if test.expected != actual {
+				t.Errorf("expected: %v, got: %v", test.expected, actual)
+			}
+		})
+	}
+}

--- a/cmd/ocm-backplane/cloud/credentials_test.go
+++ b/cmd/ocm-backplane/cloud/credentials_test.go
@@ -152,7 +152,7 @@ var _ = Describe("Cloud console command", func() {
 			mockClientUtil.EXPECT().GetBackplaneClient(proxyURI).Return(mockClient, nil).AnyTimes()
 			mockClient.EXPECT().GetCloudCredentials(gomock.Any(), trueClusterID).Return(fakeAWSResp, nil)
 
-			crdentialResponse, err := getCloudCredential(proxyURI, trueClusterID)
+			crdentialResponse, err := GetCloudCredentials(proxyURI, trueClusterID)
 			Expect(err).To(BeNil())
 
 			Expect(crdentialResponse.JSON200).NotTo(BeNil())
@@ -164,7 +164,7 @@ var _ = Describe("Cloud console command", func() {
 
 			mockClientUtil.EXPECT().GetBackplaneClient(proxyURI).Return(mockClient, nil).AnyTimes()
 			mockClient.EXPECT().GetCloudCredentials(gomock.Any(), trueClusterID).Return(fakeAWSResp, nil)
-			_, err := getCloudCredential(proxyURI, trueClusterID)
+			_, err := GetCloudCredentials(proxyURI, trueClusterID)
 			Expect(err).NotTo(BeNil())
 
 			Expect(err.Error()).To(ContainSubstring("error from backplane: \n Status Code: 500\n"))
@@ -176,7 +176,7 @@ var _ = Describe("Cloud console command", func() {
 
 			mockClientUtil.EXPECT().GetBackplaneClient(proxyURI).Return(mockClient, nil).AnyTimes()
 			mockClient.EXPECT().GetCloudCredentials(gomock.Any(), trueClusterID).Return(fakeGCloudResp, nil)
-			_, err := getCloudCredential(proxyURI, trueClusterID)
+			_, err := GetCloudCredentials(proxyURI, trueClusterID)
 			Expect(err).NotTo(BeNil())
 
 			Expect(err.Error()).To(ContainSubstring("error from backplane: \n Status Code: 500\n"))
@@ -186,7 +186,7 @@ var _ = Describe("Cloud console command", func() {
 		It("should fail when we can't parse the response from backplane", func() {
 			mockClientUtil.EXPECT().GetBackplaneClient(proxyURI).Return(mockClient, nil).AnyTimes()
 			mockClient.EXPECT().GetCloudCredentials(gomock.Any(), trueClusterID).Return(fakeMalformedJSONResp, nil)
-			_, err := getCloudCredential(proxyURI, trueClusterID)
+			_, err := GetCloudCredentials(proxyURI, trueClusterID)
 			Expect(err).NotTo(BeNil())
 
 			Expect(err.Error()).To(ContainSubstring(fmt.Errorf("unable to parse response body from backplane:\n  Status Code: %d", 200).Error()))
@@ -198,7 +198,7 @@ var _ = Describe("Cloud console command", func() {
 
 			mockClientUtil.EXPECT().GetBackplaneClient(proxyURI).Return(mockClient, nil).AnyTimes()
 			mockClient.EXPECT().GetCloudCredentials(gomock.Any(), trueClusterID).Return(fakeAWSResp, nil)
-			_, err := getCloudCredential(proxyURI, trueClusterID)
+			_, err := GetCloudCredentials(proxyURI, trueClusterID)
 			Expect(err).NotTo(BeNil())
 
 			Expect(err.Error()).Should(ContainSubstring("error from backplane: \n Status Code: 401\n"))

--- a/pkg/utils/cluster.go
+++ b/pkg/utils/cluster.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 	"regexp"
 
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	logger "github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -22,7 +21,6 @@ type ClusterUtils interface {
 	GetClusterIDAndHostFromClusterURL(clusterURL string) (string, string, error)
 	GetBackplaneClusterFromConfig() (BackplaneCluster, error)
 	GetBackplaneClusterFromClusterKey(clusterKey string) (BackplaneCluster, error)
-	GetCloudProvider(cluster *cmv1.Cluster) string
 	GetBackplaneCluster(params ...string) (BackplaneCluster, error)
 }
 
@@ -108,9 +106,4 @@ func (s *DefaultClusterUtilsImpl) GetBackplaneCluster(params ...string) (Backpla
 		return s.GetBackplaneClusterFromClusterKey(params[0])
 	}
 	return s.GetBackplaneClusterFromConfig()
-}
-
-// GetCloudProvider gets the cluster's cloud provider
-func (s *DefaultClusterUtilsImpl) GetCloudProvider(cluster *cmv1.Cluster) string {
-	return cluster.CloudProvider().ID()
 }

--- a/pkg/utils/mocks/ClusterMock.go
+++ b/pkg/utils/mocks/ClusterMock.go
@@ -8,7 +8,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	utils "github.com/openshift/backplane-cli/pkg/utils"
 )
 
@@ -82,20 +81,6 @@ func (m *MockClusterUtils) GetBackplaneClusterFromConfig() (utils.BackplaneClust
 func (mr *MockClusterUtilsMockRecorder) GetBackplaneClusterFromConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackplaneClusterFromConfig", reflect.TypeOf((*MockClusterUtils)(nil).GetBackplaneClusterFromConfig))
-}
-
-// GetCloudProvider mocks base method.
-func (m *MockClusterUtils) GetCloudProvider(arg0 *v1.Cluster) string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCloudProvider", arg0)
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetCloudProvider indicates an expected call of GetCloudProvider.
-func (mr *MockClusterUtilsMockRecorder) GetCloudProvider(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCloudProvider", reflect.TypeOf((*MockClusterUtils)(nil).GetCloudProvider), arg0)
 }
 
 // GetClusterIDAndHostFromClusterURL mocks base method.

--- a/pkg/utils/ocmWrapper.go
+++ b/pkg/utils/ocmWrapper.go
@@ -267,6 +267,8 @@ func (*DefaultOCMInterfaceImpl) GetStsSupportJumpRoleARN(clusterID string) (stri
 	if err != nil {
 		return "", fmt.Errorf("failed to create OCM connection: %v", err)
 	}
+	defer connection.Close()
+
 	response, err := connection.ClustersMgmt().V1().Clusters().Cluster(clusterID).StsSupportJumpRole().Get().Send()
 	if err != nil {
 		return "", fmt.Errorf("failed to get STS Support Jump Role for cluster %v, %w", clusterID, err)


### PR DESCRIPTION
### What type of PR is this?
bug/feature

### What this PR does / Why we need it?
This functionality was originally added in #66, but was mistakenly removed in #237

Since we are now required to pass AWS calls through a proxy, this PR adds additional logic to ensure the aws-sdk-go-v2 client returned by this function enforces the use of the provided proxy_url in a user's backplane config file.

### Which Jira/Github issue(s) does this PR fix?
[OSD-19711](https://issues.redhat.com//browse/OSD-19711)

### Special notes for your reviewer
This is semi-urgent to merge+release because osdctl builds an aws-sdk-go-v2 client using this function https://github.com/openshift/osdctl/blob/1b906de67017e15057a6312d698ac28565250941/pkg/osdCloud/aws.go#L182-L190 pinned on an older version where it still exists: https://github.com/openshift/osdctl/blob/1b906de67017e15057a6312d698ac28565250941/go.mod#L38 so SRE's using commands like `osdctl network verify-egress`, `osdctl cluster resize infra`, etc. are not going through the proxy configured in backplane.

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
