### PR TITLE
Use unauthenticated STS client for assuming payer account role

### DIFF
--- a/cmd/ocm-backplane/cloud/console.go
+++ b/cmd/ocm-backplane/cloud/console.go
@@ -147,9 +147,10 @@ func runConsole(cmd *cobra.Command, argv []string) (err error) {
 	if isolatedBackplane {
 		targetCredentials, err := getIsolatedCredentials(clusterID)
 		if err != nil {
-			// itn-2023-00143 handle case where customer's org is on the isolated flow,
-			// but they have not yet migrated their account roles
-			fmt.Println("Cluster's org is using new flow but cluster has not migrated to new account roles. Trying old flow...")
+			// TODO: This fallback should be removed in the future
+			// TODO: when we are more confident in our ability to access clusters using the isolated flow
+			logger.Infof("failed to assume role with isolated backplane flow: %v", err)
+			logger.Infof("attempting to fallback to %s", OldFlowSupportRole)
 			consoleResponse, err = getCloudConsole(bpURL, clusterID)
 			if err != nil {
 				return err

--- a/cmd/ocm-backplane/cloud/credentials.go
+++ b/cmd/ocm-backplane/cloud/credentials.go
@@ -135,8 +135,9 @@ func getCloudCredentials(backplaneURL string, cluster *cmv1.Cluster) (bpCredenti
 		logger.Debugf("cluster is using isolated backplane")
 		targetCredentials, err := getIsolatedCredentials(cluster.ID())
 		if err != nil {
-			// itn-2023-00143 handle case where customer's org is on the isolated flow,
-			// but they have not yet migrated their account roles
+			// TODO: This fallback should be removed in the future
+			// TODO: when we are more confident in our ability to access clusters using the isolated flow
+			logger.Infof("failed to assume role with isolated backplane flow: %v", err)
 			logger.Infof("attempting to fallback to %s", OldFlowSupportRole)
 			return getCloudCredentialsFromBackplaneAPI(backplaneURL, cluster)
 		}

--- a/pkg/awsutil/sts.go
+++ b/pkg/awsutil/sts.go
@@ -39,18 +39,15 @@ type AWSSigninTokenResponse struct {
 var httpGetFunc = http.Get
 
 func StsClientWithProxy(proxyURL string) (*sts.Client, error) {
-	cfg, err := config.LoadDefaultConfig(context.TODO(),
-		config.WithRegion("us-east-1"), // We don't care about region here, but the API still wants to see one set
-		config.WithHTTPClient(&http.Client{
+	cfg := aws.Config{
+		Region: "us-east-1", // We don't care about region here, but the API still wants to see one set
+		HTTPClient: &http.Client{
 			Transport: &http.Transport{
 				Proxy: func(*http.Request) (*url.URL, error) {
 					return url.Parse(proxyURL)
 				},
 			},
-		}),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load default AWS config: %w", err)
+		},
 	}
 
 	return sts.NewFromConfig(cfg), nil


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / Why we need it?
Currently, the STS client tries to build from a default config. This causes the client to believe it should be an authenticated client, however unless someone exports AWS credential in their terminal, there won't be any credentials present. This PR removes the creation of an authenticated client as it is not needed, and instead creates a bare minimum config with only the necessary properties to create the STS client we need.

### Which Jira/Github issue(s) does this PR fix?
Resolves https://issues.redhat.com/browse/OSD-19733

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
