### PR TITLE
feat: allow creating aws config with a custom ocm token

### DIFF
--- a/cmd/ocm-backplane/cloud/common.go
+++ b/cmd/ocm-backplane/cloud/common.go
@@ -33,14 +33,9 @@ type namedRoleArn struct {
 	Arn  string `json:"arn"`
 }
 
-func getIsolatedCredentials(clusterID string) (aws.Credentials, error) {
+func getIsolatedCredentials(clusterID string, ocmToken *string) (aws.Credentials, error) {
 	if clusterID == "" {
 		return aws.Credentials{}, errors.New("must provide non-empty cluster ID")
-	}
-
-	ocmToken, err := utils.DefaultOCMInterface.GetOCMAccessToken()
-	if err != nil {
-		return aws.Credentials{}, fmt.Errorf("failed to retrieve OCM token: %w", err)
 	}
 
 	email, err := utils.GetStringFieldFromJWT(*ocmToken, "email")

--- a/pkg/utils/clientUtils.go
+++ b/pkg/utils/clientUtils.go
@@ -19,7 +19,7 @@ type ClientUtils interface {
 	MakeBackplaneAPIClientWithAccessToken(base, accessToken string) (BackplaneApi.ClientWithResponsesInterface, error)
 	MakeRawBackplaneAPIClientWithAccessToken(base, accessToken string) (BackplaneApi.ClientInterface, error)
 	MakeRawBackplaneAPIClient(base string) (BackplaneApi.ClientInterface, error)
-	GetBackplaneClient(backplaneURL string) (client BackplaneApi.ClientInterface, err error)
+	GetBackplaneClient(backplaneURL string, ocmToken *string) (client BackplaneApi.ClientInterface, err error)
 	SetClientProxyURL(proxyURL string) error
 }
 
@@ -94,7 +94,7 @@ func (s *DefaultClientUtilsImpl) MakeBackplaneAPIClient(base string) (BackplaneA
 }
 
 // GetBackplaneClient returns authenticated Backplane API client
-func (s *DefaultClientUtilsImpl) GetBackplaneClient(backplaneURL string) (client BackplaneApi.ClientInterface, err error) {
+func (s *DefaultClientUtilsImpl) GetBackplaneClient(backplaneURL string, ocmToken *string) (client BackplaneApi.ClientInterface, err error) {
 	if backplaneURL == "" {
 		bpConfig, err := config.GetBackplaneConfiguration()
 		backplaneURL = bpConfig.URL
@@ -104,16 +104,8 @@ func (s *DefaultClientUtilsImpl) GetBackplaneClient(backplaneURL string) (client
 		logger.Infof("Using backplane URL: %s\n", backplaneURL)
 	}
 
-	// Get backplane API client
-	logger.Debugln("Finding ocm token")
-	accessToken, err := DefaultOCMInterface.GetOCMAccessToken()
-	if err != nil {
-		return client, err
-	}
-	logger.Debugln("Found OCM access token")
-
 	logger.Debugln("Getting client")
-	backplaneClient, err := DefaultClientUtils.MakeRawBackplaneAPIClientWithAccessToken(backplaneURL, *accessToken)
+	backplaneClient, err := DefaultClientUtils.MakeRawBackplaneAPIClientWithAccessToken(backplaneURL, *ocmToken)
 	if err != nil {
 		return client, fmt.Errorf("unable to create backplane api client: %w", err)
 	}

--- a/pkg/utils/mocks/clientUtilsMock.go
+++ b/pkg/utils/mocks/clientUtilsMock.go
@@ -35,18 +35,18 @@ func (m *MockClientUtils) EXPECT() *MockClientUtilsMockRecorder {
 }
 
 // GetBackplaneClient mocks base method.
-func (m *MockClientUtils) GetBackplaneClient(arg0 string) (Openapi.ClientInterface, error) {
+func (m *MockClientUtils) GetBackplaneClient(arg0 string, arg1 *string) (Openapi.ClientInterface, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackplaneClient", arg0)
+	ret := m.ctrl.Call(m, "GetBackplaneClient", arg0, arg1)
 	ret0, _ := ret[0].(Openapi.ClientInterface)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBackplaneClient indicates an expected call of GetBackplaneClient.
-func (mr *MockClientUtilsMockRecorder) GetBackplaneClient(arg0 interface{}) *gomock.Call {
+func (mr *MockClientUtilsMockRecorder) GetBackplaneClient(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackplaneClient", reflect.TypeOf((*MockClientUtils)(nil).GetBackplaneClient), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackplaneClient", reflect.TypeOf((*MockClientUtils)(nil).GetBackplaneClient), arg0, arg1)
 }
 
 // MakeBackplaneAPIClient mocks base method.


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / Why we need it?

This PR allows passing an ocm token to create an AWSV2 config, as we don't always have an offline token as ENV var/config file. 

This is needed because CAD uses client-id and client-secret to authenticate, and generates a token on the fly, this PR allows it to pass a token directly.
Needed for https://issues.redhat.com/browse/SDE-3276

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
