### PR TITLE
feat: make proxy configurable

### DIFF
--- a/cmd/ocm-backplane/cloud/common.go
+++ b/cmd/ocm-backplane/cloud/common.go
@@ -14,9 +14,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	ocmsdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	BackplaneApi "github.com/openshift/backplane-api/pkg/client"
 	"github.com/openshift/backplane-cli/pkg/awsutil"
 	"github.com/openshift/backplane-cli/pkg/cli/config"
+	bpCredentials "github.com/openshift/backplane-cli/pkg/credentials"
 	"github.com/openshift/backplane-cli/pkg/utils"
+	logger "github.com/sirupsen/logrus"
 )
 
 const OldFlowSupportRole = "role/RH-Technical-Support-Access"
@@ -30,6 +33,175 @@ var AssumeRoleSequence = awsutil.AssumeRoleSequence
 type QueryConfig struct {
 	config.BackplaneConfiguration
 	OcmConnection *ocmsdk.Connection
+	Cluster       *cmv1.Cluster
+}
+
+// GetAWSV2Config allows consumers to get an aws-sdk-go-v2 Config to programmatically access the AWS API
+func (cfg *QueryConfig) GetAWSV2Config() (aws.Config, error) {
+	if cfg.Cluster.CloudProvider().ID() != "aws" {
+		return aws.Config{}, fmt.Errorf("only supported for the aws cloud provider, this cluster has: %s", cfg.Cluster.CloudProvider().ID())
+	}
+	creds, err := cfg.GetCloudCredentials()
+	if err != nil {
+		return aws.Config{}, err
+	}
+
+	awsCreds, ok := creds.(*bpCredentials.AWSCredentialsResponse)
+	if !ok {
+		return aws.Config{}, errors.New("unexpected error: failed to convert backplane creds to AWSCredentialsResponse")
+	}
+
+	return awsCreds.AWSV2Config()
+}
+
+// GetCloudCredentials returns Cloud Credentials Response
+func (cfg *QueryConfig) GetCloudConsole() (*ConsoleResponse, error) {
+	ocmToken, _, err := cfg.OcmConnection.Tokens()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get token for ocm connection")
+	}
+
+	isolatedBackplane, err := isIsolatedBackplaneAccess(cfg.Cluster, cfg.OcmConnection)
+	if err != nil {
+		logger.Infof("failed to determine if the cluster is using isolated backplane access: %v", err)
+		logger.Infof("for more information, try ocm get /api/clusters_mgmt/v1/clusters/%s/sts_support_jump_role", cfg.Cluster.ID())
+		logger.Infof("attempting to fallback to %s", OldFlowSupportRole)
+	}
+
+	if isolatedBackplane {
+		logger.Debugf("cluster is using isolated backplane")
+		targetCredentials, err := cfg.getIsolatedCredentials(ocmToken)
+		if err != nil {
+			// TODO: This fallback should be removed in the future
+			// TODO: when we are more confident in our ability to access clusters using the isolated flow
+			logger.Infof("failed to assume role with isolated backplane flow: %v", err)
+			logger.Infof("attempting to fallback to %s", OldFlowSupportRole)
+			return cfg.getCloudConsoleFromPublicAPI(ocmToken)
+		}
+
+		resp, err := awsutil.GetSigninToken(targetCredentials, cfg.Cluster.Region().ID())
+		if err != nil {
+			return nil, fmt.Errorf("failed to get signin token: %w", err)
+		}
+
+		signinFederationURL, err := awsutil.GetConsoleURL(resp.SigninToken, cfg.Cluster.Region().ID())
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate console url: %w", err)
+		}
+		return &ConsoleResponse{ConsoleLink: signinFederationURL.String()}, nil
+	}
+
+	return cfg.getCloudConsoleFromPublicAPI(ocmToken)
+}
+
+// GetCloudConsole returns console response calling to public Backplane API
+func (cfg *QueryConfig) getCloudConsoleFromPublicAPI(ocmToken string) (*ConsoleResponse, error) {
+	logger.Debugln("Getting Cloud Console")
+
+	client, err := utils.DefaultClientUtils.GetBackplaneClient(cfg.BackplaneConfiguration.URL, ocmToken, cfg.BackplaneConfiguration.ProxyURL)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.GetCloudConsole(context.TODO(), cfg.Cluster.ID())
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, utils.TryPrintAPIError(resp, false)
+	}
+
+	credsResp, err := BackplaneApi.ParseGetCloudConsoleResponse(resp)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse response body from backplane:\n  Status Code: %d", resp.StatusCode)
+	}
+
+	if len(credsResp.Body) == 0 {
+		return nil, fmt.Errorf("empty response from backplane")
+	}
+
+	cliResp := &ConsoleResponse{}
+	cliResp.ConsoleLink = *credsResp.JSON200.ConsoleLink
+
+	return cliResp, nil
+}
+
+// GetCloudCredentials returns Cloud Credentials Response
+func (cfg *QueryConfig) GetCloudCredentials() (bpCredentials.Response, error) {
+	ocmToken, _, err := cfg.OcmConnection.Tokens()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get token for ocm connection")
+	}
+
+	isolatedBackplane, err := isIsolatedBackplaneAccess(cfg.Cluster, cfg.OcmConnection)
+	if err != nil {
+		logger.Infof("failed to determine if the cluster is using isolated backplane access: %v", err)
+		logger.Infof("for more information, try ocm get /api/clusters_mgmt/v1/clusters/%s/sts_support_jump_role", cfg.Cluster.ID())
+		logger.Infof("attempting to fallback to %s", OldFlowSupportRole)
+	}
+
+	if isolatedBackplane {
+		logger.Debugf("cluster is using isolated backplane")
+		targetCredentials, err := cfg.getIsolatedCredentials(ocmToken)
+		if err != nil {
+			// TODO: This fallback should be removed in the future
+			// TODO: when we are more confident in our ability to access clusters using the isolated flow
+			logger.Infof("failed to assume role with isolated backplane flow: %v", err)
+			logger.Infof("attempting to fallback to %s", OldFlowSupportRole)
+			return cfg.getCloudCredentialsFromBackplaneAPI(ocmToken)
+		}
+
+		return &bpCredentials.AWSCredentialsResponse{
+			AccessKeyID:     targetCredentials.AccessKeyID,
+			SecretAccessKey: targetCredentials.SecretAccessKey,
+			SessionToken:    targetCredentials.SessionToken,
+			Expiration:      targetCredentials.Expires.String(),
+			Region:          cfg.Cluster.Region().ID(),
+		}, nil
+	}
+
+	return cfg.getCloudCredentialsFromBackplaneAPI(ocmToken)
+}
+
+func (cfg *QueryConfig) getCloudCredentialsFromBackplaneAPI(ocmToken string) (bpCredentials.Response, error) {
+	client, err := utils.DefaultClientUtils.GetBackplaneClient(cfg.BackplaneConfiguration.URL, ocmToken, cfg.BackplaneConfiguration.ProxyURL)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.GetCloudCredentials(context.TODO(), cfg.Cluster.ID())
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, utils.TryPrintAPIError(resp, false)
+	}
+
+	logger.Debugln("Parsing response")
+
+	credsResp, err := BackplaneApi.ParseGetCloudCredentialsResponse(resp)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse response body from backplane:\n  Status Code: %d : err: %v", resp.StatusCode, err)
+	}
+
+	switch cfg.Cluster.CloudProvider().ID() {
+	case "aws":
+		cliResp := &bpCredentials.AWSCredentialsResponse{}
+		if err := json.Unmarshal([]byte(*credsResp.JSON200.Credentials), cliResp); err != nil {
+			return nil, fmt.Errorf("unable to unmarshal AWS credentials response from backplane %s: %w", *credsResp.JSON200.Credentials, err)
+		}
+		cliResp.Region = cfg.Cluster.Region().ID()
+		return cliResp, nil
+	case "gcp":
+		cliResp := &bpCredentials.GCPCredentialsResponse{}
+		if err := json.Unmarshal([]byte(*credsResp.JSON200.Credentials), cliResp); err != nil {
+			return nil, fmt.Errorf("unable to unmarshal GCP credentials response from backplane %s: %w", *credsResp.JSON200.Credentials, err)
+		}
+		return cliResp, nil
+	default:
+		return nil, fmt.Errorf("unsupported cloud provider: %s", cfg.Cluster.CloudProvider().ID())
+	}
 }
 
 type assumeChainResponse struct {
@@ -41,12 +213,12 @@ type namedRoleArn struct {
 	Arn  string `json:"arn"`
 }
 
-func getIsolatedCredentials(clusterID string, cfg *QueryConfig, ocmToken *string) (aws.Credentials, error) {
-	if clusterID == "" {
+func (cfg *QueryConfig) getIsolatedCredentials(ocmToken string) (aws.Credentials, error) {
+	if cfg.Cluster.ID() == "" {
 		return aws.Credentials{}, errors.New("must provide non-empty cluster ID")
 	}
 
-	email, err := utils.GetStringFieldFromJWT(*ocmToken, "email")
+	email, err := utils.GetStringFieldFromJWT(ocmToken, "email")
 	if err != nil {
 		return aws.Credentials{}, fmt.Errorf("unable to extract email from given token: %w", err)
 	}
@@ -60,17 +232,17 @@ func getIsolatedCredentials(clusterID string, cfg *QueryConfig, ocmToken *string
 		return aws.Credentials{}, fmt.Errorf("failed to create sts client: %w", err)
 	}
 
-	seedCredentials, err := AssumeRoleWithJWT(*ocmToken, cfg.BackplaneConfiguration.AssumeInitialArn, initialClient)
+	seedCredentials, err := AssumeRoleWithJWT(ocmToken, cfg.BackplaneConfiguration.AssumeInitialArn, initialClient)
 	if err != nil {
 		return aws.Credentials{}, fmt.Errorf("failed to assume role using JWT: %w", err)
 	}
 
-	backplaneClient, err := utils.DefaultClientUtils.GetBackplaneClient(cfg.BackplaneConfiguration.URL, *ocmToken, cfg.BackplaneConfiguration.ProxyURL)
+	backplaneClient, err := utils.DefaultClientUtils.GetBackplaneClient(cfg.BackplaneConfiguration.URL, ocmToken, cfg.BackplaneConfiguration.ProxyURL)
 	if err != nil {
 		return aws.Credentials{}, fmt.Errorf("failed to create backplane client with access token: %w", err)
 	}
 
-	response, err := backplaneClient.GetAssumeRoleSequence(context.TODO(), clusterID)
+	response, err := backplaneClient.GetAssumeRoleSequence(context.TODO(), cfg.Cluster.ID())
 	if err != nil {
 		return aws.Credentials{}, fmt.Errorf("failed to fetch arn sequence: %w", err)
 	}

--- a/cmd/ocm-backplane/cloud/common.go
+++ b/cmd/ocm-backplane/cloud/common.go
@@ -29,7 +29,7 @@ var AssumeRoleSequence = awsutil.AssumeRoleSequence
 // Wrapper for the configuration needed for cloud requests
 type CloudQueryConfig struct {
 	config.BackplaneConfiguration
-	ocmConnection *ocmsdk.Connection
+	OcmConnection *ocmsdk.Connection
 }
 
 type assumeChainResponse struct {

--- a/cmd/ocm-backplane/cloud/common_test.go
+++ b/cmd/ocm-backplane/cloud/common_test.go
@@ -31,7 +31,7 @@ var _ = Describe("getIsolatedCredentials", func() {
 		testAccessKeyID     string
 		testSecretAccessKey string
 		testSessionToken    string
-		queryConfig         CloudQueryConfig
+		queryConfig         QueryConfig
 	)
 
 	BeforeEach(func() {
@@ -48,7 +48,7 @@ var _ = Describe("getIsolatedCredentials", func() {
 		testAccessKeyID = "test-access-key-id"
 		testSecretAccessKey = "test-secret-access-key"
 		testSessionToken = "test-session-token"
-		queryConfig = CloudQueryConfig{OcmConnection: &sdk.Connection{}, BackplaneConfiguration: config.BackplaneConfiguration{URL: "test", AssumeInitialArn: "test"}}
+		queryConfig = QueryConfig{OcmConnection: &sdk.Connection{}, BackplaneConfiguration: config.BackplaneConfiguration{URL: "test", AssumeInitialArn: "test"}}
 	})
 
 	AfterEach(func() {
@@ -61,7 +61,7 @@ var _ = Describe("getIsolatedCredentials", func() {
 			Expect(err).To(Equal(fmt.Errorf("must provide non-empty cluster ID")))
 		})
 		It("should fail if cannot create sts client with proxy", func() {
-			StsClientWithProxy = func(proxyURL *string) (*sts.Client, error) {
+			StsClient = func(proxyURL *string) (*sts.Client, error) {
 				return nil, errors.New(":(")
 			}
 
@@ -69,7 +69,7 @@ var _ = Describe("getIsolatedCredentials", func() {
 			Expect(err.Error()).To(Equal("failed to create sts client: :("))
 		})
 		It("should fail if initial role cannot be assumed with JWT", func() {
-			StsClientWithProxy = func(proxyURL *string) (*sts.Client, error) {
+			StsClient = func(proxyURL *string) (*sts.Client, error) {
 				return &sts.Client{}, nil
 			}
 			AssumeRoleWithJWT = func(jwt string, roleArn string, stsClient stscreds.AssumeRoleWithWebIdentityAPIClient) (aws.Credentials, error) {
@@ -82,7 +82,7 @@ var _ = Describe("getIsolatedCredentials", func() {
 		It("should fail if email cannot be pulled off JWT", func() {
 			testOcmToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
 
-			StsClientWithProxy = func(proxyURL *string) (*sts.Client, error) {
+			StsClient = func(proxyURL *string) (*sts.Client, error) {
 				return &sts.Client{}, nil
 			}
 			AssumeRoleWithJWT = func(jwt string, roleArn string, stsClient stscreds.AssumeRoleWithWebIdentityAPIClient) (aws.Credentials, error) {
@@ -97,7 +97,7 @@ var _ = Describe("getIsolatedCredentials", func() {
 			Expect(err.Error()).To(Equal("unable to extract email from given token: no field email on given token"))
 		})
 		It("should fail if error creating backplane api client", func() {
-			StsClientWithProxy = func(proxyURL *string) (*sts.Client, error) {
+			StsClient = func(proxyURL *string) (*sts.Client, error) {
 				return &sts.Client{}, nil
 			}
 			AssumeRoleWithJWT = func(jwt string, roleArn string, stsClient stscreds.AssumeRoleWithWebIdentityAPIClient) (aws.Credentials, error) {

--- a/cmd/ocm-backplane/cloud/common_test.go
+++ b/cmd/ocm-backplane/cloud/common_test.go
@@ -110,7 +110,7 @@ var _ = Describe("getIsolatedCredentials", func() {
 			NewStaticCredentialsProvider = func(key, secret, session string) credentials.StaticCredentialsProvider {
 				return credentials.StaticCredentialsProvider{}
 			}
-			mockClientUtil.EXPECT().GetBackplaneClient(queryConfig.BackplaneConfiguration.URL, testOcmToken, queryConfig.ProxyURL).Return(nil, errors.New("foo")).Times(1)
+			mockClientUtil.EXPECT().GetBackplaneClient(queryConfig.BackplaneConfiguration.URL, testOcmToken, nil).Return(nil, errors.New("foo")).Times(1)
 
 			_, err := getIsolatedCredentials(testClusterID, &queryConfig, &testOcmToken)
 			Expect(err.Error()).To(Equal("failed to create backplane client with access token: foo"))

--- a/cmd/ocm-backplane/cloud/common_test.go
+++ b/cmd/ocm-backplane/cloud/common_test.go
@@ -110,7 +110,7 @@ var _ = Describe("getIsolatedCredentials", func() {
 			NewStaticCredentialsProvider = func(key, secret, session string) credentials.StaticCredentialsProvider {
 				return credentials.StaticCredentialsProvider{}
 			}
-			mockClientUtil.EXPECT().GetBackplaneClient(queryConfig.URL, testOcmToken, queryConfig.ProxyURL).Return(nil, errors.New("foo")).Times(1)
+			mockClientUtil.EXPECT().GetBackplaneClient(queryConfig.BackplaneConfiguration.URL, testOcmToken, queryConfig.ProxyURL).Return(nil, errors.New("foo")).Times(1)
 
 			_, err := getIsolatedCredentials(testClusterID, &queryConfig, &testOcmToken)
 			Expect(err.Error()).To(Equal("failed to create backplane client with access token: foo"))

--- a/cmd/ocm-backplane/cloud/common_test.go
+++ b/cmd/ocm-backplane/cloud/common_test.go
@@ -48,7 +48,7 @@ var _ = Describe("getIsolatedCredentials", func() {
 		testAccessKeyID = "test-access-key-id"
 		testSecretAccessKey = "test-secret-access-key"
 		testSessionToken = "test-session-token"
-		queryConfig = CloudQueryConfig{ocmConnection: &sdk.Connection{}, BackplaneConfiguration: config.BackplaneConfiguration{URL: "test", AssumeInitialArn: "test"}}
+		queryConfig = CloudQueryConfig{OcmConnection: &sdk.Connection{}, BackplaneConfiguration: config.BackplaneConfiguration{URL: "test", AssumeInitialArn: "test"}}
 	})
 
 	AfterEach(func() {

--- a/cmd/ocm-backplane/cloud/console.go
+++ b/cmd/ocm-backplane/cloud/console.go
@@ -151,7 +151,7 @@ func runConsole(cmd *cobra.Command, argv []string) (err error) {
 
 	// Initialize query config
 
-	queryConfig := &CloudQueryConfig{ocmConnection: ocmSdk, BackplaneConfiguration: backplaneConfiguration}
+	queryConfig := &CloudQueryConfig{OcmConnection: ocmSdk, BackplaneConfiguration: backplaneConfiguration}
 
 	// ======== Get cloud console from backplane API ============
 	var consoleResponse *ConsoleResponse

--- a/cmd/ocm-backplane/cloud/console.go
+++ b/cmd/ocm-backplane/cloud/console.go
@@ -215,7 +215,7 @@ func validateParams(argv []string) (err error) {
 func getCloudConsole(queryConfig *CloudQueryConfig, ocmToken string, clusterID string) (*ConsoleResponse, error) {
 	logger.Debugln("Getting Cloud Console")
 
-	client, err := utils.DefaultClientUtils.GetBackplaneClient(queryConfig.URL, ocmToken, queryConfig.ProxyURL)
+	client, err := utils.DefaultClientUtils.GetBackplaneClient(queryConfig.BackplaneConfiguration.URL, ocmToken, queryConfig.BackplaneConfiguration.ProxyURL)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ocm-backplane/cloud/console.go
+++ b/cmd/ocm-backplane/cloud/console.go
@@ -1,23 +1,18 @@
 package cloud
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"strconv"
 
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
-	"github.com/openshift/backplane-cli/pkg/awsutil"
 
 	"github.com/pkg/browser"
 	logger "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
-
-	BackplaneApi "github.com/openshift/backplane-api/pkg/client"
 
 	"github.com/openshift/backplane-cli/pkg/cli/config"
 	"github.com/openshift/backplane-cli/pkg/utils"
@@ -137,61 +132,26 @@ func runConsole(cmd *cobra.Command, argv []string) (err error) {
 	}
 	logger.Infof("Using backplane URL: %s\n", backplaneConfiguration.URL)
 
-	// Initialize OCM sdk
-	ocmSdk, err := ocm.NewConnection().Build()
+	// Initialize OCM connection
+	ocmConnection, err := ocm.NewConnection().Build()
 	if err != nil {
 		return fmt.Errorf("unable to build ocm sdk: %w", err)
 	}
-	defer ocmSdk.Close()
-
-	ocmToken, _, err := ocmSdk.Tokens()
-	if err != nil {
-		return fmt.Errorf("unable to get token for ocm connection")
-	}
+	defer ocmConnection.Close()
 
 	// Initialize query config
 
-	queryConfig := &QueryConfig{OcmConnection: ocmSdk, BackplaneConfiguration: backplaneConfiguration}
+	queryConfig := &QueryConfig{OcmConnection: ocmConnection, BackplaneConfiguration: backplaneConfiguration, Cluster: cluster}
 
 	// ======== Get cloud console from backplane API ============
-	var consoleResponse *ConsoleResponse
-	isolatedBackplane, err := isIsolatedBackplaneAccess(cluster, ocmSdk)
+	consoleResponse, err := queryConfig.GetCloudConsole()
 	if err != nil {
-		return fmt.Errorf("failed to determine if cluster is using isolated backplane access: %w", err)
-	}
-	if isolatedBackplane {
-		targetCredentials, err := getIsolatedCredentials(clusterID, queryConfig, &ocmToken)
-		if err != nil {
-			// TODO: This fallback should be removed in the future
-			// TODO: when we are more confident in our ability to access clusters using the isolated flow
-			logger.Infof("failed to assume role with isolated backplane flow: %v", err)
-			logger.Infof("attempting to fallback to %s", OldFlowSupportRole)
-			consoleResponse, err = getCloudConsole(queryConfig, ocmToken, clusterID)
-			if err != nil {
-				return err
-			}
-		} else {
-			resp, err := awsutil.GetSigninToken(targetCredentials, cluster.Region().ID())
-			if err != nil {
-				return fmt.Errorf("failed to get signin token: %w", err)
-			}
-
-			signinFederationURL, err := awsutil.GetConsoleURL(resp.SigninToken, cluster.Region().ID())
-			if err != nil {
-				return fmt.Errorf("failed to generate console url: %w", err)
-			}
-			consoleResponse = &ConsoleResponse{ConsoleLink: signinFederationURL.String()}
-		}
-	} else {
-		consoleResponse, err = getCloudConsole(queryConfig, ocmToken, clusterID)
-		if err != nil {
-			return err
-		}
+		return fmt.Errorf("failed to get cloud console for cluster %v: %w", clusterID, err)
 	}
 
 	err = renderCloudConsole(consoleResponse)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to render cloud console: %w", err)
 	}
 	return nil
 }
@@ -209,38 +169,6 @@ func validateParams(argv []string) (err error) {
 		return fmt.Errorf("expected exactly one cluster")
 	}
 	return nil
-}
-
-// getCloudConsole returns console response calling to public Backplane API
-func getCloudConsole(cfg *QueryConfig, ocmToken string, clusterID string) (*ConsoleResponse, error) {
-	logger.Debugln("Getting Cloud Console")
-
-	client, err := utils.DefaultClientUtils.GetBackplaneClient(cfg.BackplaneConfiguration.URL, ocmToken, cfg.BackplaneConfiguration.ProxyURL)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.GetCloudConsole(context.TODO(), clusterID)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, utils.TryPrintAPIError(resp, false)
-	}
-
-	credsResp, err := BackplaneApi.ParseGetCloudConsoleResponse(resp)
-	if err != nil {
-		return nil, fmt.Errorf("unable to parse response body from backplane:\n  Status Code: %d", resp.StatusCode)
-	}
-
-	if len(credsResp.Body) == 0 {
-		return nil, fmt.Errorf("empty response from backplane")
-	}
-
-	cliResp := &ConsoleResponse{}
-	cliResp.ConsoleLink = *credsResp.JSON200.ConsoleLink
-
-	return cliResp, nil
 }
 
 // renderCloudConsole output the data based output type

--- a/cmd/ocm-backplane/cloud/console.go
+++ b/cmd/ocm-backplane/cloud/console.go
@@ -151,7 +151,7 @@ func runConsole(cmd *cobra.Command, argv []string) (err error) {
 
 	// Initialize query config
 
-	queryConfig := &CloudQueryConfig{OcmConnection: ocmSdk, BackplaneConfiguration: backplaneConfiguration}
+	queryConfig := &QueryConfig{OcmConnection: ocmSdk, BackplaneConfiguration: backplaneConfiguration}
 
 	// ======== Get cloud console from backplane API ============
 	var consoleResponse *ConsoleResponse
@@ -212,10 +212,10 @@ func validateParams(argv []string) (err error) {
 }
 
 // getCloudConsole returns console response calling to public Backplane API
-func getCloudConsole(queryConfig *CloudQueryConfig, ocmToken string, clusterID string) (*ConsoleResponse, error) {
+func getCloudConsole(cfg *QueryConfig, ocmToken string, clusterID string) (*ConsoleResponse, error) {
 	logger.Debugln("Getting Cloud Console")
 
-	client, err := utils.DefaultClientUtils.GetBackplaneClient(queryConfig.BackplaneConfiguration.URL, ocmToken, queryConfig.BackplaneConfiguration.ProxyURL)
+	client, err := utils.DefaultClientUtils.GetBackplaneClient(cfg.BackplaneConfiguration.URL, ocmToken, cfg.BackplaneConfiguration.ProxyURL)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ocm-backplane/cloud/credentials.go
+++ b/cmd/ocm-backplane/cloud/credentials.go
@@ -115,7 +115,7 @@ func runCredentials(cmd *cobra.Command, argv []string) error {
 	// ======== Call Endpoint ==================================
 	logger.Debugln("Getting Cloud Credentials")
 
-	queryConfig := &CloudQueryConfig{ocmConnection: ocmSdk, BackplaneConfiguration: backplaneConfiguration}
+	queryConfig := &CloudQueryConfig{OcmConnection: ocmSdk, BackplaneConfiguration: backplaneConfiguration}
 
 	credsResp, err := getCloudCredentials(queryConfig, cluster)
 	if err != nil {
@@ -133,12 +133,12 @@ func runCredentials(cmd *cobra.Command, argv []string) error {
 
 // getCloudCredentials returns Cloud Credentials Response
 func getCloudCredentials(queryConfig *CloudQueryConfig, cluster *cmv1.Cluster) (bpCredentials.Response, error) {
-	ocmToken, _, err := queryConfig.ocmConnection.Tokens()
+	ocmToken, _, err := queryConfig.OcmConnection.Tokens()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get token for ocm connection")
 	}
 
-	isolatedBackplane, err := isIsolatedBackplaneAccess(cluster, queryConfig.ocmConnection)
+	isolatedBackplane, err := isIsolatedBackplaneAccess(cluster, queryConfig.OcmConnection)
 	if err != nil {
 		logger.Infof("failed to determine if the cluster is using isolated backplane access: %v", err)
 		logger.Infof("for more information, try ocm get /api/clusters_mgmt/v1/clusters/%s/sts_support_jump_role", cluster.ID())

--- a/cmd/ocm-backplane/cloud/credentials.go
+++ b/cmd/ocm-backplane/cloud/credentials.go
@@ -169,7 +169,7 @@ func getCloudCredentials(queryConfig *CloudQueryConfig, cluster *cmv1.Cluster) (
 }
 
 func getCloudCredentialsFromBackplaneAPI(queryConfig *CloudQueryConfig, ocmToken string, cluster *cmv1.Cluster) (bpCredentials.Response, error) {
-	client, err := utils.DefaultClientUtils.GetBackplaneClient(queryConfig.URL, ocmToken, queryConfig.ProxyURL)
+	client, err := utils.DefaultClientUtils.GetBackplaneClient(queryConfig.BackplaneConfiguration.URL, ocmToken, queryConfig.BackplaneConfiguration.ProxyURL)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ocm-backplane/cloud/credentials_test.go
+++ b/cmd/ocm-backplane/cloud/credentials_test.go
@@ -15,7 +15,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/openshift/backplane-cli/pkg/cli/config"
 	"github.com/openshift/backplane-cli/pkg/client/mocks"
 	bpCredentials "github.com/openshift/backplane-cli/pkg/credentials"
 	"github.com/openshift/backplane-cli/pkg/info"
@@ -152,19 +151,6 @@ var _ = Describe("Cloud console command", func() {
 				mockOcmInterface.EXPECT().GetClusterInfoByID(gomock.Any()).Return(&cmv1.Cluster{}, errors.New("error")).AnyTimes()
 				Expect(runCredentials(&cobra.Command{}, []string{"cluster-key"})).To(Equal(
 					fmt.Errorf("failed to get cluster info for %s: %w", "foo", errors.New("error")),
-				))
-			})
-
-			It("returns an error if GetBackplaneURL returns an error and credentialArgs.backplaneURL is empty", func() {
-				GetBackplaneConfiguration = func() (bpConfig config.BackplaneConfiguration, err error) {
-					return config.BackplaneConfiguration{}, errors.New("error bp url")
-
-				}
-
-				mockOcmInterface.EXPECT().GetTargetCluster(gomock.Any()).Return("foo", "bar", nil).AnyTimes()
-				mockOcmInterface.EXPECT().GetClusterInfoByID(gomock.Any()).Return(&cmv1.Cluster{}, nil).AnyTimes()
-				Expect(runCredentials(&cobra.Command{}, []string{"cluster-key"})).To(Equal(
-					fmt.Errorf("can't find backplane url: %w", errors.New("error bp url")),
 				))
 			})
 

--- a/cmd/ocm-backplane/config/get.go
+++ b/cmd/ocm-backplane/config/get.go
@@ -26,21 +26,21 @@ func getConfig(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	proxyUrl := ""
+	proxyURL := ""
 	if config.ProxyURL != nil {
-		proxyUrl = *config.ProxyURL
+		proxyURL = *config.ProxyURL
 	}
 
 	switch args[0] {
 	case URLConfigVar:
 		fmt.Printf("%s: %s\n", URLConfigVar, config.URL)
 	case ProxyURLConfigVar:
-		fmt.Printf("%s: %s\n", ProxyURLConfigVar, proxyUrl)
+		fmt.Printf("%s: %s\n", ProxyURLConfigVar, proxyURL)
 	case SessionConfigVar:
 		fmt.Printf("%s: %s\n", SessionConfigVar, config.SessionDirectory)
 	case "all":
 		fmt.Printf("%s: %s\n", URLConfigVar, config.URL)
-		fmt.Printf("%s: %s\n", ProxyURLConfigVar, proxyUrl)
+		fmt.Printf("%s: %s\n", ProxyURLConfigVar, proxyURL)
 		fmt.Printf("%s: %s\n", SessionConfigVar, config.SessionDirectory)
 	default:
 		return fmt.Errorf("supported config variables are %s, %s & %s", URLConfigVar, ProxyURLConfigVar, SessionConfigVar)

--- a/cmd/ocm-backplane/config/get.go
+++ b/cmd/ocm-backplane/config/get.go
@@ -26,16 +26,21 @@ func getConfig(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	proxyUrl := ""
+	if config.ProxyURL != nil {
+		proxyUrl = *config.ProxyURL
+	}
+
 	switch args[0] {
 	case URLConfigVar:
 		fmt.Printf("%s: %s\n", URLConfigVar, config.URL)
 	case ProxyURLConfigVar:
-		fmt.Printf("%s: %s\n", ProxyURLConfigVar, config.ProxyURL)
+		fmt.Printf("%s: %s\n", ProxyURLConfigVar, proxyUrl)
 	case SessionConfigVar:
 		fmt.Printf("%s: %s\n", SessionConfigVar, config.SessionDirectory)
 	case "all":
 		fmt.Printf("%s: %s\n", URLConfigVar, config.URL)
-		fmt.Printf("%s: %s\n", ProxyURLConfigVar, config.ProxyURL)
+		fmt.Printf("%s: %s\n", ProxyURLConfigVar, proxyUrl)
 		fmt.Printf("%s: %s\n", SessionConfigVar, config.SessionDirectory)
 	default:
 		return fmt.Errorf("supported config variables are %s, %s & %s", URLConfigVar, ProxyURLConfigVar, SessionConfigVar)

--- a/cmd/ocm-backplane/config/set.go
+++ b/cmd/ocm-backplane/config/set.go
@@ -42,7 +42,11 @@ func setConfig(cmd *cobra.Command, args []string) error {
 		}
 
 		bpConfig.URL = viper.GetString("url")
-		bpConfig.ProxyURL = viper.GetString("proxy-url")
+		proxyURL := viper.GetString("proxy-url")
+		if proxyURL != "" {
+			bpConfig.ProxyURL = &proxyURL
+		}
+
 		bpConfig.SessionDirectory = viper.GetString("session-dir")
 	}
 
@@ -76,7 +80,7 @@ func setConfig(cmd *cobra.Command, args []string) error {
 	case URLConfigVar:
 		bpConfig.URL = args[1]
 	case ProxyURLConfigVar:
-		bpConfig.ProxyURL = args[1]
+		bpConfig.ProxyURL = &args[1]
 	case SessionConfigVar:
 		bpConfig.SessionDirectory = args[1]
 	default:

--- a/cmd/ocm-backplane/console/console.go
+++ b/cmd/ocm-backplane/console/console.go
@@ -369,9 +369,9 @@ func runConsole(cmd *cobra.Command, argv []string) (err error) {
 		return err
 	}
 
-	if proxyURL != "" {
+	if proxyURL != nil {
 		engRunArgs = append(engRunArgs,
-			"--env", fmt.Sprintf("HTTPS_PROXY=%s", proxyURL),
+			"--env", fmt.Sprintf("HTTPS_PROXY=%s", *proxyURL),
 		)
 	}
 
@@ -509,17 +509,14 @@ func replaceConsoleURL(original string) (string, error) {
 	return original, nil
 }
 
-// Get the proxy url
-func getProxyURL() (proxyURL string, err error) {
+// getProxyURL returns the proxy url
+func getProxyURL() (proxyURL *string, err error) {
 	bpConfig, err := config.GetBackplaneConfiguration()
-
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	proxyURL = bpConfig.ProxyURL
-
-	return proxyURL, nil
+	return bpConfig.ProxyURL, nil
 }
 
 // getImageFromCluster get the image from the console deployment

--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -108,8 +108,8 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 		logger.Debugf("Using backplane Proxy URL: %s\n", proxyURL)
 	}
 
-	if len(proxyURL) == 0 {
-		proxyURL = bpConfig.ProxyURL
+	if bpConfig.ProxyURL != nil {
+		proxyURL = *bpConfig.ProxyURL
 	}
 
 	clusterID, clusterName, err := utils.DefaultOCMInterface.GetTargetCluster(clusterKey)
@@ -271,9 +271,9 @@ func GetRestConfig(bp config.BackplaneConfiguration, clusterID string) (*rest.Co
 		BearerToken: *accessToken,
 	}
 
-	if bp.ProxyURL != "" {
+	if bp.ProxyURL != nil {
 		cfg.Proxy = func(*http.Request) (*url.URL, error) {
-			return url.Parse(bp.ProxyURL)
+			return url.Parse(*bp.ProxyURL)
 		}
 	}
 

--- a/pkg/awsutil/sts_test.go
+++ b/pkg/awsutil/sts_test.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"io"
 	"net/http"
 	"net/url"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -208,7 +209,7 @@ func TestAssumeRoleSequence(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := AssumeRoleSequence("", tt.args.seedClient, tt.args.roleArnSequence, "", tt.args.stsClientProviderFunc)
+			got, err := AssumeRoleSequence("", tt.args.seedClient, tt.args.roleArnSequence, nil, tt.args.stsClientProviderFunc)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("AssumeRoleSequence() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -77,6 +78,8 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 	proxyURL := viper.GetString("proxy-url")
 	if proxyURL != "" {
 		bpConfig.ProxyURL = &proxyURL
+	} else {
+		fmt.Println("WARNING: No proxy configuration available. This may result in failing commands as backplane-api is only available from select networks.")
 	}
 
 	return bpConfig, nil

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -1,13 +1,13 @@
 package config
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"time"
 
+	logger "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 
 	"github.com/openshift/backplane-cli/pkg/info"
@@ -79,7 +79,7 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 	if proxyURL != "" {
 		bpConfig.ProxyURL = &proxyURL
 	} else {
-		fmt.Println("WARNING: No proxy configuration available. This may result in failing commands as backplane-api is only available from select networks.")
+		logger.Warn("No proxy configuration available. This may result in failing commands as backplane-api is only available from select networks.")
 	}
 
 	return bpConfig, nil

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -14,7 +14,7 @@ import (
 
 type BackplaneConfiguration struct {
 	URL              string
-	ProxyURL         string
+	ProxyURL         *string // Optional
 	SessionDirectory string
 	AssumeInitialArn string
 }
@@ -70,9 +70,14 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 	}
 
 	bpConfig.URL = viper.GetString("url")
-	bpConfig.ProxyURL = viper.GetString("proxy-url")
 	bpConfig.SessionDirectory = viper.GetString("session-dir")
 	bpConfig.AssumeInitialArn = viper.GetString("assume-initial-arn")
+
+	// proxyURL is optional
+	proxyURL := viper.GetString("proxy-url")
+	if proxyURL != "" {
+		bpConfig.ProxyURL = &proxyURL
+	}
 
 	return bpConfig, nil
 }
@@ -96,8 +101,8 @@ func (config BackplaneConfiguration) testHTTPRequestToBackplaneAPI() (bool, erro
 		Timeout: 5 * time.Second,
 	}
 
-	if config.ProxyURL != "" {
-		proxyURL, err := url.Parse(config.ProxyURL)
+	if config.ProxyURL != nil {
+		proxyURL, err := url.Parse(*config.ProxyURL)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/cli/config/config_test.go
+++ b/pkg/cli/config/config_test.go
@@ -15,7 +15,7 @@ func TestGetBackplaneConfig(t *testing.T) {
 			t.Error(err)
 		}
 
-		if config.ProxyURL != userDefinedProxy {
+		if config.ProxyURL != nil && *config.ProxyURL != userDefinedProxy {
 			t.Errorf("expected to return the explicitly defined proxy %v instead of the default one %v", userDefinedProxy, config.ProxyURL)
 		}
 	})
@@ -94,7 +94,7 @@ func TestGetBackplaneConnection(t *testing.T) {
 	})
 
 	t.Run("should fail for empty proxy url", func(t *testing.T) {
-		config := BackplaneConfiguration{URL: "https://api-backplane.apps.openshiftapps.com", ProxyURL: ""}
+		config := BackplaneConfiguration{URL: "https://api-backplane.apps.openshiftapps.com", ProxyURL: nil}
 		err := config.CheckAPIConnection()
 
 		if err != nil {

--- a/pkg/monitoring/monitoring.go
+++ b/pkg/monitoring/monitoring.go
@@ -134,8 +134,8 @@ func (c Client) RunMonitoring(monitoringType string) error {
 	if err != nil {
 		return err
 	}
-	if proxyURL != "" {
-		proxyURL, err := url.Parse(proxyURL)
+	if proxyURL != nil {
+		proxyURL, err := url.Parse(*proxyURL)
 		if err != nil {
 			return err
 		}
@@ -342,16 +342,13 @@ func serveURL(hasURL, hasNs bool, cfg *restclient.Config) (*url.URL, error) {
 }
 
 // getProxyURL returns the proxy url
-func getProxyURL() (proxyURL string, err error) {
+func getProxyURL() (proxyURL *string, err error) {
 	bpConfig, err := config.GetBackplaneConfiguration()
-
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	proxyURL = bpConfig.ProxyURL
-
-	return proxyURL, nil
+	return bpConfig.ProxyURL, nil
 }
 
 // validateClusterVersion checks the clusterversion based on namespace

--- a/pkg/utils/clientUtils.go
+++ b/pkg/utils/clientUtils.go
@@ -19,7 +19,7 @@ type ClientUtils interface {
 	MakeBackplaneAPIClientWithAccessToken(base, accessToken string) (BackplaneApi.ClientWithResponsesInterface, error)
 	MakeRawBackplaneAPIClientWithAccessToken(base, accessToken string) (BackplaneApi.ClientInterface, error)
 	MakeRawBackplaneAPIClient(base string) (BackplaneApi.ClientInterface, error)
-	GetBackplaneClient(backplaneURL string, ocmToken string, proxyUrl *string) (client BackplaneApi.ClientInterface, err error)
+	GetBackplaneClient(backplaneURL string, ocmToken string, proxyURL *string) (client BackplaneApi.ClientInterface, err error)
 	SetClientProxyURL(proxyURL string) error
 }
 
@@ -67,8 +67,8 @@ func (s *DefaultClientUtilsImpl) MakeRawBackplaneAPIClientWithAccessToken(base, 
 }
 
 // makeRawBackplaneAPIClientWithAccessTokenCustomProxy creates a BackplaneApi.ClientInterface with a custom proxy url
-// proxyUrl is optional, the default behavior is no proxy.
-func makeRawBackplaneAPIClientWithAccessTokenCustomProxy(server string, accessToken string, proxyUrl *string) (BackplaneApi.ClientInterface, error) {
+// proxyURL is optional, the default behavior is no proxy.
+func makeRawBackplaneAPIClientWithAccessTokenCustomProxy(server string, accessToken string, proxyURL *string) (BackplaneApi.ClientInterface, error) {
 	co := func(client *BackplaneApi.Client) error {
 		client.RequestEditors = append(client.RequestEditors, func(ctx context.Context, req *http.Request) error {
 			req.Header.Add("Authorization", "Bearer "+accessToken)
@@ -78,13 +78,13 @@ func makeRawBackplaneAPIClientWithAccessTokenCustomProxy(server string, accessTo
 		return nil
 	}
 
-	if proxyUrl != nil {
-		proxy, err := url.Parse(*proxyUrl)
+	if proxyURL != nil {
+		proxy, err := url.Parse(*proxyURL)
 		if err != nil {
 			return nil, err
 		}
 		http.DefaultTransport = &http.Transport{Proxy: http.ProxyURL(proxy)}
-		logger.Debugf("Using backplane Proxy URL: %s\n", *proxyUrl)
+		logger.Debugf("Using backplane Proxy URL: %s\n", *proxyURL)
 	}
 
 	return BackplaneApi.NewClient(server, co)
@@ -121,7 +121,7 @@ func (s *DefaultClientUtilsImpl) MakeBackplaneAPIClient(base string) (BackplaneA
 
 // GetBackplaneClient returns authenticated Backplane API client
 // Proxy is optional.
-func (s *DefaultClientUtilsImpl) GetBackplaneClient(backplaneURL string, ocmToken string, proxyUrl *string) (client BackplaneApi.ClientInterface, err error) {
+func (s *DefaultClientUtilsImpl) GetBackplaneClient(backplaneURL string, ocmToken string, proxyURL *string) (client BackplaneApi.ClientInterface, err error) {
 	if backplaneURL == "" {
 		bpConfig, err := config.GetBackplaneConfiguration()
 		backplaneURL = bpConfig.URL
@@ -132,7 +132,7 @@ func (s *DefaultClientUtilsImpl) GetBackplaneClient(backplaneURL string, ocmToke
 	}
 
 	logger.Debugln("Getting client")
-	backplaneClient, err := makeRawBackplaneAPIClientWithAccessTokenCustomProxy(backplaneURL, ocmToken, proxyUrl)
+	backplaneClient, err := makeRawBackplaneAPIClientWithAccessTokenCustomProxy(backplaneURL, ocmToken, proxyURL)
 	if err != nil {
 		return client, fmt.Errorf("unable to create backplane api client: %w", err)
 	}

--- a/pkg/utils/clientUtils.go
+++ b/pkg/utils/clientUtils.go
@@ -19,7 +19,7 @@ type ClientUtils interface {
 	MakeBackplaneAPIClientWithAccessToken(base, accessToken string) (BackplaneApi.ClientWithResponsesInterface, error)
 	MakeRawBackplaneAPIClientWithAccessToken(base, accessToken string) (BackplaneApi.ClientInterface, error)
 	MakeRawBackplaneAPIClient(base string) (BackplaneApi.ClientInterface, error)
-	GetBackplaneClient(backplaneURL string, ocmToken *string) (client BackplaneApi.ClientInterface, err error)
+	GetBackplaneClient(backplaneURL string, ocmToken string, proxyUrl *string) (client BackplaneApi.ClientInterface, err error)
 	SetClientProxyURL(proxyURL string) error
 }
 
@@ -47,7 +47,9 @@ func (s *DefaultClientUtilsImpl) MakeRawBackplaneAPIClientWithAccessToken(base, 
 		if err != nil {
 			return nil, err
 		}
-		s.clientProxyURL = bpConfig.ProxyURL
+		if bpConfig.ProxyURL != nil {
+			s.clientProxyURL = *bpConfig.ProxyURL
+		}
 	}
 
 	// Update http proxy transport
@@ -62,6 +64,30 @@ func (s *DefaultClientUtilsImpl) MakeRawBackplaneAPIClientWithAccessToken(base, 
 	}
 
 	return BackplaneApi.NewClient(base, co)
+}
+
+// makeRawBackplaneAPIClientWithAccessTokenCustomProxy creates a BackplaneApi.ClientInterface with a custom proxy url
+// proxyUrl is optional, the default behavior is no proxy.
+func makeRawBackplaneAPIClientWithAccessTokenCustomProxy(server string, accessToken string, proxyUrl *string) (BackplaneApi.ClientInterface, error) {
+	co := func(client *BackplaneApi.Client) error {
+		client.RequestEditors = append(client.RequestEditors, func(ctx context.Context, req *http.Request) error {
+			req.Header.Add("Authorization", "Bearer "+accessToken)
+			req.Header.Set("User-Agent", "backplane-cli"+info.Version)
+			return nil
+		})
+		return nil
+	}
+
+	if proxyUrl != nil {
+		proxy, err := url.Parse(*proxyUrl)
+		if err != nil {
+			return nil, err
+		}
+		http.DefaultTransport = &http.Transport{Proxy: http.ProxyURL(proxy)}
+		logger.Debugf("Using backplane Proxy URL: %s\n", *proxyUrl)
+	}
+
+	return BackplaneApi.NewClient(server, co)
 }
 
 func (s *DefaultClientUtilsImpl) MakeRawBackplaneAPIClient(base string) (BackplaneApi.ClientInterface, error) {
@@ -94,7 +120,8 @@ func (s *DefaultClientUtilsImpl) MakeBackplaneAPIClient(base string) (BackplaneA
 }
 
 // GetBackplaneClient returns authenticated Backplane API client
-func (s *DefaultClientUtilsImpl) GetBackplaneClient(backplaneURL string, ocmToken *string) (client BackplaneApi.ClientInterface, err error) {
+// Proxy is optional.
+func (s *DefaultClientUtilsImpl) GetBackplaneClient(backplaneURL string, ocmToken string, proxyUrl *string) (client BackplaneApi.ClientInterface, err error) {
 	if backplaneURL == "" {
 		bpConfig, err := config.GetBackplaneConfiguration()
 		backplaneURL = bpConfig.URL
@@ -105,7 +132,7 @@ func (s *DefaultClientUtilsImpl) GetBackplaneClient(backplaneURL string, ocmToke
 	}
 
 	logger.Debugln("Getting client")
-	backplaneClient, err := DefaultClientUtils.MakeRawBackplaneAPIClientWithAccessToken(backplaneURL, *ocmToken)
+	backplaneClient, err := makeRawBackplaneAPIClientWithAccessTokenCustomProxy(backplaneURL, ocmToken, proxyUrl)
 	if err != nil {
 		return client, fmt.Errorf("unable to create backplane api client: %w", err)
 	}

--- a/pkg/utils/mocks/clientUtilsMock.go
+++ b/pkg/utils/mocks/clientUtilsMock.go
@@ -35,18 +35,18 @@ func (m *MockClientUtils) EXPECT() *MockClientUtilsMockRecorder {
 }
 
 // GetBackplaneClient mocks base method.
-func (m *MockClientUtils) GetBackplaneClient(arg0 string, arg1 *string) (Openapi.ClientInterface, error) {
+func (m *MockClientUtils) GetBackplaneClient(arg0, arg1 string, arg2 *string) (Openapi.ClientInterface, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackplaneClient", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetBackplaneClient", arg0, arg1, arg2)
 	ret0, _ := ret[0].(Openapi.ClientInterface)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBackplaneClient indicates an expected call of GetBackplaneClient.
-func (mr *MockClientUtilsMockRecorder) GetBackplaneClient(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientUtilsMockRecorder) GetBackplaneClient(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackplaneClient", reflect.TypeOf((*MockClientUtils)(nil).GetBackplaneClient), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackplaneClient", reflect.TypeOf((*MockClientUtils)(nil).GetBackplaneClient), arg0, arg1, arg2)
 }
 
 // MakeBackplaneAPIClient mocks base method.

--- a/pkg/utils/mocks/ocmWrapperMock.go
+++ b/pkg/utils/mocks/ocmWrapperMock.go
@@ -8,6 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
@@ -112,18 +113,18 @@ func (mr *MockOCMInterfaceMockRecorder) GetServiceCluster(arg0 interface{}) *gom
 }
 
 // GetStsSupportJumpRoleARN mocks base method.
-func (m *MockOCMInterface) GetStsSupportJumpRoleARN(arg0 string) (string, error) {
+func (m *MockOCMInterface) GetStsSupportJumpRoleARN(arg0 *sdk.Connection, arg1 string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetStsSupportJumpRoleARN", arg0)
+	ret := m.ctrl.Call(m, "GetStsSupportJumpRoleARN", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetStsSupportJumpRoleARN indicates an expected call of GetStsSupportJumpRoleARN.
-func (mr *MockOCMInterfaceMockRecorder) GetStsSupportJumpRoleARN(arg0 interface{}) *gomock.Call {
+func (mr *MockOCMInterfaceMockRecorder) GetStsSupportJumpRoleARN(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStsSupportJumpRoleARN", reflect.TypeOf((*MockOCMInterface)(nil).GetStsSupportJumpRoleARN), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStsSupportJumpRoleARN", reflect.TypeOf((*MockOCMInterface)(nil).GetStsSupportJumpRoleARN), arg0, arg1)
 }
 
 // GetTargetCluster mocks base method.


### PR DESCRIPTION
### What type of PR is this?

cleanup

### What this PR does / Why we need it?

We need the proxy to be configurable for programmatic access. Beyond that, this PR also allows passing the whole necessary configuration to create an AWSV2Config, instead of picking up config chunks through ENVs and external config files. 

Needed for https://issues.redhat.com/browse/OSD-19388\

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR

**After these changes I tested the following:**
Old flow:
- ocm backplane cloud credentials
- ocm backplane cloud console

Non STS clusters:
- ocm backplane cloud credentials
- ocm backplane cloud console

New flow:
- ocm backplane cloud credentials
- ocm backplane cloud console

