### PR TITLE
print the related namespace when login via manager cluster

### DIFF
--- a/pkg/cli/session/session.go
+++ b/pkg/cli/session/session.go
@@ -77,7 +77,8 @@ func (e *BackplaneSession) RunCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	if e.Options.GlobalOpts.Manager {
-		clusterID, clusterName, err = ocm.DefaultOCMInterface.GetManagingCluster(clusterID)
+		clusterID, clusterName, _, err = ocm.DefaultOCMInterface.GetManagingCluster(clusterID)
+
 		e.Options.Alias = clusterID
 		if err != nil {
 			return err

--- a/pkg/ocm/mocks/ocmWrapperMock.go
+++ b/pkg/ocm/mocks/ocmWrapperMock.go
@@ -51,13 +51,14 @@ func (mr *MockOCMInterfaceMockRecorder) GetClusterInfoByID(arg0 interface{}) *go
 }
 
 // GetManagingCluster mocks base method.
-func (m *MockOCMInterface) GetManagingCluster(arg0 string) (string, string, error) {
+func (m *MockOCMInterface) GetManagingCluster(arg0 string) (string, string, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetManagingCluster", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret2, _ := ret[2].(bool)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
 }
 
 // GetManagingCluster indicates an expected call of GetManagingCluster.


### PR DESCRIPTION
### What type of PR is this?

_(feature)_

### What this PR does / Why we need it?
It prints the cluster related namespaces when login with the `--manager` option, since user may like to investigate the resources within

### Which Jira/Github issue(s) does this PR fix?

_Resolves #OSD-19081_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
