### PR TITLE
Use md5 hash as role session name when assuming into customer's support role

### DIFF
--- a/pkg/awsutil/sts_test.go
+++ b/pkg/awsutil/sts_test.go
@@ -150,7 +150,7 @@ func TestAssumeRole(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := AssumeRole("", tt.stsClient, "")
+			got, err := AssumeRole(tt.stsClient, "", "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("AssumeRole() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -165,7 +165,7 @@ func TestAssumeRole(t *testing.T) {
 func TestAssumeRoleSequence(t *testing.T) {
 	type args struct {
 		seedClient            stscreds.AssumeRoleAPIClient
-		roleArnSequence       []string
+		roleArnSequence       []RoleArnSession
 		stsClientProviderFunc STSClientProviderFunc
 	}
 	tests := []struct {
@@ -184,7 +184,7 @@ func TestAssumeRoleSequence(t *testing.T) {
 		{
 			name: "role arn sequence is empty",
 			args: args{
-				roleArnSequence: []string{},
+				roleArnSequence: []RoleArnSession{},
 			},
 			wantErr: true,
 		},
@@ -192,7 +192,7 @@ func TestAssumeRoleSequence(t *testing.T) {
 			name: "single role arn in sequence",
 			args: args{
 				seedClient:      defaultSuccessMockSTSClient(),
-				roleArnSequence: []string{"a"},
+				roleArnSequence: []RoleArnSession{{RoleArn: "a"}},
 				stsClientProviderFunc: func(optFns ...func(*config.LoadOptions) error) (stscreds.AssumeRoleAPIClient, error) {
 					return defaultSuccessMockSTSClient(), nil
 				},
@@ -209,7 +209,7 @@ func TestAssumeRoleSequence(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := AssumeRoleSequence("", tt.args.seedClient, tt.args.roleArnSequence, nil, tt.args.stsClientProviderFunc)
+			got, err := AssumeRoleSequence(tt.args.seedClient, tt.args.roleArnSequence, nil, tt.args.stsClientProviderFunc)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("AssumeRoleSequence() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / Why we need it?
backplane-cli passes the SRE's email address as a role session name when assuming a customer's support role. We should not pass any SRE usernames to a customer when assuming into their account.

### Which Jira/Github issue(s) does this PR fix?
https://issues.redhat.com/browse/OSD-19901

### Special notes for your reviewer

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
