### PR TITLE
Allow to source --multi output

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ Logging into multiple clusters via different terminal instances.
   $ export KUBECONFIG= <cluster-id-1-kube-config-path>
   ```
 
+  you can also directly run
+
+  ```
+  $ source <(ocm backplane login <cluster-id-1> --multi)
+  ```
+
 - How to log into the second cluster
 
   ```

--- a/pkg/login/kubeConfig.go
+++ b/pkg/login/kubeConfig.go
@@ -97,7 +97,7 @@ func SaveKubeConfig(clusterID string, config api.Config, isMulti bool, kubePath 
 
 		if kubePath == "" {
 			// Inform how to setup kube config
-			fmt.Printf("Execute the following command to log into the cluster %s \n", clusterID)
+			fmt.Printf("# Execute the following command to log into the cluster %s \n", clusterID)
 			fmt.Println("export " + info.BackplaneKubeconfigEnvName + "=" + path)
 		}
 


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / Why we need it?
When using login --multi, the output cannot be sourced directly.
With this change we will be able to run:
 ```
source <(ocm-backplane login multi xxx)
```

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ x] Ran unit tests locally
- [ x] Validated the changes in a cluster
- [ x] Included documentation changes with PR
