### PR TITLE
OSD-19779 Use local monitoring plugin on 4.14+ clusters

### DIFF
--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -96,6 +96,16 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 	return bpConfig, nil
 }
 
+func GetConfigDirctory() (string, error) {
+	bpConfigFilePath, err := GetConfigFilePath()
+	if err != nil {
+		return "", err
+	}
+	configDirectory := filepath.Dir(bpConfigFilePath)
+
+	return configDirectory, nil
+}
+
 // GetBackplaneURL returns API URL
 func (config *BackplaneConfiguration) GetBackplaneURL() (string, error) {
 

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -31,6 +31,23 @@ const (
 
 	// GitHub Host
 	GitHubHost = "github.com"
+
+	// Nginx configuration template for monitoring-plugin
+	MonitoringPluginNginxConfigTemplate = `
+	error_log /dev/stdout info;
+	events {}
+	http {
+  	include            /etc/nginx/mime.types;
+  	default_type       application/octet-stream;
+  	keepalive_timeout  65;
+  	server {
+    	listen              %s;
+    	root                /usr/share/nginx/html;
+  	}
+	}
+	`
+
+	MonitoringPluginNginxConfigFilename = "monitoring-plugin-nginx.conf"
 )
 
 var (


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

Since 4.14, the `monitoring-plugin` is required to be run locally. The plugin is running in cluster as a service so port forwarding is the only way to access it otherwise.
This PR sets up the locally running backplane console to include a locally running `monitoring-plugin` container in it's network and access it via a `nginx` server. The serer is pre-set in the `monitoring-plugin` container so we don't have other ways to access it.

This does not change the behavior for pre-4.14 clusters. It only adds the new container when the cluster is 4.14 and above.

### Which Jira/Github issue(s) does this PR fix?

[OSD-19779](https://issues.redhat.com//browse/OSD-19779)

### Special notes for your reviewer

This PR introduces a temporary nginx configuration and a function to run monitoring-plugin in a separate local container.
This change only takes effect on cluster with version 4.14 and above.

With this change:
- An additional container is run locally for monitoring-plugin
- The new container is run under the same network infrastructure of the console cotainer
- Both the console container and the monitoring-plugin container run in daemon mode
- Both containers use randomly reserved ports to listen for requests
- monitoring-plugin container uses an inbuilt nginx server that accepts a mounted nginx configuration. For this reason we generate a temporary nginx configuration in backplane configuration directory and mount that to the container.
- When both containers start up successfully, the terminal waits for an interrupt. Upon receiving the interrupt signal, both containers are stopped and removed.

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [x] Included documentation changes with PR
