### PR TITLE
[OSD-20024] Allow GetRestConfigAsUser with elevationReason

### DIFF
--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -300,7 +300,7 @@ func GetRestConfig(bp config.BackplaneConfiguration, clusterID string) (*rest.Co
 // GetRestConfigAsUser returns a client-go *rest.Config like GetRestConfig, but supports configuring an
 // impersonation username. Commonly, this is "backplane-cluster-admin"
 // best practice would be to add at least one elevationReason in order to justity the impersonation
-func GetRestConfigAsUser(bp config.BackplaneConfiguration, clusterID, username string, elevationReason ...string) (*rest.Config, error) {
+func GetRestConfigAsUser(bp config.BackplaneConfiguration, clusterID, username string, elevationReasons ...string) (*rest.Config, error) {
 	cfg, err := GetRestConfig(bp, clusterID)
 	if err != nil {
 		return nil, err
@@ -308,7 +308,10 @@ func GetRestConfigAsUser(bp config.BackplaneConfiguration, clusterID, username s
 
 	cfg.Impersonate = rest.ImpersonationConfig{
 		UserName: username,
-		Extra: map[string][]string{"reason": elevationReason},
+	}
+
+	if len(elevationReasons) > 0 {
+		cfg.Impersonate.Extra = map[string][]string{"reason": elevationReasons}
 	}
 
 	return cfg, nil

--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -299,13 +299,17 @@ func GetRestConfig(bp config.BackplaneConfiguration, clusterID string) (*rest.Co
 
 // GetRestConfigAsUser returns a client-go *rest.Config like GetRestConfig, but supports configuring an
 // impersonation username. Commonly, this is "backplane-cluster-admin"
-func GetRestConfigAsUser(bp config.BackplaneConfiguration, clusterID, username string) (*rest.Config, error) {
+// best practice would be to add at least one elevationReason in order to justity the impersonation
+func GetRestConfigAsUser(bp config.BackplaneConfiguration, clusterID, username string, elevationReason ...string) (*rest.Config, error) {
 	cfg, err := GetRestConfig(bp, clusterID)
 	if err != nil {
 		return nil, err
 	}
 
-	cfg.Impersonate = rest.ImpersonationConfig{UserName: username}
+	cfg.Impersonate = rest.ImpersonationConfig{
+		UserName: username,
+		Extra: map[string][]string{"reason": elevationReason},
+	}
 
 	return cfg, nil
 }


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / Why we need it?
When we use GetRestConfigAsUser (eg in osdctl) we cannot specift a reason for the elevation.

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ x] Ran unit tests locally
- [ na] Validated the changes in a cluster
- [ na] Included documentation changes with PR
