### PR TITLE
Add Backplane URL deprecate env variable to control the warning message

### DIFF
--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -68,7 +68,10 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 
 	// Warn user if url defined in the config file
 	if viper.GetString("url") != "" {
-		logger.Warn("Manual URL configuration is deprecated, please remove URL key from Backplane configuration")
+		if _, ok := getBackplaneEnv(info.BackplaneURLDeprecateEnvName); !ok {
+			logger.Warn("Manual URL configuration is deprecated, please remove URL key from Backplane configuration")
+			os.Setenv(info.BackplaneURLDeprecateEnvName, "ok")
+		}
 	}
 
 	// Check if user has explicitly defined backplane URL via env; it has higher precedence over the ocm env URL

--- a/pkg/cli/config/config_test.go
+++ b/pkg/cli/config/config_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetBackplaneConfig(t *testing.T) {
+	t.Run("it returns the user defined proxy instead of the configuration variable", func(t *testing.T) {
+
+		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("dummy data"))
+		}))
+
+		userDefinedProxy := "example-proxy"
+		t.Setenv("BACKPLANE_URL", svr.URL)
+		t.Setenv("HTTPS_PROXY", userDefinedProxy)
+		config, err := GetBackplaneConfiguration()
+		if err != nil {
+			t.Error(err)
+		}
+
+		if config.ProxyURL != nil && *config.ProxyURL != userDefinedProxy {
+			t.Errorf("expected to return the explicitly defined proxy %v instead of the default one %v", userDefinedProxy, config.ProxyURL)
+		}
+	})
+
+}
+
+func TestGetBackplaneConnection(t *testing.T) {
+	t.Run("should fail if backplane API return connection errors", func(t *testing.T) {
+
+		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("dummy data"))
+		}))
+
+		proxyURL := "http://squid.myproxy.com"
+		t.Setenv("BACKPLANE_URL", svr.URL)
+		t.Setenv("HTTPS_PROXY", proxyURL)
+		config, err := GetBackplaneConfiguration()
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = config.CheckAPIConnection()
+		if err != nil {
+			t.Failed()
+		}
+
+	})
+
+	t.Run("should fail for empty proxy url", func(t *testing.T) {
+		config := BackplaneConfiguration{URL: "https://api-backplane.apps.openshiftapps.com", ProxyURL: nil}
+		err := config.CheckAPIConnection()
+
+		if err != nil {
+			t.Failed()
+		}
+	})
+}

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -8,10 +8,11 @@ import (
 
 const (
 	// Environment Variables
-	BackplaneURLEnvName        = "BACKPLANE_URL"
-	BackplaneProxyEnvName      = "HTTPS_PROXY"
-	BackplaneConfigPathEnvName = "BACKPLANE_CONFIG"
-	BackplaneKubeconfigEnvName = "KUBECONFIG"
+	BackplaneURLEnvName          = "BACKPLANE_URL"
+	BackplaneProxyEnvName        = "HTTPS_PROXY"
+	BackplaneConfigPathEnvName   = "BACKPLANE_CONFIG"
+	BackplaneKubeconfigEnvName   = "KUBECONFIG"
+	BackplaneURLDeprecateEnvName = "BACKPLANE_URL_DEPRECATE"
 
 	// Configuration
 	BackplaneConfigDefaultFilePath = ".config/backplane"


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / Why we need it?

backplane URL deprecate error message shows multiple time

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_ https://issues.redhat.com/browse/OSD-20028


### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
