### PR TITLE
[OSD-20017] create config file with login --multi even if target config file exists

### DIFF
--- a/pkg/login/kubeConfig.go
+++ b/pkg/login/kubeConfig.go
@@ -35,7 +35,7 @@ func CreateClusterKubeConfig(clusterID string, kubeConfig api.Config) (string, e
 		}
 	}
 
-	// Write kube config if file not exist
+	// Write kube config
 	filename := filepath.Join(path, "config")
 	f, err := os.Create(filename)
 	if err != nil {

--- a/pkg/login/kubeConfig.go
+++ b/pkg/login/kubeConfig.go
@@ -41,18 +41,16 @@ func CreateClusterKubeConfig(clusterID string, kubeConfig api.Config) (string, e
 	if err != nil {
 		return "", err
 	}
-	err = clientcmd.WriteToFile(kubeConfig, f.Name())
+	defer func() {
+		f.Close()
+	}()
 
-	if err != nil {
-		return "", err
-	}
-	err = f.Close()
+	err = clientcmd.WriteToFile(kubeConfig, f.Name())
 	if err != nil {
 		return "", err
 	}
 
 	// set kube config env with temp kube config file
-
 	err = os.Setenv(info.BackplaneKubeconfigEnvName, filename)
 	if err != nil {
 		return "", err

--- a/pkg/login/kubeConfig.go
+++ b/pkg/login/kubeConfig.go
@@ -37,21 +37,18 @@ func CreateClusterKubeConfig(clusterID string, kubeConfig api.Config) (string, e
 
 	// Write kube config if file not exist
 	filename := filepath.Join(path, "config")
-	_, err = os.Stat(filename)
-	if errors.Is(err, os.ErrNotExist) {
-		f, err := os.Create(filename)
-		if err != nil {
-			return "", err
-		}
-		err = clientcmd.WriteToFile(kubeConfig, f.Name())
+	f, err := os.Create(filename)
+	if err != nil {
+		return "", err
+	}
+	err = clientcmd.WriteToFile(kubeConfig, f.Name())
 
-		if err != nil {
-			return "", err
-		}
-		err = f.Close()
-		if err != nil {
-			return "", err
-		}
+	if err != nil {
+		return "", err
+	}
+	err = f.Close()
+	if err != nil {
+		return "", err
 	}
 
 	// set kube config env with temp kube config file

--- a/pkg/login/kubeConfig_test.go
+++ b/pkg/login/kubeConfig_test.go
@@ -3,6 +3,7 @@ package login
 import (
 	"errors"
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -37,18 +38,28 @@ var _ = Describe("Login Kube Config test", func() {
 	})
 
 	Context("save kubeconfig ", func() {
-		It("should save cluster kube config in cluster folder", func() {
+		It("should save cluster kube config in cluster folder, and replace it on second call", func() {
 
 			err := SetKubeConfigBasePath(kubePath)
 			Expect(err).To(BeNil())
-			path, err := CreateClusterKubeConfig(testClusterID, kubeConfig)
 
+			path, err := CreateClusterKubeConfig(testClusterID, kubeConfig)
 			Expect(err).To(BeNil())
 			Expect(path).Should(ContainSubstring(testClusterID))
 
 			//check file is exist
-			_, err = os.Stat(path)
+			firstStat, err := os.Stat(path)
 			Expect(err).To(BeNil())
+
+			time.Sleep(1 * time.Second)
+			path, err = CreateClusterKubeConfig(testClusterID, kubeConfig)
+			Expect(err).To(BeNil())
+			Expect(path).Should(ContainSubstring(testClusterID))
+
+			//check file has been replaced
+			secondStat, err := os.Stat(path)
+			Expect(err).To(BeNil())
+			Expect(firstStat).ToNot(Equal(secondStat))
 		})
 	})
 


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

Without this change, when using login --multi on a cluster where we already did it, but where credentials expired, the connection will not work.

### Which Jira/Github issue(s) does this PR fix?

Resolves #[OSD-20017](https://issues.redhat.com//browse/OSD-20017)

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ x] Ran unit tests locally
- [ x] Validated the changes in a cluster
- [na ] Included documentation changes with PR
