### PR TITLE
[OSD-19188] remove the backplane url checks from cloud subcommands

### DIFF
--- a/cmd/ocm-backplane/cloud/console.go
+++ b/cmd/ocm-backplane/cloud/console.go
@@ -2,12 +2,12 @@ package cloud
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
 
 	ocmsdk "github.com/openshift-online/ocm-cli/pkg/ocm"
+
 	"github.com/openshift/backplane-cli/pkg/ocm"
 
 	"github.com/pkg/browser"
@@ -126,10 +126,6 @@ func runConsole(cmd *cobra.Command, argv []string) (err error) {
 	// ============Get Backplane URl ==========================
 	if credentialArgs.backplaneURL != "" { // Overwrite if parameter is set
 		backplaneConfiguration.URL = credentialArgs.backplaneURL
-	}
-
-	if backplaneConfiguration.URL == "" {
-		return errors.New("empty backplane url - check your backplane-cli configuration")
 	}
 	logger.Infof("Using backplane URL: %s\n", backplaneConfiguration.URL)
 

--- a/cmd/ocm-backplane/cloud/credentials.go
+++ b/cmd/ocm-backplane/cloud/credentials.go
@@ -2,17 +2,17 @@ package cloud
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	ocmsdk "github.com/openshift-online/ocm-cli/pkg/ocm"
+	logger "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+
 	"github.com/openshift/backplane-cli/pkg/cli/config"
 	bpCredentials "github.com/openshift/backplane-cli/pkg/credentials"
 	"github.com/openshift/backplane-cli/pkg/ocm"
 	"github.com/openshift/backplane-cli/pkg/utils"
-	logger "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	"sigs.k8s.io/yaml"
 )
 
 var GetBackplaneClusterFromConfig = utils.DefaultClusterUtils.GetBackplaneClusterFromConfig
@@ -94,10 +94,6 @@ func runCredentials(cmd *cobra.Command, argv []string) error {
 	// ============Get Backplane URl ==========================
 	if credentialArgs.backplaneURL != "" { // Overwrite if parameter is set
 		backplaneConfiguration.URL = credentialArgs.backplaneURL
-	}
-
-	if backplaneConfiguration.URL == "" {
-		return errors.New("empty backplane url - check your backplane-cli configuration")
 	}
 	logger.Infof("Using backplane URL: %s\n", backplaneConfiguration.URL)
 


### PR DESCRIPTION
### What type of PR is this?

_(cleanup)_

### What this PR does / Why we need it?

With the previous changes, the `backplaneConfiguration` should always have the URL value set, if not, it will return with error earlier. 

### Pre-checks (if applicable)

- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
