### PR TITLE
Always use isolated flow for HCP clusters

### DIFF
--- a/cmd/ocm-backplane/cloud/common.go
+++ b/cmd/ocm-backplane/cloud/common.go
@@ -56,7 +56,7 @@ func (cfg *QueryConfig) GetAWSV2Config() (aws.Config, error) {
 	return awsCreds.AWSV2Config()
 }
 
-// GetCloudCredentials returns Cloud Credentials Response
+// GetCloudConsole returns Cloud Credentials Response
 func (cfg *QueryConfig) GetCloudConsole() (*ConsoleResponse, error) {
 	ocmToken, _, err := cfg.OcmConnection.Tokens()
 	if err != nil {
@@ -281,6 +281,10 @@ func (cfg *QueryConfig) getIsolatedCredentials(ocmToken string) (aws.Credentials
 }
 
 func isIsolatedBackplaneAccess(cluster *cmv1.Cluster, ocmConnection *ocmsdk.Connection) (bool, error) {
+	if cluster.Hypershift().Enabled() {
+		return true, nil
+	}
+
 	if cluster.AWS().STS().Enabled() {
 		stsSupportJumpRole, err := ocm.DefaultOCMInterface.GetStsSupportJumpRoleARN(ocmConnection, cluster.ID())
 		if err != nil {

--- a/cmd/ocm-backplane/cloud/common_test.go
+++ b/cmd/ocm-backplane/cloud/common_test.go
@@ -202,6 +202,19 @@ var _ = Describe("isIsolatedBackplaneAccess", func() {
 	})
 
 	Context("Execute isIsolatedBackplaneAccess", func() {
+		It("returns true immediately if the cluster is hypershift enabled", func() {
+			hyperShiftBuilder := &cmv1.HypershiftBuilder{}
+			hyperShiftBuilder.Enabled(true)
+
+			clusterBuilder := cmv1.ClusterBuilder{}
+			clusterBuilder.Hypershift(hyperShiftBuilder)
+
+			cluster, _ := clusterBuilder.Build()
+			result, err := isIsolatedBackplaneAccess(cluster, nil)
+
+			Expect(result).To(Equal(true))
+			Expect(err).To(BeNil())
+		})
 		It("returns an error if fails to get STS Support Jump Role from OCM for STS enabled cluster", func() {
 			mockOcmInterface.EXPECT().GetStsSupportJumpRoleARN(&sdk.Connection{}, testClusterID).Return("", errors.New("oops"))
 


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / Why we need it?
If we are dealing with an HCP cluster, there is no reason to call OCM to determine which flow to use. All HCP clusters must be on the new flow.

### Which Jira/Github issue(s) does this PR fix?
[OSD-20257](https://issues.redhat.com//browse/OSD-20257)

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster