### PR TITLE
[OSD-19314] - Update the bp-cli release script to add version comparison mechanism

### DIFF
--- a/ci-release.sh
+++ b/ci-release.sh
@@ -10,6 +10,12 @@ if [ -z "$VERSION" ]; then
     exit 1
 fi
 
+# Check if the tag already exists in the repository
+if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+    echo "Error: Tag v$VERSION already exists. Aborting release."
+    exit 1
+fi
+
 # Git configurations
 git config user.name "CI release"
 git config user.email "ci-test@release.com"


### PR DESCRIPTION
### What type of PR is this?

_(feature)_

### What this PR does / Why we need it?
Update the `ci-release.sh` script to add a version comparison mechanism.  If the tag already exists, the new script aborts the release process, thereby preventing the re-release of an existing version.

### Which Jira/Github issue(s) does this PR fix?
https://issues.redhat.com/browse/OSD-19314
