### PR TITLE
Modify the awk command to exclude the rhel-specific binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ WORKDIR /oc
 # Download the checksum
 RUN curl -sSLf ${OC_URL}/sha256sum.txt -o sha256sum.txt
 # Download the amd64 binary tarball
-RUN curl -sSLf -O ${OC_URL}/$(awk -v asset="openshift-client-linux" '$0~asset {print $2}' sha256sum.txt | grep -v arm64)
+RUN curl -sSLf -O ${OC_URL}/$(awk -v asset="openshift-client-linux" '$0~asset {print $2}' sha256sum.txt | grep -v arm64 | grep -v rhel)
 # Check the tarball and checksum match
 RUN sha256sum --check --ignore-missing sha256sum.txt
 RUN tar --extract --gunzip --no-same-owner --directory /out oc --file *.tar.gz


### PR DESCRIPTION
### What type of PR is this?

_(bug)_

### What this PR does / Why we need it?
To modify the awk command to exclude the rhel-specific binary to avoid curl resolving issues

### Which Jira/Github issue(s) does this PR fix?
To fix the curl resolving issue in prow job

### Special notes for your reviewer
[SLACK THREAD for more context](https://redhat-internal.slack.com/archives/C016S65RNG5/p1709249252551559?thread_ts=1709147482.559129&cid=C016S65RNG5)
