### PR TITLE
Fix monitoring-plugin on podman

### DIFF
--- a/cmd/ocm-backplane/console/console.go
+++ b/cmd/ocm-backplane/console/console.go
@@ -567,9 +567,8 @@ func (o *consoleOptions) runMonitorPlugin(ce containerEngineInterface) error {
 	}
 	// Setup nginx configurations
 	config := fmt.Sprintf(info.MonitoringPluginNginxConfigTemplate, o.monitorPluginPort)
-	err := ce.putFileToMount(info.MonitoringPluginNginxConfigFilename, []byte(config))
-	if err != nil {
-		return nil
+	if err := ce.putFileToMount(info.MonitoringPluginNginxConfigFilename, []byte(config)); err != nil {
+		return err
 	}
 
 	clusterID, err := getClusterID()
@@ -1209,7 +1208,7 @@ func (ce *podmanMac) putFileToMount(filename string, content []byte) error {
 	// To do so, we encode the content, send it to VM via ssh then decode it.
 	dstFilename := filepath.Join("/tmp/", filename)
 	contentEncoded := base64.StdEncoding.EncodeToString(content)
-	writeConfigCmd := fmt.Sprintf("podman machine ssh \"echo %s | base64 -d > %s \"", contentEncoded, dstFilename)
+	writeConfigCmd := fmt.Sprintf("podman machine ssh $(podman machine info --format {{.Host.CurrentMachine}}) \"echo %s | base64 -d > %s \"", contentEncoded, dstFilename)
 	logger.Debugf("Executing: %s\n", writeConfigCmd)
 	writeConfigOutput, err := createCommand("bash", "-c", writeConfigCmd).CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / Why we need it?
This fixes a bug where if `ce.putFileToMount` encountered an error, it wouldn't be passed through. This resulted in a situation where the monitoring plugin wouldn't start, but no error would be passed (even with debug).

It also fixes the root bug that was causing `ce.putFileToMount` to fail. The `podman machine ssh` command requires the name of the machine you are SSH'ing into to be specified if you are putting an in-line command command.

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [x] Included documentation changes with PR
