### PR TITLE
OSD-19615: Enhance backplane-cli verbose messages for login subcommand

### DIFF
--- a/pkg/login/kubeConfig.go
+++ b/pkg/login/kubeConfig.go
@@ -1,6 +1,7 @@
 package login
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -110,6 +111,8 @@ func SaveKubeConfig(clusterID string, config api.Config, isMulti bool, kubePath 
 		}
 	}
 	logger.Debugln("Wrote Kube configuration")
+	conf, _ := json.Marshal(config)
+	logger.Debugln(string(conf))
 	return nil
 }
 


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / Why we need it?
This commit adds some more detailed debug printouts for the ocm-backplane login command, the printouts could be used by using  --verbosity=debug.

e.g 
```
./ocm-backplane --verbosity=debug login <cluster identification>
```


### Which Jira/Github issue(s) does this PR fix?
[OSD-19615](https://issues.redhat.com/browse/OSD-19615)

_Resolves #_

### Special notes for your reviewer

### Pre-checks (if applicable)

- X Ran unit tests locally
- X Validated the changes in a cluster
- [ ] Included documentation changes with PR
