### PR TITLE
fix: Include condition to check if arg pd is empty

### DIFF
--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -136,7 +136,7 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 		clusterKey = argv[0]
 		logger.WithField("Search Key", clusterKey).Debugln("Finding target cluster")
 
-	} else if len(argv) == 0 {
+	} else if len(argv) == 0 && args.pd == "" {
 		// if no args given, try to log into the cluster that the user is logged into
 		logger.Debugf("Finding Clustrer Key from current cluster")
 		clusterInfo, err := utils.DefaultClusterUtils.GetBackplaneClusterFromConfig()


### PR DESCRIPTION
### What type of PR is this?
bug fix

### What this PR does / Why we need it?
> ERRO[0003] invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable

Fixes login via PagerDuty incident link or ID.

### Which Jira/Github issue(s) does this PR fix?
[#368](https://github.com/openshift/backplane-cli/pull/368)
