### PR TITLE
OSD-21670: Reduce verbosity level of pd-token config

### DIFF
--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -83,10 +83,7 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 		}
 	}
 
-	bpConfig.SessionDirectory = viper.GetString("session-dir")
-	bpConfig.AssumeInitialArn = viper.GetString("assume-initial-arn")
-
-	// proxyURL is optional
+	// proxyURL is required
 	proxyInConfigFile := viper.GetStringSlice("proxy-url")
 	proxyURL := bpConfig.getFirstWorkingProxyURL(proxyInConfigFile)
 	if proxyURL != "" {
@@ -95,11 +92,15 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 		logger.Warn("No proxy configuration available. This may result in failing commands as backplane-api is only available from select networks.")
 	}
 
+	bpConfig.SessionDirectory = viper.GetString("session-dir")
+	bpConfig.AssumeInitialArn = viper.GetString("assume-initial-arn")
+
+	// pagerDuty token is optional
 	pagerDutyAPIKey := viper.GetString("pd-key")
 	if pagerDutyAPIKey != "" {
 		bpConfig.PagerDutyAPIKey = pagerDutyAPIKey
 	} else {
-		logger.Warn("No PagerDuty API Key configuration available. This will result in failure of `ocm-backplane login --pd <incident-id>` command.")
+		logger.Info("No PagerDuty API Key configuration available. This will result in failure of `ocm-backplane login --pd <incident-id>` command.")
 	}
 
 	return bpConfig, nil


### PR DESCRIPTION
### What type of PR is this?

Bug

### What this PR does / Why we need it?
PD token config missing warning shows when users login to the cluster 

### Which Jira/Github issue(s) does this PR fix?
https://issues.redhat.com/browse/OSD-21670


### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
