### PR TITLE
OSD-19729: Enables ocm backplane login to provide  default namespace as an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ In this example, we will login to a cluster with id `123456abcdef` in production
 - Run `oc` command to access the target cluster.
   ```
   $ oc whoami
-  system:serviceaccount:openshift-backplane-srep:1234567
+  system:serviceaccount:default:1234567
   ```
   
 - To login to the Management cluster for HyperShift (or) the managing Hive shard of normal OSD/ROSA cluster

--- a/cmd/ocm-backplane/login/login_test.go
+++ b/cmd/ocm-backplane/login/login_test.go
@@ -13,11 +13,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/clientcmd/api"
-
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-
 	"github.com/openshift/backplane-cli/pkg/backplaneapi"
 	backplaneapiMock "github.com/openshift/backplane-cli/pkg/backplaneapi/mocks"
 	"github.com/openshift/backplane-cli/pkg/cli/config"
@@ -26,6 +22,8 @@ import (
 	"github.com/openshift/backplane-cli/pkg/ocm"
 	ocmMock "github.com/openshift/backplane-cli/pkg/ocm/mocks"
 	"github.com/openshift/backplane-cli/pkg/utils"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 func MakeIoReader(s string) io.ReadCloser {
@@ -255,6 +253,29 @@ var _ = Describe("Login command", func() {
 			Expect(len(cfg.Contexts)).To(Equal(1))
 			Expect(cfg.Contexts["default/test123/anonymous"].Cluster).To(Equal(testClusterID))
 			Expect(cfg.Contexts["default/test123/anonymous"].Namespace).To(Equal("default"))
+		})
+
+		It("when the namespace of the context is passed as an argument", func() {
+			err := utils.CreateTempKubeConfig(nil)
+			args.defaultNamespace = "default"
+			Expect(err).To(BeNil())
+			mockOcmInterface.EXPECT().GetOCMEnvironment().Return(ocmEnv, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(trueClusterID, testClusterID, nil)
+			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterID)).Return(false, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil)
+			mockClientUtil.EXPECT().MakeRawBackplaneAPIClientWithAccessToken(backplaneAPIURI, testToken).Return(mockClient, nil)
+			mockClient.EXPECT().LoginCluster(gomock.Any(), gomock.Eq(trueClusterID)).Return(fakeResp, nil)
+
+			err = runLogin(nil, []string{testClusterID})
+
+			Expect(err).To(BeNil())
+
+			cfg, err := utils.ReadKubeconfigRaw()
+			Expect(err).To(BeNil())
+			Expect(cfg.CurrentContext).To(Equal("default/test123/anonymous"))
+			Expect(len(cfg.Contexts)).To(Equal(1))
+			Expect(cfg.Contexts["default/test123/anonymous"].Cluster).To(Equal(testClusterID))
+			Expect(cfg.Contexts["default/test123/anonymous"].Namespace).To(Equal(args.defaultNamespace))
 		})
 
 		It("Should fail when trying to find a non existent cluster", func() {

--- a/docs/PS1-setup.md
+++ b/docs/PS1-setup.md
@@ -5,7 +5,7 @@ You can use the below methods to set the shell prompt, so you can learn which cl
 [user@user ~ (⎈ |stg/user-test-1.zlob.s1:default)]$ date
 Tue Sep  7 17:40:35 CST 2021
 [user@user ~ (⎈ |stg/user-test-1.zlob.s1:default)]$ oc whoami
-system:serviceaccount:openshift-backplane-srep:xxxxxxxxxxxx
+system:serviceaccount:default:xxxxxxxxxxxx
 ~~~
 
 ## Bash

--- a/docs/design.md
+++ b/docs/design.md
@@ -16,7 +16,7 @@ When executing `ocm backplane login <cluster-id>`, it will:
   - Create a script file in `$HOME/.kube/ocm-token` for later use. As backplane uses OCM token for authentication, the `ocm-token` script will call `ocm token` to get a fresh access token, and feed to the `oc` command.
   - Create cluster in `kubeconfig`. The `server` of the cluster points to the proxy url just received.
   - Create user in `kubeconfig`. The user has an [ExecConfig](https://godoc.org/k8s.io/client-go/tools/clientcmd/api#ExecConfig) pointing to the script just created.
-  - Create a context using the cluster & user just created, and set it to current context.
+  - Create a context using the cluster, namespace passed as an argument( default: default ) & user just created, and set it to current context.
 
 ### Logout
 


### PR DESCRIPTION
### What type of PR is this?
- feature
- documentation
- unit-test
### What this PR does / Why we need it?
As a SRE, I want backplane login to prompt for a  default namespace for me to run commands like oc debug node/xxx.
### Which Jira/Github issue(s) does this PR fix?

_Resolves #_[OSD-19729](https://issues.redhat.com//browse/OSD-19729)

### Special notes for your reviewer
Once merged,  `./ocm-backplane login --help`  will display                                                                                                                                                                          
```
Running login command will send a request to backplane api
...
Usage:
  ocm-backplane login <CLUSTERID|EXTERNAL_ID|CLUSTER_NAME|CLUSTER_NAME_SEARCH> [flags]
...
Flags:
     -n,  --namespace string   Sets a default namespace for SRE to run commands like oc debug node/xxx
...  
Example: 
Considering cluster name as asathe-19729     

- Without options

```
./ocm-backplane login asathe-19729
oc project
```
Output will be

> _Using project "default" on server "https://api.stage.backplane.openshift.com/backplane/cluster/2afh53rispkj3vbsp6asa4f7hlpb78uv/"._

- By passing a valid kubernetes namespace to the option ' **_namespace_** '
```
./ocm-backplane login --namespace openshift-sre-pruning   28lje9u3jd59j3dmf36sojgpa32qrag3
oc project
```
Output will be
`_Using project "openshift-backplane-srep" on server "https://api.stage.backplane.openshift.com/backplane/cluster/2afh53rispkj3vbsp6asa4f7hlpb78uv/"._`

- By passing an **invalid  namespace** to the option ' **_namespace_** '
```
./ocm-backplane login --namespace ""   asathe-19729
```

Following error  displayed.
_ERRO[0016]  is not a valid namespace_

```
./ocm-backplane login --namespace 'kube_system'   asathe-19729
```
Following error  displayed.                                                                                                                                
ERRO[0012] kube_system is not a valid namespace
```
Hence, the command "**oc status**" will display the following error
_error: Missing or incomplete configuration info.  Please point to an existing, complete config file:_


Please do refer to  the prior discussion in the https://github.com/openshift/backplane-cli/pull/315  .

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [x] Included documentation changes with PR
