### PR TITLE
Update dockerfile to exclude all arch binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ WORKDIR /oc
 # Download the checksum
 RUN curl -sSLf ${OC_URL}/sha256sum.txt -o sha256sum.txt
 # Download the amd64 binary tarball
-RUN curl -sSLf -O ${OC_URL}/$(awk -v asset="openshift-client-linux" '$0~asset {print $2}' sha256sum.txt | grep -v arm64 | grep -v rhel)
+RUN curl -sSLf -O ${OC_URL}/$(awk -v asset="openshift-client-linux" '$0~asset {print $2}' sha256sum.txt | grep -v arm64 | grep -v ppc64 | grep -v amd64)
 # Check the tarball and checksum match
 RUN sha256sum --check --ignore-missing sha256sum.txt
 RUN tar --extract --gunzip --no-same-owner --directory /out oc --file *.tar.gz


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

This PR will fix the failed build `ci/prow/images `  :
 https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_backplane-cli/386/pull-ci-openshift-backplane-cli-main-images/1775807436830019584 

### Which Jira/Github issue(s) does this PR fix?

https://issues.redhat.com/browse/OSD-22036

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
