### PR TITLE
OSD-21691 : Add domain prefix in place of cluster name for cluster namespace

### DIFF
--- a/cmd/ocm-backplane/login/login_test.go
+++ b/cmd/ocm-backplane/login/login_test.go
@@ -292,6 +292,7 @@ var _ = Describe("Login command", func() {
 
 		It("should return the managing cluster if one is requested", func() {
 			globalOpts.Manager = true
+			mockOcmInterface.EXPECT().GetClusterInfoByID(gomock.Any()).Return(mockCluster, nil).AnyTimes()
 			mockOcmInterface.EXPECT().GetOCMEnvironment().Return(ocmEnv, nil).AnyTimes()
 			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(trueClusterID, testClusterID, nil)
 			mockOcmInterface.EXPECT().GetManagingCluster(trueClusterID).Return(managingClusterID, managingClusterID, true, nil)


### PR DESCRIPTION
### What type of PR is this?

_bug_

### What this PR does / Why we need it?
This will list the correct namespace when logging into the cluster's management cluster
 
### Which Jira/Github issue(s) does this PR fix?
_Resolves_ #[OSD-21691](https://issues.redhat.com/browse/OSD-21691)

### Special notes for your reviewer
Checked in a HCP staging cluster:
OCM Get:
![image](https://github.com/openshift/backplane-cli/assets/73513838/3f614fed-015e-4879-b06c-ed1c3af03349)
Before Change:
![image](https://github.com/openshift/backplane-cli/assets/73513838/f7d2ccbf-77f2-44d3-a011-dc019582f60b)
After adding domain-prefix:
![image](https://github.com/openshift/backplane-cli/assets/73513838/8388eb34-24cc-4244-a31a-58b8a954ae9a)
### Pre-checks (if applicable)

- [X] Ran unit tests locally
- [X] Validated the changes in a cluster
- [ ] Included documentation changes with PR
