### PR TITLE
OSD-22522 elevate allows args with quotes

### DIFF
--- a/pkg/elevate/elevate.go
+++ b/pkg/elevate/elevate.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	logger "github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -45,11 +44,11 @@ func AddElevationReasonToRawKubeconfig(config api.Config, elevationReason string
 func RunElevate(argv []string) error {
 	logger.Debugln("Finding target cluster from kubeconfig")
 	config, err := ReadKubeConfigRaw()
-
 	if err != nil {
 		return err
 	}
 
+	logger.Debug("Adding impersonation RBAC allow permissions to kubeconfig")
 	err = AddElevationReasonToRawKubeconfig(config, argv[0])
 	if err != nil {
 		return err
@@ -73,42 +72,24 @@ func RunElevate(argv []string) error {
 		return err
 	}
 
-	logger.Debug("Adding impersonation RBAC allow permissions to kubeconfig")
-
-	elevateCmd := "oc " + strings.Join(argv[1:], " ")
-
-	// Make the Default SHELL environment variable to /bin/bash
-	shell := os.Getenv("SHELL")
-	if shell == "" || !utils.ShellChecker.IsValidShell(shell) {
-		if utils.ShellChecker.IsValidShell("/bin/bash") {
-			shell = "/bin/bash"
-		} else {
-			return fmt.Errorf("both the SHELL environment variable and /bin/bash are not set or invalid. Please ensure a valid shell is set in your environment")
-		}
-	}
-
-	logger.Debugln("Executing command with temporary kubeconfig as backplane-cluster-admin")
-
-	ocCmd := ExecCmd(shell, "-c", elevateCmd)
-	ocCmd.Env = append(ocCmd.Env, os.Environ()...)
-	ocCmd.Stdin = os.Stdin
-	ocCmd.Stderr = os.Stderr
-	ocCmd.Stdout = os.Stdout
-
-	if err != nil {
-		return err
-	}
-
-	err = ocCmd.Run()
-
-	kubeconfigPath, _ := os.LookupEnv("KUBECONFIG")
+	// As WriteKubeconfigToFile is also creating a tempory file reference by new KUBECONFIG variable setting,
+	// we need to take care of its cleanup
+	tempKubeconfigPath, _ := os.LookupEnv("KUBECONFIG")
 	defer func() {
-		logger.Debugln("Cleaning up temporary kubeconfig", kubeconfigPath)
-		err := OsRemove(kubeconfigPath)
+		logger.Debugln("Cleaning up temporary kubeconfig", tempKubeconfigPath)
+		err := OsRemove(tempKubeconfigPath)
 		if err != nil {
 			fmt.Println(err)
 		}
 	}()
+
+	logger.Debugln("Executing command with temporary kubeconfig as backplane-cluster-admin")
+	ocCmd := ExecCmd("oc", argv[1:]...)
+	ocCmd.Env = append(ocCmd.Env, os.Environ()...)
+	ocCmd.Stdin = os.Stdin
+	ocCmd.Stderr = os.Stderr
+	ocCmd.Stdout = os.Stdout
+	err = ocCmd.Run()
 	if err != nil {
 		return err
 	}

--- a/pkg/elevate/elevate_test.go
+++ b/pkg/elevate/elevate_test.go
@@ -7,9 +7,6 @@ import (
 	"os/exec"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-	"github.com/openshift/backplane-cli/pkg/utils"
-	mocks2 "github.com/openshift/backplane-cli/pkg/utils/mocks"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 
@@ -29,6 +26,34 @@ func fakeExecCommandSuccess(command string, args ...string) *exec.Cmd {
 	return cmd
 }
 
+var fakeAPIConfig = api.Config {
+	Kind:        "Config",
+	APIVersion:  "v1",
+	Preferences: api.Preferences{},
+	Clusters: map[string]*api.Cluster{
+		"dummy_cluster": {
+			Server: "https://api-backplane.apps.something.com/backplane/cluster/configcluster",
+		},
+	},
+	AuthInfos: map[string]*api.AuthInfo{
+		"anonymous": {
+			LocationOfOrigin: "England",
+		},
+	},
+	Contexts: map[string]*api.Context{
+		"default/test123/anonymous": {
+			Cluster:   "dummy_cluster",
+			Namespace: "default",
+			AuthInfo:  "anonymous",
+		},
+	},
+	CurrentContext: "default/test123/anonymous",
+}
+
+func fakeReadKubeConfigRaw() (api.Config, error) {
+	return fakeAPIConfig, nil
+}
+
 func TestHelperProcessError(t *testing.T) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
 		return
@@ -45,67 +70,24 @@ func TestHelperProcessSuccess(t *testing.T) {
 }
 
 func TestAddElevationReasonToRawKubeconfig(t *testing.T) {
+	fakeAPIConfigNoUser := *fakeAPIConfig.DeepCopy()
+	delete(fakeAPIConfigNoUser.AuthInfos, "anonymous")
+	fakeAPIConfigNoUser.Contexts["default/test123/anonymous"].AuthInfo = ""
+
 	t.Run("It returns an error if there is no current kubeconfig context", func(t *testing.T) {
-		if err := AddElevationReasonToRawKubeconfig(
-			api.Config{},
-			"Production cluster",
-		); err == nil {
+		if err := AddElevationReasonToRawKubeconfig(api.Config{}, "Production cluster"); err == nil {
 			t.Error("Expected error, got nil")
 		}
 	})
 
 	t.Run("it returns an error if there is no user info in kubeconfig", func(t *testing.T) {
-		if err := AddElevationReasonToRawKubeconfig(
-			api.Config{
-				Kind:        "Config",
-				APIVersion:  "v1",
-				Preferences: api.Preferences{},
-				Clusters: map[string]*api.Cluster{
-					"dummy_cluster": {
-						Server: "https://api-backplane.apps.something.com/backplane/cluster/configcluster",
-					},
-				},
-				Contexts: map[string]*api.Context{
-					"default/test123/anonymous": {
-						Cluster:   "dummy_cluster",
-						Namespace: "default",
-					},
-				},
-				CurrentContext: "default/test123/anonymous",
-			},
-			"Production cluster",
-		); err == nil {
+		if err := AddElevationReasonToRawKubeconfig(fakeAPIConfigNoUser, "Production cluster"); err == nil {
 			t.Error("Expected error, got nil")
 		}
 	})
 
 	t.Run("it succeeds if the auth info exists for the current context", func(t *testing.T) {
-		if err := AddElevationReasonToRawKubeconfig(
-			api.Config{
-				Kind:        "Config",
-				APIVersion:  "v1",
-				Preferences: api.Preferences{},
-				Clusters: map[string]*api.Cluster{
-					"dummy_cluster": {
-						Server: "https://api-backplane.apps.something.com/backplane/cluster/configcluster",
-					},
-				},
-				AuthInfos: map[string]*api.AuthInfo{
-					"anonymous": {
-						LocationOfOrigin: "England",
-					},
-				},
-				Contexts: map[string]*api.Context{
-					"default/test123/anonymous": {
-						Cluster:   "dummy_cluster",
-						Namespace: "default",
-						AuthInfo:  "anonymous",
-					},
-				},
-				CurrentContext: "default/test123/anonymous",
-			},
-			"Production cluster",
-		); err != nil {
+		if err := AddElevationReasonToRawKubeconfig(fakeAPIConfig, "Production cluster"); err != nil {
 			t.Errorf("Expected no errors, got %v", err)
 		}
 	})
@@ -137,94 +119,36 @@ func TestRunElevate(t *testing.T) {
 	t.Run("It returns an error if the exec command has errors", func(t *testing.T) {
 		ExecCmd = fakeExecCommandError
 		OsRemove = os.Remove
-		ReadKubeConfigRaw = func() (api.Config, error) {
-			return api.Config{
-				Kind:        "Config",
-				APIVersion:  "v1",
-				Preferences: api.Preferences{},
-				Clusters: map[string]*api.Cluster{
-					"dummy_cluster": {
-						Server: "https://api-backplane.apps.something.com/backplane/cluster/configcluster",
-					},
-				},
-				AuthInfos: map[string]*api.AuthInfo{
-					"anonymous": {
-						LocationOfOrigin: "England",
-					},
-				},
-				Contexts: map[string]*api.Context{
-					"default/test123/anonymous": {
-						Cluster:   "dummy_cluster",
-						Namespace: "default",
-						AuthInfo:  "anonymous",
-					},
-				},
-				CurrentContext: "default/test123/anonymous",
-			}, nil
-		}
-
+		ReadKubeConfigRaw = fakeReadKubeConfigRaw
 		if err := RunElevate([]string{"oc", "get pods"}); err == nil {
 			t.Error("Expected error, got nil")
 		}
 	})
 
-	t.Run("It suceeds if the command succeeds and we can clean up the tmp kubeconfig", func(t *testing.T) {
+	t.Run("It suceeds if the command succeeds, we can clean up the tmp kubeconfig and KUBECONFIG is still set to previous definbed value", func(t *testing.T) {
 		ExecCmd = fakeExecCommandSuccess
 		OsRemove = func(name string) error { return nil }
-		ReadKubeConfigRaw = func() (api.Config, error) {
-			return api.Config{
-				Kind:        "Config",
-				APIVersion:  "v1",
-				Preferences: api.Preferences{},
-				Clusters: map[string]*api.Cluster{
-					"dummy_cluster": {
-						Server: "https://api-backplane.apps.something.com/backplane/cluster/configcluster",
-					},
-				},
-				AuthInfos: map[string]*api.AuthInfo{
-					"anonymous": {
-						LocationOfOrigin: "England",
-					},
-				},
-				Contexts: map[string]*api.Context{
-					"default/test123/anonymous": {
-						Cluster:   "dummy_cluster",
-						Namespace: "default",
-						AuthInfo:  "anonymous",
-					},
-				},
-				CurrentContext: "default/test123/anonymous",
-			}, nil
-		}
+		ReadKubeConfigRaw = fakeReadKubeConfigRaw
+		mockKubeconfig := "/tmp/dummy_kubeconfig"
+		os.Setenv("KUBECONFIG", mockKubeconfig)
 		if err := RunElevate([]string{"oc", "get pods"}); err != nil {
 			t.Errorf("Expected no errors, got %v", err)
 		}
+		if kubeconfigPath, kubeconfigDefined := os.LookupEnv("KUBECONFIG"); ! kubeconfigDefined || kubeconfigPath != mockKubeconfig {
+			t.Errorf("Expected KUBECONFIG to be definied to previous value, got %v", kubeconfigPath)
+		}
 	})
 
-	t.Run("It returns an error when SHELL environment variable is empty and /bin/bash is invalid", func(t *testing.T) {
-		mockCtrl := gomock.NewController(t)
-		defer mockCtrl.Finish()
-
-		mockShellChecker := mocks2.NewMockShellCheckerInterface(mockCtrl)
-		mockShellChecker.EXPECT().IsValidShell("").Return(false).AnyTimes()
-		mockShellChecker.EXPECT().IsValidShell("/bin/bash").Return(false).Times(1)
-
-		// Inject the mockShellChecker into the actual code
-		originalShellChecker := utils.ShellChecker
-		defer func() { utils.ShellChecker = originalShellChecker }()
-		utils.ShellChecker = mockShellChecker
-
-		os.Setenv("SHELL", "")
-		defer os.Unsetenv("SHELL")
-
-		// Run the elevate command with the SHELL environment variable empty
-		err := RunElevate([]string{"elevate-reason", "oc", "get", "pods"})
-
-		expectedErrorMsg := "both the SHELL environment variable and /bin/bash are not set or invalid. Please ensure a valid shell is set in your environment"
-		if err == nil {
-			t.Errorf("expected an error when SHELL environment variable is empty and /bin/bash is invalid, got nil")
-		} else if err.Error() != expectedErrorMsg {
-			t.Errorf("expected error message to be: '%s', but got: '%s'", expectedErrorMsg, err.Error())
+	t.Run("It suceeds if the command succeeds, we can clean up the tmp kubeconfig and KUBECONFIG is still not set", func(t *testing.T) {
+		ExecCmd = fakeExecCommandSuccess
+		OsRemove = func(name string) error { return nil }
+		ReadKubeConfigRaw = fakeReadKubeConfigRaw
+		os.Unsetenv("KUBECONFIG")
+		if err := RunElevate([]string{"oc", "get pods"}); err != nil {
+			t.Errorf("Expected no errors, got %v", err)
+		}
+		if kubeconfigPath, kubeconfigDefined := os.LookupEnv("KUBECONFIG"); kubeconfigDefined {
+			t.Errorf("Expected KUBECONFIG to not be definied as previously, got %v", kubeconfigPath)
 		}
 	})
 


### PR DESCRIPTION
### What type of PR is this?

_bug_

### What this PR does / Why we need it?

_ref [OSD-22522](https://issues.redhat.com//browse/OSD-22522)_

When running ocm backplane elevate with args containing single/double quotes, those args are not managed properly. Here is an exemple:
```
$ ocm-backplane elevate test -- -n openshift-operator-lifecycle-manager patch deployment packageserver \  
  --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "xxx"}]' \  
  -o yaml --dry-run=client
error: unable to parse "[{op:": yaml: line 1: did not find expected node content
ERRO[0000] exit status 1 
```

### Which Jira/Github issue(s) does this PR fix?

_Resolves #[OSD-22522](https://issues.redhat.com//browse/OSD-22522)_

### Special notes for your reviewer

With this change, we can now use args with quotes as we can see here:
```
$ ./ocm-backplane elevate test -- -n openshift-operator-lifecycle-manager patch deployment packageserver \  
  --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "xxx"}]' \  
  -o yaml --dry-run=client | yq .spec.template.spec.containers[0].command
- /bin/package-server
- -v=4
- --secure-port
- "5443"
- --global-namespace
- openshift-marketplace
- xxx
```

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
