### PR TITLE
OSD-22935: Remove use of dummy.com from test cases in backplane-cli

### DIFF
--- a/pkg/cli/config/config_test.go
+++ b/pkg/cli/config/config_test.go
@@ -79,27 +79,27 @@ func TestBackplaneConfiguration_getFirstWorkingProxyURL(t *testing.T) {
 		},
 		{
 			name:    "valid-proxies",
-			proxies: []string{"https://dummy.com"},
+			proxies: []string{"https://proxy.invalid"},
 			clientDoFunc: func(client *http.Client, req *http.Request) (*http.Response, error) {
 				return &http.Response{StatusCode: http.StatusOK}, nil
 			},
-			want: "https://dummy.com",
+			want: "https://proxy.invalid",
 		},
 		{
 			name:    "multiple-valid-proxies",
-			proxies: []string{"https://dummy.com", "https://dummy.proxy"},
+			proxies: []string{"https://proxy.invalid", "https://dummy.proxy.invalid"},
 			clientDoFunc: func(client *http.Client, req *http.Request) (*http.Response, error) {
 				return &http.Response{StatusCode: http.StatusOK}, nil
 			},
-			want: "https://dummy.com",
+			want: "https://proxy.invalid",
 		},
 		{
 			name:    "multiple-mixed-proxies",
-			proxies: []string{"-", "gellso", "https://dummy.com"},
+			proxies: []string{"-", "gellso", "https://proxy.invalid"},
 			clientDoFunc: func(client *http.Client, req *http.Request) (*http.Response, error) {
 				return &http.Response{StatusCode: http.StatusOK}, nil
 			},
-			want: "https://dummy.com",
+			want: "https://proxy.invalid",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### What type of PR is this?
unit-test
_(bug/feature/cleanup/documentation/unit-test)_

### What this PR does / Why we need it?
Replaces "dummy.com" used in unit tests with "proxy.invalid"  because dummy.com is considered malicious
### Which Jira/Github issue(s) does this PR fix?
[OSD-22935](https://issues.redhat.com//browse/OSD-22935)
_Resolves #_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
