### PR TITLE
Use replace

### DIFF
--- a/cmd/ocm-backplane/console/console.go
+++ b/cmd/ocm-backplane/console/console.go
@@ -1044,6 +1044,7 @@ func podmanRunConsoleContainer(containerName string, port string, consoleArgs []
 		"--rm",
 		"--detach", // run in background
 		"--name", containerName,
+		"--replace", // when name is already in use, --replace to instruct Podman to do so
 		"--publish", fmt.Sprintf("127.0.0.1:%s:%s", port, port),
 	}
 	for _, e := range envVars {


### PR DESCRIPTION
### What type of PR is this?

_feature_

### What this PR does / Why we need it?

handles cases when the container name "console-$ID" is already in use, by adding --replace to the podman run args

### Which Jira/Github issue(s) does this PR fix?

```
[~ {prod} (hive-stage-01.n1u3.p1:default)]$ cluster-console                                                                                                                                    
== Console is available at http://127.0.0.1:35435 ==
                                               
^Z                                                                                                                                                                                             
[1]+  Stopped                 cluster-console                                                  
[~ {prod} (hive-stage-01.n1u3.p1:default)]$ cluster-console 
Error: creating container storage: the container name "console-1dn9fsn53b9vh3m63n8ajr679cslbkhd" is already in use by e8cea7d13298f3468ba857e709e0fc5cc6f8adf070bb300bef0823b2771449ed. You hav
e to remove that container to be able to reuse that name: that name is already in use, or use --replace to instruct Podman to do so.                                                                                                                                                                                                                       
```

### Special notes for your reviewer

with the change

```
[~ {prod} ]$ podman ps -a
CONTAINER ID  IMAGE                                                                                                                   COMMAND               CREATED         STATUS      PORTS  
     NAMES
94044763cedb  quay.io/taislam_osd/openshift-console:latest                                                                            /opt/bridge/bin/b...  24 minutes ago  Created            
     console-1lovg6qv4k1mathpcauk2tajn7qqaktm
8030bf8e865d  quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4a38a32affff30d07ca0da00dd54c8d556ca8137755a6fe4889c7a2fc62a3df4                        24 minutes ago  Created            
     monitoring-plugin-1lovg6qv4k1mathpcauk2tajn7qqaktm
[~ {prod} ]$ cp ~/scratch/src/github/openshift/backplane-cli/dist/ocm-backplane_linux_amd64_v1/ocm-backplane /usr/local/bin/ocm-backplane
cp: overwrite '/usr/local/bin/ocm-backplane'? y
[~ {prod} ]$ ocm-backplane login hive-stage-01
WARN[0001] Your Backplane CLI is not up to date. Please run the command 'ocm backplane upgrade' to upgrade to the latest version  Current version=v0.1.30-next Latest version=0.1.30
[~ {prod} (hive-stage-01.n1u3.p1:default)]$ cluster-console 
== Console is available at http://127.0.0.1:36559 ==

```

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- Not applicable: Included documentation changes with PR
