### PR TITLE
[OSD-21620] Add validation for the backplane config file

### DIFF
--- a/cmd/ocm-backplane/console/console.go
+++ b/cmd/ocm-backplane/console/console.go
@@ -34,10 +34,6 @@ import (
 
 	"github.com/Masterminds/semver"
 	homedir "github.com/mitchellh/go-homedir"
-	"github.com/openshift/backplane-cli/pkg/cli/config"
-	"github.com/openshift/backplane-cli/pkg/info"
-	"github.com/openshift/backplane-cli/pkg/ocm"
-	"github.com/openshift/backplane-cli/pkg/utils"
 	consolev1typedclient "github.com/openshift/client-go/console/clientset/versioned/typed/console/v1"
 	consolev1alpha1typedclient "github.com/openshift/client-go/console/clientset/versioned/typed/console/v1alpha1"
 	operatorv1typedclient "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
@@ -49,6 +45,11 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	"github.com/openshift/backplane-cli/pkg/cli/config"
+	"github.com/openshift/backplane-cli/pkg/info"
+	"github.com/openshift/backplane-cli/pkg/ocm"
+	"github.com/openshift/backplane-cli/pkg/utils"
 )
 
 type containerEngineInterface interface {
@@ -1194,7 +1195,7 @@ func dockerRunMonitorPlugin(containerName string, consoleContainerName string, n
 }
 
 func (ce *dockerLinux) runMonitorPlugin(containerName string, consoleContainerName string, nginxConf string, pluginArgs []string) error {
-	configDirectory, err := config.GetConfigDirctory()
+	configDirectory, err := config.GetConfigDirectory()
 	if err != nil {
 		return err
 	}
@@ -1203,7 +1204,7 @@ func (ce *dockerLinux) runMonitorPlugin(containerName string, consoleContainerNa
 }
 
 func (ce *dockerMac) runMonitorPlugin(containerName string, consoleContainerName string, nginxConf string, pluginArgs []string) error {
-	configDirectory, err := config.GetConfigDirctory()
+	configDirectory, err := config.GetConfigDirectory()
 	if err != nil {
 		return err
 	}
@@ -1265,7 +1266,7 @@ func (ce *podmanMac) putFileToMount(filename string, content []byte) error {
 // filename should be name only, not a path
 func dockerPutFileToMount(filename string, content []byte) error {
 	// for files in linux, we put them into the user's backplane config directory
-	configDirectory, err := config.GetConfigDirctory()
+	configDirectory, err := config.GetConfigDirectory()
 	if err != nil {
 		return err
 	}

--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -122,6 +122,9 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 	logger.Debugf("Extracting Backplane Cluster ID")
 	// Currently go-pagerduty pkg does not include incident id validation.
 	if args.pd != "" {
+		if bpConfig.PagerDutyAPIKey == "" {
+			return fmt.Errorf("please make sure the PD API Key is configured correctly in the config file")
+		}
 		pdClient, err := pagerduty.NewWithToken(bpConfig.PagerDutyAPIKey)
 		if err != nil {
 			return fmt.Errorf("could not initialize the client: %w", err)

--- a/cmd/ocm-backplane/logout/logout_test.go
+++ b/cmd/ocm-backplane/logout/logout_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/login"
 	"github.com/openshift/backplane-cli/pkg/backplaneapi"
 	backplaneapiMock "github.com/openshift/backplane-cli/pkg/backplaneapi/mocks"

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -15,9 +15,10 @@ import (
 	"github.com/openshift/backplane-cli/pkg/ocm"
 )
 
+// Please update the validateConfig function if there is any required config key added
 type BackplaneConfiguration struct {
 	URL              string  `json:"url"`
-	ProxyURL         *string `json:"proxy-url"` // Optional
+	ProxyURL         *string `json:"proxy-url"`
 	SessionDirectory string  `json:"session-dir"`
 	AssumeInitialArn string  `json:"assume-initial-arn"`
 	PagerDutyAPIKey  string  `json:"pd-key"`
@@ -61,6 +62,11 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 		}
 	}
 
+	if err = validateConfig(); err != nil {
+		// FIXME: we should return instead of warning here, after the tests do not require external network access
+		logger.Warn(err)
+	}
+
 	// Check if user has explicitly defined proxy; it has higher precedence over the config file
 	err = viper.BindEnv("proxy-url", info.BackplaneProxyEnvName)
 	if err != nil {
@@ -72,9 +78,10 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 		logger.Warn("Manual URL configuration is deprecated, please remove URL key from Backplane configuration")
 	}
 
-	// Check if user has explicitly defined backplane URL via env; it has higher precedence over the ocm env URL
+	// Warn if user has explicitly defined backplane URL via env
 	url, ok := getBackplaneEnv(info.BackplaneURLEnvName)
 	if ok {
+		logger.Warn(fmt.Printf("Manual URL configuration is deprecated, please unset the environment %s", info.BackplaneURLEnvName))
 		bpConfig.URL = url
 	} else {
 		// Fetch backplane URL from ocm env
@@ -88,8 +95,6 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 	proxyURL := bpConfig.getFirstWorkingProxyURL(proxyInConfigFile)
 	if proxyURL != "" {
 		bpConfig.ProxyURL = &proxyURL
-	} else {
-		logger.Warn("No proxy configuration available. This may result in failing commands as backplane-api is only available from select networks.")
 	}
 
 	bpConfig.SessionDirectory = viper.GetString("session-dir")
@@ -102,7 +107,6 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 	} else {
 		logger.Info("No PagerDuty API Key configuration available. This will result in failure of `ocm-backplane login --pd <incident-id>` command.")
 	}
-
 	return bpConfig, nil
 }
 
@@ -145,7 +149,18 @@ func (config *BackplaneConfiguration) getFirstWorkingProxyURL(s []string) string
 	return ""
 }
 
-func GetConfigDirctory() (string, error) {
+func validateConfig() error {
+
+	// Validate the proxy url
+	if viper.GetStringSlice("proxy-url") == nil && os.Getenv(info.BackplaneProxyEnvName) == "" {
+		return fmt.Errorf("proxy-url must be set explicitly in either config file or via the environment HTTPS_PROXY")
+	}
+
+	return nil
+}
+
+// GetConfigDirectory returns the backplane config path
+func GetConfigDirectory() (string, error) {
 	bpConfigFilePath, err := GetConfigFilePath()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
validation mandatory value proxy-url in backplane config validate the PD API KEY in config file if login via PD

### What type of PR is this?

_(/feature/)_

### What this PR does / Why we need it?

There are two parts for this PR:
1. Add validation to the backplane config
The original plan is to make the struct `BackplaneConfiguration` to have the mandatory fields as required, but it turns out the there are multiple ways to setup the proxy-url currently.
- ocm backplane login --proxy-url
- HTTPS_PROXY=xxxx ocm backplane login
- read through the config file

So it is not possible to change the struct. Adding a small function to make sure the proxy url was set by any of above methods, and exit early if it is not set.

2. Validate the pd api key when login via PD
Currently, the PD API Key can be configured in config file only, and the `--pd` will be used in login sub-command only. So, just add a simple condition to check the backplane config when `--pd` passed.

### Which Jira/Github issue(s) does this PR fix?

_Resolves #[OSD-21620](https://issues.redhat.com//browse/OSD-21620)_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
