### PR TITLE
OSD-23312: Refactor GetRestConfig() to allow passing an ocm connection programatically

### DIFF
--- a/cmd/ocm-backplane/login/login_test.go
+++ b/cmd/ocm-backplane/login/login_test.go
@@ -502,7 +502,6 @@ var _ = Describe("Login command", func() {
 	})
 
 	Context("check GetRestConfigAsUser", func() {
-
 		It("check config creation with username and without elevationReasons", func() {
 			mockOcmInterface.EXPECT().GetClusterInfoByID(testClusterID).Return(mockCluster, nil)
 			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil)

--- a/pkg/ocm/mocks/ocmWrapperMock.go
+++ b/pkg/ocm/mocks/ocmWrapperMock.go
@@ -50,6 +50,21 @@ func (mr *MockOCMInterfaceMockRecorder) GetClusterInfoByID(arg0 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterInfoByID", reflect.TypeOf((*MockOCMInterface)(nil).GetClusterInfoByID), arg0)
 }
 
+// GetClusterInfoByIDWithConn mocks base method.
+func (m *MockOCMInterface) GetClusterInfoByIDWithConn(arg0 *sdk.Connection, arg1 string) (*v1.Cluster, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterInfoByIDWithConn", arg0, arg1)
+	ret0, _ := ret[0].(*v1.Cluster)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterInfoByIDWithConn indicates an expected call of GetClusterInfoByIDWithConn.
+func (mr *MockOCMInterfaceMockRecorder) GetClusterInfoByIDWithConn(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterInfoByIDWithConn", reflect.TypeOf((*MockOCMInterface)(nil).GetClusterInfoByIDWithConn), arg0, arg1)
+}
+
 // GetManagingCluster mocks base method.
 func (m *MockOCMInterface) GetManagingCluster(arg0 string) (string, string, bool, error) {
 	m.ctrl.T.Helper()
@@ -80,6 +95,21 @@ func (m *MockOCMInterface) GetOCMAccessToken() (*string, error) {
 func (mr *MockOCMInterfaceMockRecorder) GetOCMAccessToken() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOCMAccessToken", reflect.TypeOf((*MockOCMInterface)(nil).GetOCMAccessToken))
+}
+
+// GetOCMAccessTokenWithConn mocks base method.
+func (m *MockOCMInterface) GetOCMAccessTokenWithConn(arg0 *sdk.Connection) (*string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOCMAccessTokenWithConn", arg0)
+	ret0, _ := ret[0].(*string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOCMAccessTokenWithConn indicates an expected call of GetOCMAccessTokenWithConn.
+func (mr *MockOCMInterfaceMockRecorder) GetOCMAccessTokenWithConn(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOCMAccessTokenWithConn", reflect.TypeOf((*MockOCMInterface)(nil).GetOCMAccessTokenWithConn), arg0)
 }
 
 // GetOCMEnvironment mocks base method.


### PR DESCRIPTION

### What type of PR is this?
cleanup

### What this PR does / Why we need it?

CAD needs to use the GetRestConfig() function, but it doesn't allow passing an ocmConnection programatically. 
To not refactor the whole ocm package/usage, I dupliacted the functions to allow passing and initializing on the fly. 

### Which Jira/Github issue(s) does this PR fix?


### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
