### PR TITLE
log when we discard proxies and default to the first proxy if all fail healthchecks

### DIFF
--- a/pkg/cli/config/config_test.go
+++ b/pkg/cli/config/config_test.go
@@ -75,7 +75,7 @@ func TestBackplaneConfiguration_getFirstWorkingProxyURL(t *testing.T) {
 		{
 			name:    "multiple-invalid-proxies",
 			proxies: []string{"-", "gellso", ""},
-			want:    "",
+			want:    "-",
 		},
 		{
 			name:    "valid-proxies",


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?
The message
```
WARN[0002] No proxy configuration available. This may result in failing commands as backplane-api is only available from select networks.
```
is misleading when a proxies are specified, but they are failing health checks. This PR adds logging when proxies are discarded and falls back to selecting the first specified proxy if all fail health checks.

### Which Jira/Github issue(s) does this PR fix?

[OSD-23471](https://issues.redhat.com//browse/OSD-23471)

### Special notes for your reviewer

### Pre-checks (if applicable)

- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
