### PR TITLE
Check for nil ptr proxy-url value in troubleshoot util

### DIFF
--- a/cmd/ocm-backplane/config/troubleshoot.go
+++ b/cmd/ocm-backplane/config/troubleshoot.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -65,12 +66,21 @@ func (o *troubleshootOptions) checkBPCli() error {
 		printWrong("Failed to get backplane-cli configuration path: %v\n", err)
 	} else {
 		printCorrect("backplane-cli configuration path: %s\n", configFilePath)
+		// Check if the config file exists
+		if _, err = os.Stat(configFilePath); err != nil {
+			printNotice("config file not found: %s\n", configFilePath)
+		}
 	}
+
 	currentBPConfig, err := getBackplaneConfiguration()
 	if err != nil {
 		printWrong("Failed to read backplane-cli config file: %v\n", err)
 	} else {
-		printCorrect("proxy in backplane-cli config: %s\n", *currentBPConfig.ProxyURL)
+		if currentBPConfig.ProxyURL == nil {
+			printNotice("No proxy in backplane-cli config\n")
+		} else {
+			printCorrect("proxy in backplane-cli config: %s\n", currentBPConfig.ProxyURL)
+		}
 	}
 	return nil
 }

--- a/cmd/ocm-backplane/config/troubleshoot.go
+++ b/cmd/ocm-backplane/config/troubleshoot.go
@@ -77,9 +77,9 @@ func (o *troubleshootOptions) checkBPCli() error {
 		printWrong("Failed to read backplane-cli config file: %v\n", err)
 	} else {
 		if currentBPConfig.ProxyURL == nil {
-			printNotice("No proxy in backplane-cli config\n")
+			printNotice("proxy in backplane-cli config:\n")
 		} else {
-			printCorrect("proxy in backplane-cli config: %s\n", currentBPConfig.ProxyURL)
+			printCorrect("proxy in backplane-cli config: %s\n", *currentBPConfig.ProxyURL)
 		}
 	}
 	return nil


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?
Fixes nil pointer deference seg fault during the troubleshoot util
Adds notice in the troubleshoot util for missing config file if not found at the expected path. 

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer
This should address the following error when "proxy-url" value is not set in the current configuration file/path, and not provided as an environment var. 

```
[BP]➜ ~/rh_sandbox/backplane-cli/ git:(main) ✗ ./ocm-backplane config troubleshoot
[V] backplane-cli configuration path: /Users/maclark/.config/backplane/config.json
WARN[0001] No proxy configuration available. This may result in failing commands as backplane-api is only available from select networks. 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1036af5ec]

goroutine 1 [running]:
github.com/openshift/backplane-cli/cmd/ocm-backplane/config.(*troubleshootOptions).checkBPCli(0x0?)
	/Users/maclark/rh_sandbox/backplane-cli/cmd/ocm-backplane/config/troubleshoot.go:73 +0x20c
github.com/openshift/backplane-cli/cmd/ocm-backplane/config.(*troubleshootOptions).run(0x1059c0968, 0x43995fd100000000?, {0x14000605b68?, 0x0?, 0x0?})
	/Users/maclark/rh_sandbox/backplane-cli/cmd/ocm-backplane/config/troubleshoot.go:122 +0x20
github.com/spf13/cobra.(*Command).execute(0x14000485808, {0x1059c0968, 0x0, 0x0})
	/Users/maclark/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0x840
github.com/spf13/cobra.(*Command).ExecuteC(0x105881980)
	/Users/maclark/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/maclark/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
main.Execute()
	/Users/maclark/rh_sandbox/backplane-cli/cmd/ocm-backplane/root.go:56 +0x24
main.main()
	/Users/maclark/rh_sandbox/backplane-cli/cmd/ocm-backplane/main.go:20 +0x1c
```

### Pre-checks (if applicable)

- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
