### PR TITLE
use 'AWS_REGION' instead of 'AWS_DEFAULT_REGION' when formatting credentials output

### DIFF
--- a/pkg/credentials/aws.go
+++ b/pkg/credentials/aws.go
@@ -24,7 +24,8 @@ const (
 	AwsExportFormat = `export AWS_ACCESS_KEY_ID=%s
 export AWS_SECRET_ACCESS_KEY=%s
 export AWS_SESSION_TOKEN=%s
-export AWS_DEFAULT_REGION=%s`
+export AWS_DEFAULT_REGION=%s
+export AWS_REGION=%s`
 )
 
 type AWSCredentialsResponse struct {
@@ -40,7 +41,7 @@ func (r *AWSCredentialsResponse) String() string {
 }
 
 func (r *AWSCredentialsResponse) FmtExport() string {
-	return fmt.Sprintf(AwsExportFormat, r.AccessKeyID, r.SecretAccessKey, r.SessionToken, r.Region)
+	return fmt.Sprintf(AwsExportFormat, r.AccessKeyID, r.SecretAccessKey, r.SessionToken, r.Region, r.Region)
 }
 
 // AWSV2Config returns an aws-sdk-go-v2 config that can be used to programmatically access the AWS API


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / Why we need it?
When outputting cloud credentials with the `-o env` flag, the current output will contain the region as `AWS_DEFAULT_REGION`. Looking at the [AWS docs](https://docs.aws.amazon.com/sdkref/latest/guide/feature-region.html#feature-region-sdk-compat), this seems to be dropping in favor of AWS_REGION. Furthermore, some AWS SDKs don't even acknowledge the `AWS_DEFAULT_REGION` envar.

Resolves [OSD-23927](https://issues.redhat.com//browse/OSD-23927)