### PR TITLE
inform user to login to OCM if the backplane failed due to that

### DIFF
--- a/cmd/ocm-backplane/accessrequest/createAccessRequest.go
+++ b/cmd/ocm-backplane/accessrequest/createAccessRequest.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/openshift/backplane-cli/pkg/accessrequest"
 
-	ocmcli "github.com/openshift-online/ocm-cli/pkg/ocm"
-	"github.com/openshift/backplane-cli/pkg/login"
-	"github.com/openshift/backplane-cli/pkg/utils"
 	logger "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/openshift/backplane-cli/pkg/login"
+	"github.com/openshift/backplane-cli/pkg/ocm"
+	"github.com/openshift/backplane-cli/pkg/utils"
 )
 
 var (
@@ -96,7 +97,7 @@ func runCreateAccessRequest(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to compute cluster ID: %v", err)
 	}
 
-	ocmConnection, err := ocmcli.NewConnection().Build()
+	ocmConnection, err := ocm.DefaultOCMInterface.SetupOCMConnection()
 	if err != nil {
 		return fmt.Errorf("failed to create OCM connection: %v", err)
 	}

--- a/cmd/ocm-backplane/accessrequest/expireAccessRequest.go
+++ b/cmd/ocm-backplane/accessrequest/expireAccessRequest.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/openshift/backplane-cli/pkg/accessrequest"
+	"github.com/openshift/backplane-cli/pkg/ocm"
 
-	ocmcli "github.com/openshift-online/ocm-cli/pkg/ocm"
 	"github.com/spf13/cobra"
 )
 
@@ -30,7 +30,7 @@ func runExpireAccessRequest(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to compute cluster ID: %v", err)
 	}
 
-	ocmConnection, err := ocmcli.NewConnection().Build()
+	ocmConnection, err := ocm.DefaultOCMInterface.SetupOCMConnection()
 	if err != nil {
 		return fmt.Errorf("failed to create OCM connection: %v", err)
 	}

--- a/cmd/ocm-backplane/accessrequest/getAccessRequest.go
+++ b/cmd/ocm-backplane/accessrequest/getAccessRequest.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/openshift/backplane-cli/pkg/accessrequest"
+	"github.com/openshift/backplane-cli/pkg/ocm"
 
-	ocmcli "github.com/openshift-online/ocm-cli/pkg/ocm"
 	logger "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -31,7 +31,7 @@ func runGetAccessRequest(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to compute cluster ID: %v", err)
 	}
 
-	ocmConnection, err := ocmcli.NewConnection().Build()
+	ocmConnection, err := ocm.DefaultOCMInterface.SetupOCMConnection()
 	if err != nil {
 		return fmt.Errorf("failed to create OCM connection: %v", err)
 	}

--- a/cmd/ocm-backplane/cloud/console.go
+++ b/cmd/ocm-backplane/cloud/console.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"strconv"
 
-	ocmsdk "github.com/openshift-online/ocm-cli/pkg/ocm"
-
 	"github.com/openshift/backplane-cli/pkg/ocm"
 
 	"github.com/pkg/browser"
@@ -130,9 +128,9 @@ func runConsole(cmd *cobra.Command, argv []string) (err error) {
 	logger.Infof("Using backplane URL: %s\n", backplaneConfiguration.URL)
 
 	// Initialize OCM connection
-	ocmConnection, err := ocmsdk.NewConnection().Build()
+	ocmConnection, err := ocm.DefaultOCMInterface.SetupOCMConnection()
 	if err != nil {
-		return fmt.Errorf("unable to build ocm sdk: %w", err)
+		return fmt.Errorf("failed to create OCM connection: %w", err)
 	}
 	defer ocmConnection.Close()
 

--- a/cmd/ocm-backplane/cloud/credentials.go
+++ b/cmd/ocm-backplane/cloud/credentials.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	ocmsdk "github.com/openshift-online/ocm-cli/pkg/ocm"
 	logger "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
@@ -98,9 +97,9 @@ func runCredentials(cmd *cobra.Command, argv []string) error {
 	logger.Infof("Using backplane URL: %s\n", backplaneConfiguration.URL)
 
 	// Initialize OCM connection
-	ocmConnection, err := ocmsdk.NewConnection().Build()
+	ocmConnection, err := ocm.DefaultOCMInterface.SetupOCMConnection()
 	if err != nil {
-		return fmt.Errorf("unable to build ocm sdk: %w", err)
+		return fmt.Errorf("failed to create OCM connection: %w", err)
 	}
 	defer ocmConnection.Close()
 

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
+	github.com/trivago/tgo v1.0.7
 	golang.org/x/term v0.22.0
 	gopkg.in/AlecAivazis/survey.v1 v1.8.8
 	k8s.io/api v0.28.3
@@ -123,7 +124,6 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/trivago/tgo v1.0.7 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	github.com/zalando/go-keyring v0.2.3 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect

--- a/pkg/ocm/mocks/ocmWrapperMock.go
+++ b/pkg/ocm/mocks/ocmWrapperMock.go
@@ -279,3 +279,18 @@ func (mr *MockOCMInterfaceMockRecorder) IsProduction() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsProduction", reflect.TypeOf((*MockOCMInterface)(nil).IsProduction))
 }
+
+// SetupOCMConnection mocks base method.
+func (m *MockOCMInterface) SetupOCMConnection() (*sdk.Connection, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetupOCMConnection")
+	ret0, _ := ret[0].(*sdk.Connection)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SetupOCMConnection indicates an expected call of SetupOCMConnection.
+func (mr *MockOCMInterfaceMockRecorder) SetupOCMConnection() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupOCMConnection", reflect.TypeOf((*MockOCMInterface)(nil).SetupOCMConnection))
+}


### PR DESCRIPTION
### What type of PR is this?

_(feature)_

### What this PR does / Why we need it?

OCM offline token disabled, backplane login would fail if OCM not logged in, inform the user to do the ocm login if it is not when executing the backplane commands

### Which Jira/Github issue(s) does this PR fix?

_Resolves #OSD-21603_

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
