### PR TITLE
Update to use Ginkgo BDD testing framework to align with the exist test style

### DIFF
--- a/pkg/healthcheck/check_vpn.go
+++ b/pkg/healthcheck/check_vpn.go
@@ -51,7 +51,7 @@ func CheckVPNConnectivity(netInterfaces NetworkInterface, client HTTPClient) err
 }
 
 func GetVPNCheckEndpoint() (string, error) {
-	bpConfig, err := getConfigFunc()
+	bpConfig, err := GetConfigFunc()
 	if err != nil {
 		logger.Errorf("Failed to get backplane configuration: %v", err)
 		return "", fmt.Errorf("failed to get backplane configuration: %v", err)

--- a/pkg/healthcheck/connectivity_checks.go
+++ b/pkg/healthcheck/connectivity_checks.go
@@ -20,34 +20,39 @@ type HTTPClient interface {
 	Get(url string) (*http.Response, error)
 }
 
-type DefaultNetworkInterface struct{}
-type DefaultHTTPClient struct {
+// Default implementations
+type DefaultNetworkInterfaceImpl struct{}
+
+type DefaultHTTPClientImpl struct {
 	Client *http.Client
 }
 
-func (d DefaultNetworkInterface) Interfaces() ([]net.Interface, error) {
+func (d DefaultNetworkInterfaceImpl) Interfaces() ([]net.Interface, error) {
 	return net.Interfaces()
 }
 
-func (d DefaultHTTPClient) Get(url string) (*http.Response, error) {
+func (d DefaultHTTPClientImpl) Get(url string) (*http.Response, error) {
 	return d.Client.Get(url)
 }
 
 var (
-	netInterfaces            NetworkInterface = DefaultNetworkInterface{}
-	httpClient               HTTPClient       = DefaultHTTPClient{Client: &http.Client{}}
+	NetInterfaces            NetworkInterface = DefaultNetworkInterfaceImpl{}
+	HTTPClients              HTTPClient       = DefaultHTTPClientImpl{Client: &http.Client{}}
 	GetVPNCheckEndpointFunc                   = GetVPNCheckEndpoint
 	GetProxyTestEndpointFunc                  = GetProxyTestEndpoint
+	GetConfigFunc                             = config.GetBackplaneConfiguration
 )
-
-// Dependency injection for testing purposes
-var getConfigFunc = config.GetBackplaneConfiguration
 
 func RunHealthCheck(checkVPN, checkProxy bool) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
+		if NetInterfaces == nil || HTTPClients == nil {
+			logger.Error("Network interfaces or HTTP client is not configured")
+			os.Exit(1)
+		}
+
 		if checkVPN {
 			fmt.Println("Checking VPN connectivity...")
-			err := CheckVPNConnectivity(netInterfaces, httpClient)
+			err := CheckVPNConnectivity(NetInterfaces, HTTPClients)
 			if err != nil {
 				fmt.Println("VPN connectivity check failed:", err)
 				os.Exit(1)
@@ -58,7 +63,7 @@ func RunHealthCheck(checkVPN, checkProxy bool) func(cmd *cobra.Command, args []s
 		}
 
 		if checkProxy {
-			err := CheckVPNConnectivity(netInterfaces, httpClient)
+			err := CheckVPNConnectivity(NetInterfaces, HTTPClients)
 			if err != nil {
 				fmt.Println("VPN connectivity check failed:", err)
 				fmt.Println("Note: Proxy connectivity check requires VPN to be connected. Please ensure VPN is connected and try again.")
@@ -66,7 +71,7 @@ func RunHealthCheck(checkVPN, checkProxy bool) func(cmd *cobra.Command, args []s
 			}
 
 			fmt.Println("Checking proxy connectivity...")
-			_, err = CheckProxyConnectivity(httpClient)
+			_, err = CheckProxyConnectivity(HTTPClients)
 			if err != nil {
 				fmt.Println("Proxy connectivity check failed:", err)
 				os.Exit(1)
@@ -77,44 +82,50 @@ func RunHealthCheck(checkVPN, checkProxy bool) func(cmd *cobra.Command, args []s
 		}
 
 		// If neither flag is set, check both VPN and Proxy connectivity, then check Backplane API connectivity.
-		fmt.Println("Checking VPN connectivity...")
-		err := CheckVPNConnectivity(netInterfaces, httpClient)
-		if err != nil {
-			fmt.Println("VPN connectivity check failed:", err)
-			os.Exit(1)
-		} else {
-			fmt.Println("VPN connectivity check passed!")
-		}
+		checkAllConnections()
+	}
+}
 
-		fmt.Println("Checking proxy connectivity...")
-		proxyURL, err := CheckProxyConnectivity(httpClient)
-		if err != nil {
-			fmt.Println("Proxy connectivity check failed:", err)
-			os.Exit(1)
-		} else {
-			fmt.Println("Proxy connectivity check passed!")
-		}
+func checkAllConnections() {
+	fmt.Println("Checking VPN connectivity...")
+	err := CheckVPNConnectivity(NetInterfaces, HTTPClients)
+	if err != nil {
+		fmt.Println("VPN connectivity check failed:", err)
+		os.Exit(1)
+	} else {
+		fmt.Println("VPN connectivity check passed!")
+	}
 
-		fmt.Println("Checking backplane API connectivity...")
-		err = CheckBackplaneAPIConnectivity(httpClient, proxyURL)
-		if err != nil {
-			fmt.Println("Backplane API connectivity check failed:", err)
-			os.Exit(1)
-		} else {
-			fmt.Println("Backplane API connectivity check passed!")
-		}
+	fmt.Println("Checking proxy connectivity...")
+	proxyURL, err := CheckProxyConnectivity(HTTPClients)
+	if err != nil {
+		fmt.Println("Proxy connectivity check failed:", err)
+		os.Exit(1)
+	} else {
+		fmt.Println("Proxy connectivity check passed!")
+	}
+
+	fmt.Println("Checking backplane API connectivity...")
+	err = CheckBackplaneAPIConnectivity(HTTPClients, proxyURL)
+	if err != nil {
+		fmt.Println("Backplane API connectivity check failed:", err)
+		os.Exit(1)
+	} else {
+		fmt.Println("Backplane API connectivity check passed!")
 	}
 }
 
 func testEndPointConnectivity(testURL string, client HTTPClient) error {
 	if client == nil {
-		client = &DefaultHTTPClient{Client: &http.Client{}}
+		client = &DefaultHTTPClientImpl{Client: &http.Client{}}
 	}
+	logger.Debugf("Making GET request to %s", testURL)
 	resp, err := client.Get(testURL)
 	if err != nil {
 		logger.Error("Failed to get response from test endpoint:", err)
 		return err
 	}
+	logger.Debugf("Received response status code: %d", resp.StatusCode)
 	if resp.StatusCode != http.StatusOK {
 		errMsg := fmt.Sprintf("Unexpected status code: %v", resp.StatusCode)
 		logger.Error(errMsg)
@@ -124,7 +135,8 @@ func testEndPointConnectivity(testURL string, client HTTPClient) error {
 }
 
 func CheckBackplaneAPIConnectivity(client HTTPClient, proxyURL string) error {
-	bpConfig, err := getConfigFunc()
+	logger.Debug("Starting CheckBackplaneAPIConnectivity")
+	bpConfig, err := GetConfigFunc()
 	if err != nil {
 		logger.Error("Failed to get backplane configuration:", err)
 		return fmt.Errorf("failed to get backplane configuration: %v", err)

--- a/pkg/healthcheck/healthcheck_suite_test.go
+++ b/pkg/healthcheck/healthcheck_suite_test.go
@@ -1,0 +1,13 @@
+package healthcheck_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestHealthCheck(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Health Check Suite")
+}


### PR DESCRIPTION
### What type of PR is this?

_(unit-test)_

### What this PR does / Why we need it?
Updated to use Ginkgo BDD testing framework for my `healthcheck` subcommand to align with the current test style

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer
- The main logic of the merged `healthcheck` subcommand is not change but just refactored the test cases using the Ginkgo BDD framework
-  Changed the struct name (e.g below) based on the naming convention
```
// Default implementations
type DefaultNetworkInterfaceImpl struct{}

type DefaultHTTPClientImpl struct {
        Client *http.Client
}
```
- `CheckBackplaneAPIConnectivity` function is not covered by the test case since it's just call the existing `CheckAPIConnection()` which defined in the existing `config.GetBackplaneConfiguration`.
