### PR TITLE
[OSD-25177] Enhance readability of healthcheck prompt messages

### DIFF
--- a/cmd/ocm-backplane/cloud/console.go
+++ b/cmd/ocm-backplane/cloud/console.go
@@ -140,14 +140,17 @@ func runConsole(cmd *cobra.Command, argv []string) (err error) {
 
 	// ======== Get cloud console from backplane API ============
 	consoleResponse, err := queryConfig.GetCloudConsole()
+
+	// Declare helperMsg
+	helperMsg := "\n\033[1mNOTE: To troubleshoot the connectivity issues, please run `ocm-backplane health-check`\033[0m\n\n"
+
 	if err != nil {
 		// Check API connection with configured proxy
 		if connErr := backplaneConfiguration.CheckAPIConnection(); connErr != nil {
 			logger.Error("Cannot connect to backplane API URL, check if you need to use a proxy/VPN to access backplane:")
-			logger.Errorf("Error: %v", connErr)
-			logger.Info("To troubleshoot connectivity issues, please run the following command:")
-			logger.Info("ocm-backplane health-check")
+			logger.Errorf("Error: %v.\n%s", connErr, helperMsg)
 		}
+
 		return fmt.Errorf("failed to get cloud console for cluster %v: %w", clusterID, err)
 	}
 

--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -306,15 +306,15 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 			return fmt.Errorf("cluster %s is hibernating, login failed", clusterKey)
 		}
 
+		// Declare helperMsg
+		helperMsg := "\n\033[1mNOTE: To troubleshoot the connectivity issues, please run `ocm-backplane health-check`\033[0m\n\n"
+
 		// Check API connection with configured proxy
 		if connErr := bpConfig.CheckAPIConnection(); connErr != nil {
-			logger.Errorf("Cannot connect to backplane API URL, check if you need to use a proxy/VPN to access backplane: %v. To troubleshoot connectivity issues, please run the following command: ocm-backplane health-check", connErr)
-			return fmt.Errorf("cannot connect to backplane API URL: %v", connErr)
+			return fmt.Errorf("cannot connect to Backplane API URL: %v.\n%s", connErr, helperMsg)
 		}
 
-		// Log suggestion to run connectivity health check if login fails
-		logger.Errorf("Login failed: %v. To troubleshoot connectivity issues, please run the following command: ocm-backplane health-check", err)
-		return fmt.Errorf("login failed: %v", err)
+		return fmt.Errorf("login Attempt Failed: %v.\n%s", err, helperMsg)
 	}
 
 	logger.WithField("URL", bpAPIClusterURL).Debugln("Proxy")


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / Why we need it?
Enhance readability of healthcheck prompt messages when backplane access failed
context: https://redhat-internal.slack.com/archives/C016S65RNG5/p1723016359859959

The Expected Output with the change
- Error connecting to bp-api
 ```
ERRO[0006] Connection Error to Backplane API:
ERRO[0006] cannot connect to Backplane API URL: Head "https://api.stage.backplane.openshift.com": proxyconnect tcp: dial tcp: lookup proxy2.squi-001.prod.rdu2.dc.redhat.com: no such host.
[**NOTE:** To troubleshoot the connectivity issues, please run `ocm-backplane health-check`]
```

- Error of login
```
ERRO[0006] Login Attempt Failed:
ERRO[0006] login failed: error from backplane: Status Code: 406.
[**NOTE:** To troubleshoot the connectivity issues, please run `ocm-backplane health-check`]
```