### PR TITLE
feat: print ocm error in backplane session

### DIFF
--- a/pkg/cli/session/session.go
+++ b/pkg/cli/session/session.go
@@ -73,7 +73,7 @@ func (e *BackplaneSession) RunCommand(cmd *cobra.Command, args []string) error {
 	clusterID, clusterName, err := ocm.DefaultOCMInterface.GetTargetCluster(clusterKey)
 
 	if err != nil {
-		return fmt.Errorf("invalid cluster Id %s", clusterKey)
+		return fmt.Errorf("invalid cluster Id %s. error: %w", clusterKey, err)
 	}
 
 	if e.Options.GlobalOpts.Manager {
@@ -103,7 +103,7 @@ func (e *BackplaneSession) RunCommand(cmd *cobra.Command, args []string) error {
 
 	err = e.initSessionPath()
 	if err != nil {
-		return fmt.Errorf("could not init session path")
+		return fmt.Errorf("could not init session path. error: %w", err)
 	}
 
 	if e.Options.DeleteSession {


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / Why we need it?

This PR is to expose the error returned by OCM when looking up the cluster.
Printing this error can help user troubleshoot the issue easier.

Before this PR:
```
$ ocm backplane session siwu-test
ERRO[0000] invalid cluster Id siwu-test         
```

After this PR:
```
$ ocm.prod backplane session siwu-test
ERRO[0000] invalid cluster Id siwu-test. error: failed to create OCM connection: please ensure you are logged into OCM by using the command "ocm login --url $ENV"
```

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
