### PR TITLE
Accept deprecation warnings from the server and warn the user

### DIFF
--- a/cmd/ocm-backplane/cloud/console.go
+++ b/cmd/ocm-backplane/cloud/console.go
@@ -125,7 +125,7 @@ func runConsole(cmd *cobra.Command, argv []string) (err error) {
 	if consoleArgs.backplaneURL != "" { // Overwrite if parameter is set
 		backplaneConfiguration.URL = consoleArgs.backplaneURL
 	}
-	logger.Infof("Using backplane URL: %s\n", backplaneConfiguration.URL)
+	logger.Infof("Using backplane URL: %s\n", consoleArgs.backplaneURL)
 
 	// Initialize OCM connection
 	ocmConnection, err := ocm.DefaultOCMInterface.SetupOCMConnection()

--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift/backplane-cli/pkg/backplaneapi"
 	"github.com/openshift/backplane-cli/pkg/cli/config"
 	"github.com/openshift/backplane-cli/pkg/cli/globalflags"
+	"github.com/openshift/backplane-cli/pkg/info"
 	"github.com/openshift/backplane-cli/pkg/jira"
 	"github.com/openshift/backplane-cli/pkg/login"
 	"github.com/openshift/backplane-cli/pkg/ocm"
@@ -518,6 +519,11 @@ func doLogin(api, clusterID, accessToken string) (string, error) {
 		}
 
 		return "", err
+	}
+
+	err = backplaneapi.CheckResponseDeprecation(resp)
+	if errors.Is(err, backplaneapi.ErrDeprecation) {
+		logger.Warnf("The server indicated that backplane-cli version %s is deprecated. Please update as soon as possible.", info.DefaultInfoService.GetVersion())
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/pkg/backplaneapi/backplaneapi_suite_test.go
+++ b/pkg/backplaneapi/backplaneapi_suite_test.go
@@ -1,0 +1,13 @@
+package backplaneapi_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBackplaneapi(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Backplaneapi Suite")
+}

--- a/pkg/backplaneapi/clientUtils.go
+++ b/pkg/backplaneapi/clientUtils.go
@@ -37,6 +37,7 @@ func makeClientOptions(accessToken string) BackplaneApi.ClientOption {
 		client.RequestEditors = append(client.RequestEditors, func(ctx context.Context, req *http.Request) error {
 			req.Header.Add("Authorization", "Bearer "+accessToken)
 			req.Header.Set("User-Agent", "backplane-cli"+info.Version)
+			req.Header.Set("Backplane-Version", info.DefaultInfoService.GetVersion())
 			return nil
 		})
 		return nil

--- a/pkg/backplaneapi/deprecation.go
+++ b/pkg/backplaneapi/deprecation.go
@@ -1,0 +1,18 @@
+package backplaneapi
+
+import (
+	"errors"
+	"net/http"
+)
+
+const deprecationMsg = "server indicated that this client is deprecated"
+
+var ErrDeprecation = errors.New(deprecationMsg)
+
+func CheckResponseDeprecation(r *http.Response) error {
+	if r.Header.Get("Deprecated-Client") == "true" {
+		return ErrDeprecation
+	}
+
+	return nil
+}

--- a/pkg/backplaneapi/deprecation_test.go
+++ b/pkg/backplaneapi/deprecation_test.go
@@ -1,0 +1,40 @@
+package backplaneapi_test
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/backplane-cli/pkg/backplaneapi"
+)
+
+var _ = Describe("backplaneapi/deprecation", func() {
+	It("Returns ErrDeprecation when the 'Deprecated-Client' header is present.", func() {
+		r := http.Response{Header: http.Header{}}
+
+		r.Header.Add("Deprecated-Client", "true")
+
+		err := backplaneapi.CheckResponseDeprecation(&r)
+
+		Expect(err).To(Equal(backplaneapi.ErrDeprecation))
+	})
+
+	It("Returns nil when the 'Deprecated-Client' header is not present.", func() {
+		r := http.Response{Header: http.Header{}}
+
+		err := backplaneapi.CheckResponseDeprecation(&r)
+
+		Expect(err).To(BeNil())
+	})
+
+	It("Returns nil when the 'Deprecated-Client' header is not 'true'.", func() {
+		r := http.Response{Header: http.Header{}}
+
+		r.Header.Add("Deprecated-Client", "false")
+
+		err := backplaneapi.CheckResponseDeprecation(&r)
+
+		Expect(err).To(BeNil())
+	})
+})


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / Why we need it?

This will allow us to add code in the server to warn the user when their client is old and may be blocked soon.

### Which Jira/Github issue(s) does this PR fix?

This is the client side code for https://issues.redhat.com/browse/OSD-19766

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [x] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
