### PR TITLE
Fixing a copy-paste typo of command line args 

### DIFF
--- a/cmd/ocm-backplane/cloud/console.go
+++ b/cmd/ocm-backplane/cloud/console.go
@@ -122,8 +122,8 @@ func runConsole(cmd *cobra.Command, argv []string) (err error) {
 	}
 
 	// ============Get Backplane URl ==========================
-	if credentialArgs.backplaneURL != "" { // Overwrite if parameter is set
-		backplaneConfiguration.URL = credentialArgs.backplaneURL
+	if consoleArgs.backplaneURL != "" { // Overwrite if parameter is set
+		backplaneConfiguration.URL = consoleArgs.backplaneURL
 	}
 	logger.Infof("Using backplane URL: %s\n", backplaneConfiguration.URL)
 


### PR DESCRIPTION
Looks like a copy-paste from "ocm-backplane cloud credentials" command made it to "ocm-backplane cloud console"

### What type of PR is this?

bug

### What this PR does / Why we need it?

credentialArgs aren't populated, consoleArgs should be used in the ocm-backplane cloud console command

### Which Jira/Github issue(s) does this PR fix?

_Resolves OSD-26222_

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests N/A
- [ ] Created jira card to add unit test N/A
- [x] This PR may not need unit tests 

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR N/A
