### PR TITLE
Add commands to create and delete remediations

### DIFF
--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -49,6 +49,7 @@ var (
 		defaultNamespace string
 		ohss             string
 		clusterInfo      bool
+		remediation      string
 	}
 
 	// loginType derive the login type based on flags and args
@@ -131,7 +132,7 @@ func init() {
 		"cluster-info",
 		false, "Print basic cluster information after login",
 	)
-
+	flags.StringVar(&args.remediation, "remediation", "", "The name of the remediation for which RBAC should get created")
 }
 
 func runLogin(cmd *cobra.Command, argv []string) (err error) {
@@ -521,7 +522,9 @@ func doLogin(api, clusterID, accessToken string) (string, error) {
 		return "", fmt.Errorf("unable to create backplane api client")
 	}
 
-	resp, err := client.LoginCluster(context.TODO(), clusterID)
+	resp, err := client.LoginCluster(context.TODO(), clusterID, &BackplaneApi.LoginClusterParams{
+		Remediation: &args.remediation,
+	})
 	// Print the whole response if we can't parse it. Eg. 5xx error from http server.
 	if err != nil {
 		// trying to determine the error

--- a/cmd/ocm-backplane/login/login_test.go
+++ b/cmd/ocm-backplane/login/login_test.go
@@ -556,7 +556,7 @@ var _ = Describe("Login command", func() {
 
 			username := "test-user"
 
-			config, err := GetRestConfigAsUser(backplaneConfiguration, testClusterID, username, "")
+			config, err := GetRestConfigAsUser(backplaneConfiguration, testClusterID, username)
 			Expect(err).To(BeNil())
 			Expect(config.Impersonate.UserName).To(Equal(username))
 			Expect(len(config.Impersonate.Extra["reason"])).To(Equal(0))
@@ -572,7 +572,7 @@ var _ = Describe("Login command", func() {
 			username := "test-user"
 			elevationReasons := []string{"reason1", "reason2"}
 
-			config, err := GetRestConfigAsUser(backplaneConfiguration, testClusterID, username, "", elevationReasons...)
+			config, err := GetRestConfigAsUser(backplaneConfiguration, testClusterID, username, elevationReasons...)
 			Expect(err).To(BeNil())
 			Expect(config.Impersonate.UserName).To(Equal(username))
 			Expect(config.Impersonate.Extra["reason"][0]).To(Equal(elevationReasons[0]))

--- a/cmd/ocm-backplane/login/login_test.go
+++ b/cmd/ocm-backplane/login/login_test.go
@@ -556,7 +556,7 @@ var _ = Describe("Login command", func() {
 
 			username := "test-user"
 
-			config, err := GetRestConfigAsUser(backplaneConfiguration, testClusterID, username)
+			config, err := GetRestConfigAsUser(backplaneConfiguration, testClusterID, username, "")
 			Expect(err).To(BeNil())
 			Expect(config.Impersonate.UserName).To(Equal(username))
 			Expect(len(config.Impersonate.Extra["reason"])).To(Equal(0))
@@ -572,7 +572,7 @@ var _ = Describe("Login command", func() {
 			username := "test-user"
 			elevationReasons := []string{"reason1", "reason2"}
 
-			config, err := GetRestConfigAsUser(backplaneConfiguration, testClusterID, username, elevationReasons...)
+			config, err := GetRestConfigAsUser(backplaneConfiguration, testClusterID, username, "", elevationReasons...)
 			Expect(err).To(BeNil())
 			Expect(config.Impersonate.UserName).To(Equal(username))
 			Expect(config.Impersonate.Extra["reason"][0]).To(Equal(elevationReasons[0]))

--- a/cmd/ocm-backplane/remediation/remediation.go
+++ b/cmd/ocm-backplane/remediation/remediation.go
@@ -1,0 +1,97 @@
+package remediation
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/openshift/backplane-cli/pkg/backplaneapi"
+	"github.com/openshift/backplane-cli/pkg/cli/config"
+	"github.com/openshift/backplane-cli/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+func NewRemediationCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "remediation",
+		Short:        "Remediation cleanup",
+		SilenceUsage: true,
+	}
+	cmd.PersistentFlags().String(
+		"url",
+		"",
+		"Specify backplane url.",
+	)
+
+	// cluster-id Flag
+	cmd.PersistentFlags().StringP("cluster-id", "c", "", "Cluster ID could be cluster name, id or external-id")
+
+	// raw Flag
+	cmd.PersistentFlags().Bool("raw", false, "Prints the raw response returned by the backplane API")
+	cmd.AddCommand(newDeleteRemediationCmd())
+	return cmd
+}
+
+func newDeleteRemediationCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "delete",
+		Short:        "Delete remediation RBAC",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// ======== Parsing Flags ========
+			// Cluster ID flag
+			clusterKey, err := cmd.Flags().GetString("cluster-id")
+			if err != nil {
+				return err
+			}
+
+			// URL flag
+			urlFlag, err := cmd.Flags().GetString("url")
+			if err != nil {
+				return err
+			}
+
+			// ======== Initialize backplaneURL ========
+			bpConfig, err := config.GetBackplaneConfiguration()
+			if err != nil {
+				return err
+			}
+
+			bpCluster, err := utils.DefaultClusterUtils.GetBackplaneCluster(clusterKey)
+			if err != nil {
+				return err
+			}
+
+			backplaneHost := bpConfig.URL
+			if err != nil {
+				return err
+			}
+			clusterID := bpCluster.ClusterID
+
+			if urlFlag != "" {
+				backplaneHost = urlFlag
+			}
+
+			client, err := backplaneapi.DefaultClientUtils.MakeRawBackplaneAPIClient(backplaneHost)
+			if err != nil {
+				return err
+			}
+
+			// ======== Call Endpoint ========
+			resp, err := client.DeleteRemediation(context.TODO(), clusterID)
+
+			// ======== Render Results ========
+			if err != nil {
+				return err
+			}
+
+			if resp.StatusCode != http.StatusOK {
+				return utils.TryPrintAPIError(resp, false)
+			}
+
+			fmt.Printf("Deleted remediations RBAC on cluster %s\n", clusterID)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cmd/ocm-backplane/remediation/remediation.go
+++ b/cmd/ocm-backplane/remediation/remediation.go
@@ -2,40 +2,56 @@ package remediation
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 
+	ocmsdk "github.com/openshift-online/ocm-sdk-go"
+	BackplaneApi "github.com/openshift/backplane-api/pkg/client"
 	"github.com/openshift/backplane-cli/pkg/backplaneapi"
 	"github.com/openshift/backplane-cli/pkg/cli/config"
+	"github.com/openshift/backplane-cli/pkg/cli/globalflags"
+	"github.com/openshift/backplane-cli/pkg/login"
+	"github.com/openshift/backplane-cli/pkg/ocm"
 	"github.com/openshift/backplane-cli/pkg/utils"
+	logger "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+var (
+	globalOpts = &globalflags.GlobalOptions{}
 )
 
 func NewRemediationCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "remediation",
-		Short:        "Remediation cleanup",
+		Short:        "Create and delete remediation resources",
 		SilenceUsage: true,
 	}
-	cmd.PersistentFlags().String(
-		"url",
-		"",
-		"Specify backplane url.",
-	)
+
+	globalflags.AddGlobalFlags(cmd, globalOpts)
 
 	// cluster-id Flag
 	cmd.PersistentFlags().StringP("cluster-id", "c", "", "Cluster ID could be cluster name, id or external-id")
 
 	// raw Flag
 	cmd.PersistentFlags().Bool("raw", false, "Prints the raw response returned by the backplane API")
+	cmd.AddCommand(newCreateRemediationCmd())
 	cmd.AddCommand(newDeleteRemediationCmd())
 	return cmd
 }
 
-func newDeleteRemediationCmd() *cobra.Command {
+func newCreateRemediationCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "delete",
-		Short:        "Delete remediation RBAC",
+		Use:          "create",
+		Short:        "create remediation SA and RBAC",
+		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// ======== Parsing Flags ========
@@ -63,35 +79,258 @@ func newDeleteRemediationCmd() *cobra.Command {
 			}
 
 			backplaneHost := bpConfig.URL
-			if err != nil {
-				return err
-			}
+
 			clusterID := bpCluster.ClusterID
 
 			if urlFlag != "" {
 				backplaneHost = urlFlag
 			}
 
-			client, err := backplaneapi.DefaultClientUtils.MakeRawBackplaneAPIClient(backplaneHost)
+			// ======== Parsing Args ========
+			if len(args) < 1 {
+				return fmt.Errorf("missing remediation name as an argument")
+			}
+			remediationName := args[0]
+
+			accessToken, err := ocm.DefaultOCMInterface.GetOCMAccessToken()
 			if err != nil {
 				return err
 			}
-
-			// ======== Call Endpoint ========
-			resp, err := client.DeleteRemediation(context.TODO(), clusterID)
-
+			proxyURI, err := doCreateRemediation(backplaneHost, clusterID, *accessToken, remediationName)
 			// ======== Render Results ========
 			if err != nil {
 				return err
 			}
 
-			if resp.StatusCode != http.StatusOK {
-				return utils.TryPrintAPIError(resp, false)
+			logger.Infof("Created remediation RBAC and serviceaccount\nuri: %s", proxyURI)
+			// TODO needs code to create local kubeconfig factorized from login command
+			// So that we are "logged in"
+			// CAD uses the programmatic endpoint and resulting kubeconfig directly
+
+			// Add a new cluster & context & user
+			logger.Debugln("Writing OCM configuration ")
+
+			targetCluster := api.NewCluster()
+			targetUser := api.NewAuthInfo()
+			targetContext := api.NewContext()
+
+			targetCluster.Server = proxyURI
+
+			// Add proxy URL to target cluster
+			proxyURL := globalOpts.ProxyURL
+			if proxyURL != "" {
+				err = backplaneapi.DefaultClientUtils.SetClientProxyURL(proxyURL)
+
+				if err != nil {
+					return err
+				}
+				logger.Debugf("Using backplane Proxy URL: %s\n", proxyURL)
 			}
 
-			fmt.Printf("Deleted remediations RBAC on cluster %s\n", clusterID)
+			if bpConfig.ProxyURL != nil {
+				proxyURL = *bpConfig.ProxyURL
+				logger.Debugln("backplane configuration file also contains a proxy url, using that one instead")
+				logger.Debugf("New backplane Proxy URL: %s\n", proxyURL)
+			}
+
+			logger.Debugln("Extracting target cluster ID and name")
+			clusterID, clusterName, err := ocm.DefaultOCMInterface.GetTargetCluster(clusterKey)
+			if err != nil {
+				return err
+			}
+			if proxyURL != "" {
+				targetCluster.ProxyURL = proxyURL
+			}
+
+			targetUserNickName := utils.GetUsernameFromJWT(*accessToken)
+
+			targetUser.Token = *accessToken
+
+			targetContext.AuthInfo = targetUserNickName
+			targetContext.Cluster = clusterName
+
+			targetContext.Namespace = "default"
+
+			targetContextNickName := utils.GetContextNickname(targetContext.Namespace, targetContext.Cluster, targetContext.AuthInfo)
+
+			cf := genericclioptions.NewConfigFlags(true)
+			rc, err := cf.ToRawKubeConfigLoader().RawConfig()
+			if err != nil {
+				return err
+			}
+			// Put user, cluster, context into rawconfig
+			rc.Clusters[targetContext.Cluster] = targetCluster
+			rc.AuthInfos[targetUserNickName] = targetUser
+			rc.Contexts[targetContextNickName] = targetContext
+			rc.CurrentContext = targetContextNickName
+
+			logger.Debugln("Saving new API config")
+			// Save the config
+			if err = login.SaveKubeConfig(clusterID, rc, false, ""); err != nil {
+				return err
+			}
+
 			return nil
 		},
 	}
 	return cmd
+}
+
+func newDeleteRemediationCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "delete",
+		Short:        "Delete remediation SA and RBAC",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// ======== Parsing Flags ========
+			// Cluster ID flag
+			clusterKey, err := cmd.Flags().GetString("cluster-id")
+			if err != nil {
+				return err
+			}
+
+			// URL flag
+			urlFlag, err := cmd.Flags().GetString("url")
+			if err != nil {
+				return err
+			}
+
+			// ======== Initialize backplaneURL ========
+			bpConfig, err := config.GetBackplaneConfiguration()
+			if err != nil {
+				return err
+			}
+
+			bpCluster, err := utils.DefaultClusterUtils.GetBackplaneCluster(clusterKey)
+			if err != nil {
+				return err
+			}
+
+			backplaneHost := bpConfig.URL
+
+			clusterID := bpCluster.ClusterID
+
+			if urlFlag != "" {
+				backplaneHost = urlFlag
+			}
+
+			// ======== Parsing Args ========
+			if len(args) < 1 {
+				return fmt.Errorf("missing remediations service account name as an argument")
+			}
+			remediationSA := args[0]
+
+			accessToken, err := ocm.DefaultOCMInterface.GetOCMAccessToken()
+			if err != nil {
+				return err
+			}
+			// ======== Call Endpoint ========
+			err = doDeleteRemediation(backplaneHost, clusterID, *accessToken, remediationSA)
+			// ======== Render Results ========
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("Deleted remediation RBAC on cluster %s\n", clusterID)
+			return nil
+		},
+	}
+	return cmd
+}
+
+// TODO are we missusing the backplane api package? We have generated functions like backplaneapi.CreateRemediationWithResponse which already reads the body. All the utils functions do read the body again. Failing my calls here.
+func doCreateRemediation(api string, clusterID string, accessToken string, remediationName string) (proxyURI string, err error) {
+	client, err := backplaneapi.DefaultClientUtils.MakeBackplaneAPIClientWithAccessToken(api, accessToken)
+	if err != nil {
+		return "", fmt.Errorf("unable to create backplane api client")
+	}
+
+	logger.Debug("Sending request...")
+	resp, err := client.CreateRemediationWithResponse(context.TODO(), clusterID, &BackplaneApi.CreateRemediationParams{Remediation: remediationName})
+	if err != nil {
+		logger.Debug("unexpected...")
+		return "", err
+	}
+
+	// TODO figure out the error handling here
+	if resp.StatusCode() != http.StatusOK {
+		// logger.Debugf("Unmarshal error resp body: %s", resp.Body)
+		var dest BackplaneApi.Error
+		if err := json.Unmarshal(resp.Body, &dest); err != nil {
+			// Avoid squashing the HTTP response info with Unmarshal err...
+			logger.Debugf("Unmarshaled %s", *dest.Message)
+
+			bodyStr := strings.ReplaceAll(string(resp.Body[:]), "\n", " ")
+			err := fmt.Errorf("code:'%d'; failed to unmarshal response:'%s'; %w", resp.StatusCode(), bodyStr, err)
+			return "", err
+		}
+		return "", errors.New(*dest.Message)
+
+	}
+
+	return api + *resp.JSON200.ProxyUri, nil
+}
+
+// CreateRemediationWithConn can be used to programtically interact with backplaneapi
+func CreateRemediationWithConn(bp config.BackplaneConfiguration, ocmConnection *ocmsdk.Connection, clusterID string, remediationName string) (config *rest.Config, serviceAccountName string, err error) {
+	accessToken, err := ocm.DefaultOCMInterface.GetOCMAccessTokenWithConn(ocmConnection)
+	if err != nil {
+		return nil, "", err
+	}
+
+	bpAPIClusterURL, err := doCreateRemediation(bp.URL, clusterID, *accessToken, remediationName)
+	if err != nil {
+		return nil, "", err
+	}
+
+	cfg := &rest.Config{
+		Host:        bpAPIClusterURL,
+		BearerToken: *accessToken,
+	}
+
+	if bp.ProxyURL != nil {
+		cfg.Proxy = func(r *http.Request) (*url.URL, error) {
+			return url.Parse(*bp.ProxyURL)
+		}
+	}
+	return cfg, "", nil
+}
+
+func doDeleteRemediation(api string, clusterID string, accessToken string, remediation string) error {
+	client, err := backplaneapi.DefaultClientUtils.MakeBackplaneAPIClientWithAccessToken(api, accessToken)
+	if err != nil {
+		return fmt.Errorf("unable to create backplane api client")
+	}
+
+	resp, err := client.DeleteRemediationWithResponse(context.TODO(), clusterID, &BackplaneApi.DeleteRemediationParams{Remediation: &remediation})
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode() != http.StatusOK {
+		// logger.Debugf("Unmarshal error resp body: %s", resp.Body)
+		var dest BackplaneApi.Error
+		if err := json.Unmarshal(resp.Body, &dest); err != nil {
+			// Avoid squashing the HTTP response info with Unmarshal err...
+			logger.Debugf("Unmarshaled %s", *dest.Message)
+
+			bodyStr := strings.ReplaceAll(string(resp.Body[:]), "\n", " ")
+			err := fmt.Errorf("code:'%d'; failed to unmarshal response:'%s'; %w", resp.StatusCode(), bodyStr, err)
+			return err
+		}
+		return errors.New(*dest.Message)
+	}
+
+	return nil
+}
+
+// DeleteRemediationWithConn can be used to programtically interact with backplaneapi
+func DeleteRemediationWithConn(bp config.BackplaneConfiguration, ocmConnection *ocmsdk.Connection, clusterID string, remediationSA string) error {
+	accessToken, err := ocm.DefaultOCMInterface.GetOCMAccessTokenWithConn(ocmConnection)
+	if err != nil {
+		return err
+	}
+
+	return doDeleteRemediation(bp.URL, clusterID, *accessToken, remediationSA)
 }

--- a/cmd/ocm-backplane/remediation/remediation_test.go
+++ b/cmd/ocm-backplane/remediation/remediation_test.go
@@ -1,0 +1,270 @@
+package remediation
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	BackplaneApi "github.com/openshift/backplane-api/pkg/client"
+	"github.com/openshift/backplane-cli/pkg/backplaneapi"
+	backplaneapiMock "github.com/openshift/backplane-cli/pkg/backplaneapi/mocks"
+	"github.com/openshift/backplane-cli/pkg/client/mocks"
+	"github.com/openshift/backplane-cli/pkg/ocm"
+	ocmMock "github.com/openshift/backplane-cli/pkg/ocm/mocks"
+	"github.com/openshift/backplane-cli/pkg/utils"
+)
+
+func MakeIoReader(s string) io.ReadCloser {
+	r := io.NopCloser(strings.NewReader(s)) // r type is io.ReadCloser
+	return r
+}
+
+var _ = Describe("New Remediation command", func() {
+	var (
+		mockCtrl         *gomock.Controller
+		mockOcmInterface *ocmMock.MockOCMInterface
+		mockClientUtil   *backplaneapiMock.MockClientUtils
+		//mockClient         *mocks.MockClientInterface
+		mockClientWithResp *mocks.MockClientWithResponsesInterface
+		//mockCluster        *cmv1.Cluster
+
+		testClusterID             string
+		trueClusterID             string
+		testToken                 string
+		testRemediationName       string
+		testProxyURI              string
+		fakeResp                  *http.Response
+		bpConfigPath              string
+		backplaneAPIURI           string
+		ocmEnv                    *cmv1.Environment
+		createRemediationResponse *BackplaneApi.CreateRemediationResponse
+		deleteRemediationResponse *BackplaneApi.DeleteRemediationResponse
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockClientWithResp = mocks.NewMockClientWithResponsesInterface(mockCtrl)
+		//ockClient = mocks.NewMockClientInterface(mockCtrl)
+
+		mockOcmInterface = ocmMock.NewMockOCMInterface(mockCtrl)
+		ocm.DefaultOCMInterface = mockOcmInterface
+
+		mockClientUtil = backplaneapiMock.NewMockClientUtils(mockCtrl)
+		backplaneapi.DefaultClientUtils = mockClientUtil
+
+		mockClientWithResp.EXPECT().LoginClusterWithResponse(gomock.Any(), gomock.Any()).Return(nil, nil).Times(0)
+
+		_ = clientcmd.ModifyConfig(clientcmd.NewDefaultPathOptions(), api.Config{}, true)
+		clientcmd.UseModifyConfigLock = false
+
+		globalOpts.BackplaneURL = backplaneAPIURI
+
+		ocmEnv, _ = cmv1.NewEnvironment().BackplaneURL("https://api.example.com").Build()
+
+		//mockCluster = &cmv1.Cluster{}
+
+		//backplaneConfiguration = config.BackplaneConfiguration{URL: backplaneAPIURI}
+
+		fakeResp = &http.Response{
+			Body:       MakeIoReader(`{"proxy_uri":"proxy", "statusCode":200, "message":"msg"}`),
+			Header:     map[string][]string{},
+			StatusCode: http.StatusOK,
+		}
+		fakeResp.Header.Add("Content-Type", "json")
+
+		testProxyURI = "http://proxy.example.com/"
+
+		createRemediationResponse = &BackplaneApi.CreateRemediationResponse{
+			HTTPResponse: fakeResp,
+			Body:         []byte(""),
+			JSON200:      &BackplaneApi.LoginResponse{ProxyUri: &testProxyURI},
+		}
+
+		deleteRemediationResponse = &BackplaneApi.DeleteRemediationResponse{
+			HTTPResponse: fakeResp,
+			Body:         []byte(""),
+		}
+
+		testClusterID = "test123"
+		trueClusterID = "trueID123"
+		backplaneAPIURI = "https://shard.apps.example.com/"
+		testToken = "testToken"
+		testRemediationName = "remediationName"
+
+	})
+
+	AfterEach(func() {
+		globalOpts.Manager = false
+		globalOpts.Service = false
+		globalOpts.BackplaneURL = ""
+		globalOpts.ProxyURL = ""
+		os.Setenv("HTTPS_PROXY", "")
+		os.Setenv("HTTP_PROXY", "")
+		os.Unsetenv("BACKPLANE_CONFIG")
+		os.Remove(bpConfigPath)
+		mockCtrl.Finish()
+		utils.RemoveTempKubeConfig()
+	})
+	Context("create Remediation", func() {
+		It("Should run the query without returning an error", func() {
+			mockOcmInterface.EXPECT().GetOCMEnvironment().Return(ocmEnv, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(trueClusterID, testClusterID, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil)
+			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterID)).Return(false, nil).AnyTimes()
+
+			mockClientUtil.EXPECT().MakeBackplaneAPIClientWithAccessToken(backplaneAPIURI, testToken).Return(mockClientWithResp, nil)
+			mockClientWithResp.EXPECT().CreateRemediationWithResponse(context.TODO(), trueClusterID, &BackplaneApi.CreateRemediationParams{Remediation: testRemediationName}).Return(createRemediationResponse, nil)
+
+			err := runCreateRemediation([]string{testRemediationName}, testClusterID, backplaneAPIURI)
+
+			Expect(err).To(BeNil())
+		})
+
+		It("Should use the custom URI if provided", func() {
+			mockOcmInterface.EXPECT().GetOCMEnvironment().Return(ocmEnv, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(trueClusterID, testClusterID, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil)
+			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterID)).Return(false, nil).AnyTimes()
+
+			mockClientUtil.EXPECT().MakeBackplaneAPIClientWithAccessToken("http://uri2.example.com", testToken).Return(mockClientWithResp, nil)
+			mockClientWithResp.EXPECT().CreateRemediationWithResponse(context.TODO(), trueClusterID, &BackplaneApi.CreateRemediationParams{Remediation: testRemediationName}).Return(createRemediationResponse, nil)
+
+			err := runCreateRemediation([]string{testRemediationName}, testClusterID, "http://uri2.example.com")
+
+			Expect(err).To(BeNil())
+		})
+
+		It("Should use the Proxy URL set in global opts", func() {
+			globalOpts.ProxyURL = "https://squid.example.com"
+			os.Setenv("HTTPS_PROXY", "https://squid.example.com")
+
+			mockOcmInterface.EXPECT().GetOCMEnvironment().Return(ocmEnv, nil).AnyTimes()
+			mockClientUtil.EXPECT().SetClientProxyURL(globalOpts.ProxyURL).Return(nil)
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(trueClusterID, testClusterID, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil)
+			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterID)).Return(false, nil).AnyTimes()
+
+			mockClientUtil.EXPECT().MakeBackplaneAPIClientWithAccessToken(backplaneAPIURI, testToken).Return(mockClientWithResp, nil)
+			mockClientWithResp.EXPECT().CreateRemediationWithResponse(context.TODO(), trueClusterID, &BackplaneApi.CreateRemediationParams{Remediation: testRemediationName}).Return(createRemediationResponse, nil)
+
+			err := runCreateRemediation([]string{testRemediationName}, testClusterID, backplaneAPIURI)
+
+			Expect(err).To(BeNil())
+		})
+
+		It("Should fail when failed to get OCM token", func() {
+			mockOcmInterface.EXPECT().GetOCMEnvironment().Return(ocmEnv, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(trueClusterID, testClusterID, nil)
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(nil, errors.New("err")).AnyTimes()
+			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterID)).Return(false, nil).AnyTimes()
+
+			err := runCreateRemediation([]string{testRemediationName}, testClusterID, backplaneAPIURI)
+
+			Expect(err).ToNot(BeNil())
+		})
+
+		It("Should fail if unable to create API client", func() {
+			mockOcmInterface.EXPECT().GetOCMEnvironment().Return(ocmEnv, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(trueClusterID, testClusterID, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil)
+			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterID)).Return(false, nil).AnyTimes()
+
+			mockClientUtil.EXPECT().MakeBackplaneAPIClientWithAccessToken(backplaneAPIURI, testToken).Return(nil, errors.New("err"))
+
+			err := runCreateRemediation([]string{testRemediationName}, testClusterID, backplaneAPIURI)
+
+			Expect(err).ToNot(BeNil())
+		})
+
+		It("Should fail if backplaneURL is empty", func() {
+			ocmEnv, _ = cmv1.NewEnvironment().Build()
+
+			mockOcmInterface.EXPECT().GetOCMEnvironment().Return(ocmEnv, nil).AnyTimes()
+
+			err := runCreateRemediation([]string{testRemediationName}, testClusterID, backplaneAPIURI)
+
+			Expect(err).ToNot(BeNil())
+		})
+	})
+
+	Context("delete remediation", func() {
+		It("Should run the query without returning an error", func() {
+			mockOcmInterface.EXPECT().GetOCMEnvironment().Return(ocmEnv, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(trueClusterID, testClusterID, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil)
+			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterID)).Return(false, nil).AnyTimes()
+
+			mockClientUtil.EXPECT().MakeBackplaneAPIClientWithAccessToken(backplaneAPIURI, testToken).Return(mockClientWithResp, nil)
+			mockClientWithResp.EXPECT().DeleteRemediationWithResponse(context.TODO(), trueClusterID, &BackplaneApi.DeleteRemediationParams{Remediation: &testRemediationName}).Return(deleteRemediationResponse, nil)
+
+			err := runDeleteRemediation([]string{testRemediationName}, testClusterID, backplaneAPIURI)
+
+			Expect(err).To(BeNil())
+		})
+
+		It("Should use the custom URI if provided", func() {
+			mockOcmInterface.EXPECT().GetOCMEnvironment().Return(ocmEnv, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(trueClusterID, testClusterID, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil)
+			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterID)).Return(false, nil).AnyTimes()
+
+			mockClientUtil.EXPECT().MakeBackplaneAPIClientWithAccessToken("https://uri2.example.com/", testToken).Return(mockClientWithResp, nil)
+			mockClientWithResp.EXPECT().DeleteRemediationWithResponse(context.TODO(), trueClusterID, &BackplaneApi.DeleteRemediationParams{Remediation: &testRemediationName}).Return(deleteRemediationResponse, nil)
+
+			err := runDeleteRemediation([]string{testRemediationName}, testClusterID, "https://uri2.example.com/")
+
+			Expect(err).To(BeNil())
+		})
+
+		It("Should fail when failed to get OCM token", func() {
+			mockOcmInterface.EXPECT().GetOCMEnvironment().Return(ocmEnv, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(trueClusterID, testClusterID, nil)
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(nil, errors.New("err")).AnyTimes()
+			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterID)).Return(false, nil).AnyTimes()
+
+			err := runDeleteRemediation([]string{testRemediationName}, testClusterID, backplaneAPIURI)
+
+			Expect(err).ToNot(BeNil())
+		})
+
+		It("Should fail if unable to create API client", func() {
+			mockOcmInterface.EXPECT().GetOCMEnvironment().Return(ocmEnv, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(trueClusterID, testClusterID, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil)
+			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterID)).Return(false, nil).AnyTimes()
+
+			mockClientUtil.EXPECT().MakeBackplaneAPIClientWithAccessToken(backplaneAPIURI, testToken).Return(nil, errors.New("err"))
+
+			err := runDeleteRemediation([]string{testRemediationName}, testClusterID, backplaneAPIURI)
+
+			Expect(err).ToNot(BeNil())
+		})
+
+		It("Should fail if backplaneURL is empty", func() {
+			ocmEnv, _ = cmv1.NewEnvironment().Build()
+
+			mockOcmInterface.EXPECT().GetOCMEnvironment().Return(ocmEnv, nil).AnyTimes()
+
+			err := runDeleteRemediation([]string{testRemediationName}, testClusterID, backplaneAPIURI)
+
+			Expect(err).ToNot(BeNil())
+		})
+	})
+
+})
+
+func TestIt(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Login Test Suite")
+}

--- a/cmd/ocm-backplane/remediation/remediation_test.go
+++ b/cmd/ocm-backplane/remediation/remediation_test.go
@@ -57,6 +57,9 @@ var _ = Describe("New Remediation command", func() {
 		mockClientWithResp = mocks.NewMockClientWithResponsesInterface(mockCtrl)
 		//ockClient = mocks.NewMockClientInterface(mockCtrl)
 
+		err := utils.CreateTempKubeConfig(nil)
+		Expect(err).To(BeNil())
+
 		mockOcmInterface = ocmMock.NewMockOCMInterface(mockCtrl)
 		ocm.DefaultOCMInterface = mockOcmInterface
 

--- a/cmd/ocm-backplane/root.go
+++ b/cmd/ocm-backplane/root.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/logout"
 	managedjob "github.com/openshift/backplane-cli/cmd/ocm-backplane/managedJob"
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/monitoring"
+	"github.com/openshift/backplane-cli/cmd/ocm-backplane/remediation"
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/script"
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/session"
 	"github.com/openshift/backplane-cli/cmd/ocm-backplane/status"
@@ -82,4 +83,5 @@ func init() {
 	rootCmd.AddCommand(version.VersionCmd)
 	rootCmd.AddCommand(monitoring.MonitoringCmd)
 	rootCmd.AddCommand(healthcheck.HealthCheckCmd)
+	rootCmd.AddCommand(remediation.NewRemediationCmd())
 }

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/onsi/gomega v1.35.1
 	github.com/openshift-online/ocm-cli v1.0.2
 	github.com/openshift-online/ocm-sdk-go v0.1.448
-	github.com/openshift/backplane-api v0.0.0-20240620101759-427d89f7620c
+	github.com/openshift/backplane-api v0.0.0-20241127094828-0f66644ff53d
 	github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -392,8 +392,6 @@ github.com/openshift-online/ocm-sdk-go v0.1.448 h1:U7zXZER/2nBR25AnAxENgB3wS0O/N
 github.com/openshift-online/ocm-sdk-go v0.1.448/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
 github.com/openshift/api v0.0.0-20221018124113-7edcfe3c76cb h1:QsBjYe5UfHIZi/3SMzQBIjYDKnWqZxq50eQkBp9eUew=
 github.com/openshift/api v0.0.0-20221018124113-7edcfe3c76cb/go.mod h1:JRz+ZvTqu9u7t6suhhPTacbFl5K65Y6rJbNM7HjWA3g=
-github.com/openshift/backplane-api v0.0.0-20240620101759-427d89f7620c h1:/o3tQoMyGGUkFC14ibcftiF1X9VtT3p4qKoA+gdGtEc=
-github.com/openshift/backplane-api v0.0.0-20240620101759-427d89f7620c/go.mod h1:RuJZpJy45AJnkp7A0ZPTZhLOVkCGDLI6cGknKvp65LE=
 github.com/openshift/backplane-api v0.0.0-20241127094828-0f66644ff53d h1:7Dx+1tKC8eegHGXTnrmMrV0QV68qHdOFFseQR5L3ej4=
 github.com/openshift/backplane-api v0.0.0-20241127094828-0f66644ff53d/go.mod h1:RuJZpJy45AJnkp7A0ZPTZhLOVkCGDLI6cGknKvp65LE=
 github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c h1:CV76yFOTXmq9VciBR3Bve5ZWzSxdft7gaMVB3kS0rwg=

--- a/go.sum
+++ b/go.sum
@@ -394,6 +394,8 @@ github.com/openshift/api v0.0.0-20221018124113-7edcfe3c76cb h1:QsBjYe5UfHIZi/3SM
 github.com/openshift/api v0.0.0-20221018124113-7edcfe3c76cb/go.mod h1:JRz+ZvTqu9u7t6suhhPTacbFl5K65Y6rJbNM7HjWA3g=
 github.com/openshift/backplane-api v0.0.0-20240620101759-427d89f7620c h1:/o3tQoMyGGUkFC14ibcftiF1X9VtT3p4qKoA+gdGtEc=
 github.com/openshift/backplane-api v0.0.0-20240620101759-427d89f7620c/go.mod h1:RuJZpJy45AJnkp7A0ZPTZhLOVkCGDLI6cGknKvp65LE=
+github.com/openshift/backplane-api v0.0.0-20241127094828-0f66644ff53d h1:7Dx+1tKC8eegHGXTnrmMrV0QV68qHdOFFseQR5L3ej4=
+github.com/openshift/backplane-api v0.0.0-20241127094828-0f66644ff53d/go.mod h1:RuJZpJy45AJnkp7A0ZPTZhLOVkCGDLI6cGknKvp65LE=
 github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c h1:CV76yFOTXmq9VciBR3Bve5ZWzSxdft7gaMVB3kS0rwg=
 github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c/go.mod h1:lFMO8mLHXWFzSdYvGNo8ivF9SfF6zInA8ZGw4phRnUE=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=

--- a/pkg/client/mocks/ClientMock.go
+++ b/pkg/client/mocks/ClientMock.go
@@ -77,6 +77,26 @@ func (mr *MockClientInterfaceMockRecorder) CreateJobWithBody(arg0, arg1, arg2, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateJobWithBody", reflect.TypeOf((*MockClientInterface)(nil).CreateJobWithBody), varargs...)
 }
 
+// CreateRemediation mocks base method.
+func (m *MockClientInterface) CreateRemediation(arg0 context.Context, arg1 string, arg2 *Openapi.CreateRemediationParams, arg3 ...Openapi.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateRemediation", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateRemediation indicates an expected call of CreateRemediation.
+func (mr *MockClientInterfaceMockRecorder) CreateRemediation(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRemediation", reflect.TypeOf((*MockClientInterface)(nil).CreateRemediation), varargs...)
+}
+
 // CreateTestScriptRun mocks base method.
 func (m *MockClientInterface) CreateTestScriptRun(arg0 context.Context, arg1 string, arg2 Openapi.CreateTestJob, arg3 ...Openapi.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -137,6 +157,26 @@ func (mr *MockClientInterfaceMockRecorder) DeleteBackplaneClusterClusterId(arg0,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackplaneClusterClusterId", reflect.TypeOf((*MockClientInterface)(nil).DeleteBackplaneClusterClusterId), varargs...)
 }
 
+// DeleteBackplaneRemediateClusterIdRemediation mocks base method.
+func (m *MockClientInterface) DeleteBackplaneRemediateClusterIdRemediation(arg0 context.Context, arg1, arg2 string, arg3 ...Openapi.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteBackplaneRemediateClusterIdRemediation", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteBackplaneRemediateClusterIdRemediation indicates an expected call of DeleteBackplaneRemediateClusterIdRemediation.
+func (mr *MockClientInterfaceMockRecorder) DeleteBackplaneRemediateClusterIdRemediation(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackplaneRemediateClusterIdRemediation", reflect.TypeOf((*MockClientInterface)(nil).DeleteBackplaneRemediateClusterIdRemediation), varargs...)
+}
+
 // DeleteJob mocks base method.
 func (m *MockClientInterface) DeleteJob(arg0 context.Context, arg1, arg2 string, arg3 ...Openapi.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -155,6 +195,26 @@ func (mr *MockClientInterfaceMockRecorder) DeleteJob(arg0, arg1, arg2 interface{
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteJob", reflect.TypeOf((*MockClientInterface)(nil).DeleteJob), varargs...)
+}
+
+// DeleteRemediation mocks base method.
+func (m *MockClientInterface) DeleteRemediation(arg0 context.Context, arg1 string, arg2 *Openapi.DeleteRemediationParams, arg3 ...Openapi.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteRemediation", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteRemediation indicates an expected call of DeleteRemediation.
+func (mr *MockClientInterfaceMockRecorder) DeleteRemediation(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRemediation", reflect.TypeOf((*MockClientInterface)(nil).DeleteRemediation), varargs...)
 }
 
 // GetAllJobs mocks base method.
@@ -215,6 +275,26 @@ func (mr *MockClientInterfaceMockRecorder) GetBackplaneClusterClusterId(arg0, ar
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackplaneClusterClusterId", reflect.TypeOf((*MockClientInterface)(nil).GetBackplaneClusterClusterId), varargs...)
+}
+
+// GetBackplaneRemediateClusterIdRemediation mocks base method.
+func (m *MockClientInterface) GetBackplaneRemediateClusterIdRemediation(arg0 context.Context, arg1, arg2 string, arg3 ...Openapi.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetBackplaneRemediateClusterIdRemediation", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBackplaneRemediateClusterIdRemediation indicates an expected call of GetBackplaneRemediateClusterIdRemediation.
+func (mr *MockClientInterfaceMockRecorder) GetBackplaneRemediateClusterIdRemediation(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackplaneRemediateClusterIdRemediation", reflect.TypeOf((*MockClientInterface)(nil).GetBackplaneRemediateClusterIdRemediation), varargs...)
 }
 
 // GetCloudConsole mocks base method.
@@ -377,6 +457,26 @@ func (mr *MockClientInterfaceMockRecorder) HeadBackplaneClusterClusterId(arg0, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeadBackplaneClusterClusterId", reflect.TypeOf((*MockClientInterface)(nil).HeadBackplaneClusterClusterId), varargs...)
 }
 
+// HeadBackplaneRemediateClusterIdRemediation mocks base method.
+func (m *MockClientInterface) HeadBackplaneRemediateClusterIdRemediation(arg0 context.Context, arg1, arg2 string, arg3 ...Openapi.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "HeadBackplaneRemediateClusterIdRemediation", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HeadBackplaneRemediateClusterIdRemediation indicates an expected call of HeadBackplaneRemediateClusterIdRemediation.
+func (mr *MockClientInterfaceMockRecorder) HeadBackplaneRemediateClusterIdRemediation(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeadBackplaneRemediateClusterIdRemediation", reflect.TypeOf((*MockClientInterface)(nil).HeadBackplaneRemediateClusterIdRemediation), varargs...)
+}
+
 // LoginCluster mocks base method.
 func (m *MockClientInterface) LoginCluster(arg0 context.Context, arg1 string, arg2 ...Openapi.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -417,6 +517,26 @@ func (mr *MockClientInterfaceMockRecorder) OptionsBackplaneClusterClusterId(arg0
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OptionsBackplaneClusterClusterId", reflect.TypeOf((*MockClientInterface)(nil).OptionsBackplaneClusterClusterId), varargs...)
 }
 
+// OptionsBackplaneRemediateClusterIdRemediation mocks base method.
+func (m *MockClientInterface) OptionsBackplaneRemediateClusterIdRemediation(arg0 context.Context, arg1, arg2 string, arg3 ...Openapi.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "OptionsBackplaneRemediateClusterIdRemediation", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OptionsBackplaneRemediateClusterIdRemediation indicates an expected call of OptionsBackplaneRemediateClusterIdRemediation.
+func (mr *MockClientInterfaceMockRecorder) OptionsBackplaneRemediateClusterIdRemediation(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OptionsBackplaneRemediateClusterIdRemediation", reflect.TypeOf((*MockClientInterface)(nil).OptionsBackplaneRemediateClusterIdRemediation), varargs...)
+}
+
 // PatchBackplaneClusterClusterId mocks base method.
 func (m *MockClientInterface) PatchBackplaneClusterClusterId(arg0 context.Context, arg1 string, arg2 ...Openapi.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -435,6 +555,26 @@ func (mr *MockClientInterfaceMockRecorder) PatchBackplaneClusterClusterId(arg0, 
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchBackplaneClusterClusterId", reflect.TypeOf((*MockClientInterface)(nil).PatchBackplaneClusterClusterId), varargs...)
+}
+
+// PatchBackplaneRemediateClusterIdRemediation mocks base method.
+func (m *MockClientInterface) PatchBackplaneRemediateClusterIdRemediation(arg0 context.Context, arg1, arg2 string, arg3 ...Openapi.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PatchBackplaneRemediateClusterIdRemediation", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PatchBackplaneRemediateClusterIdRemediation indicates an expected call of PatchBackplaneRemediateClusterIdRemediation.
+func (mr *MockClientInterfaceMockRecorder) PatchBackplaneRemediateClusterIdRemediation(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchBackplaneRemediateClusterIdRemediation", reflect.TypeOf((*MockClientInterface)(nil).PatchBackplaneRemediateClusterIdRemediation), varargs...)
 }
 
 // PostBackplaneClusterClusterId mocks base method.
@@ -457,6 +597,26 @@ func (mr *MockClientInterfaceMockRecorder) PostBackplaneClusterClusterId(arg0, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostBackplaneClusterClusterId", reflect.TypeOf((*MockClientInterface)(nil).PostBackplaneClusterClusterId), varargs...)
 }
 
+// PostBackplaneRemediateClusterIdRemediation mocks base method.
+func (m *MockClientInterface) PostBackplaneRemediateClusterIdRemediation(arg0 context.Context, arg1, arg2 string, arg3 ...Openapi.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PostBackplaneRemediateClusterIdRemediation", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PostBackplaneRemediateClusterIdRemediation indicates an expected call of PostBackplaneRemediateClusterIdRemediation.
+func (mr *MockClientInterfaceMockRecorder) PostBackplaneRemediateClusterIdRemediation(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostBackplaneRemediateClusterIdRemediation", reflect.TypeOf((*MockClientInterface)(nil).PostBackplaneRemediateClusterIdRemediation), varargs...)
+}
+
 // PutBackplaneClusterClusterId mocks base method.
 func (m *MockClientInterface) PutBackplaneClusterClusterId(arg0 context.Context, arg1 string, arg2 ...Openapi.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -477,6 +637,26 @@ func (mr *MockClientInterfaceMockRecorder) PutBackplaneClusterClusterId(arg0, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutBackplaneClusterClusterId", reflect.TypeOf((*MockClientInterface)(nil).PutBackplaneClusterClusterId), varargs...)
 }
 
+// PutBackplaneRemediateClusterIdRemediation mocks base method.
+func (m *MockClientInterface) PutBackplaneRemediateClusterIdRemediation(arg0 context.Context, arg1, arg2 string, arg3 ...Openapi.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PutBackplaneRemediateClusterIdRemediation", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PutBackplaneRemediateClusterIdRemediation indicates an expected call of PutBackplaneRemediateClusterIdRemediation.
+func (mr *MockClientInterfaceMockRecorder) PutBackplaneRemediateClusterIdRemediation(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutBackplaneRemediateClusterIdRemediation", reflect.TypeOf((*MockClientInterface)(nil).PutBackplaneRemediateClusterIdRemediation), varargs...)
+}
+
 // TraceBackplaneClusterClusterId mocks base method.
 func (m *MockClientInterface) TraceBackplaneClusterClusterId(arg0 context.Context, arg1 string, arg2 ...Openapi.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -495,4 +675,24 @@ func (mr *MockClientInterfaceMockRecorder) TraceBackplaneClusterClusterId(arg0, 
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TraceBackplaneClusterClusterId", reflect.TypeOf((*MockClientInterface)(nil).TraceBackplaneClusterClusterId), varargs...)
+}
+
+// TraceBackplaneRemediateClusterIdRemediation mocks base method.
+func (m *MockClientInterface) TraceBackplaneRemediateClusterIdRemediation(arg0 context.Context, arg1, arg2 string, arg3 ...Openapi.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "TraceBackplaneRemediateClusterIdRemediation", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TraceBackplaneRemediateClusterIdRemediation indicates an expected call of TraceBackplaneRemediateClusterIdRemediation.
+func (mr *MockClientInterfaceMockRecorder) TraceBackplaneRemediateClusterIdRemediation(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TraceBackplaneRemediateClusterIdRemediation", reflect.TypeOf((*MockClientInterface)(nil).TraceBackplaneRemediateClusterIdRemediation), varargs...)
 }

--- a/pkg/client/mocks/ClientWithResponsesMock.go
+++ b/pkg/client/mocks/ClientWithResponsesMock.go
@@ -76,6 +76,26 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) CreateJobWithResponse(ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateJobWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).CreateJobWithResponse), varargs...)
 }
 
+// CreateRemediationWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) CreateRemediationWithResponse(arg0 context.Context, arg1 string, arg2 *Openapi.CreateRemediationParams, arg3 ...Openapi.RequestEditorFn) (*Openapi.CreateRemediationResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateRemediationWithResponse", varargs...)
+	ret0, _ := ret[0].(*Openapi.CreateRemediationResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateRemediationWithResponse indicates an expected call of CreateRemediationWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) CreateRemediationWithResponse(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRemediationWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).CreateRemediationWithResponse), varargs...)
+}
+
 // CreateTestScriptRunWithBodyWithResponse mocks base method.
 func (m *MockClientWithResponsesInterface) CreateTestScriptRunWithBodyWithResponse(arg0 context.Context, arg1, arg2 string, arg3 io.Reader, arg4 ...Openapi.RequestEditorFn) (*Openapi.CreateTestScriptRunResponse, error) {
 	m.ctrl.T.Helper()
@@ -136,6 +156,26 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) DeleteBackplaneClusterCl
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackplaneClusterClusterIdWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DeleteBackplaneClusterClusterIdWithResponse), varargs...)
 }
 
+// DeleteBackplaneRemediateClusterIdRemediationWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) DeleteBackplaneRemediateClusterIdRemediationWithResponse(arg0 context.Context, arg1, arg2 string, arg3 ...Openapi.RequestEditorFn) (*Openapi.DeleteBackplaneRemediateClusterIdRemediationResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteBackplaneRemediateClusterIdRemediationWithResponse", varargs...)
+	ret0, _ := ret[0].(*Openapi.DeleteBackplaneRemediateClusterIdRemediationResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteBackplaneRemediateClusterIdRemediationWithResponse indicates an expected call of DeleteBackplaneRemediateClusterIdRemediationWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) DeleteBackplaneRemediateClusterIdRemediationWithResponse(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackplaneRemediateClusterIdRemediationWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DeleteBackplaneRemediateClusterIdRemediationWithResponse), varargs...)
+}
+
 // DeleteJobWithResponse mocks base method.
 func (m *MockClientWithResponsesInterface) DeleteJobWithResponse(arg0 context.Context, arg1, arg2 string, arg3 ...Openapi.RequestEditorFn) (*Openapi.DeleteJobResponse, error) {
 	m.ctrl.T.Helper()
@@ -154,6 +194,26 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) DeleteJobWithResponse(ar
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteJobWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DeleteJobWithResponse), varargs...)
+}
+
+// DeleteRemediationWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) DeleteRemediationWithResponse(arg0 context.Context, arg1 string, arg2 *Openapi.DeleteRemediationParams, arg3 ...Openapi.RequestEditorFn) (*Openapi.DeleteRemediationResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteRemediationWithResponse", varargs...)
+	ret0, _ := ret[0].(*Openapi.DeleteRemediationResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteRemediationWithResponse indicates an expected call of DeleteRemediationWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) DeleteRemediationWithResponse(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRemediationWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DeleteRemediationWithResponse), varargs...)
 }
 
 // GetAllJobsWithResponse mocks base method.
@@ -214,6 +274,26 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) GetBackplaneClusterClust
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackplaneClusterClusterIdWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).GetBackplaneClusterClusterIdWithResponse), varargs...)
+}
+
+// GetBackplaneRemediateClusterIdRemediationWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) GetBackplaneRemediateClusterIdRemediationWithResponse(arg0 context.Context, arg1, arg2 string, arg3 ...Openapi.RequestEditorFn) (*Openapi.GetBackplaneRemediateClusterIdRemediationResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetBackplaneRemediateClusterIdRemediationWithResponse", varargs...)
+	ret0, _ := ret[0].(*Openapi.GetBackplaneRemediateClusterIdRemediationResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBackplaneRemediateClusterIdRemediationWithResponse indicates an expected call of GetBackplaneRemediateClusterIdRemediationWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) GetBackplaneRemediateClusterIdRemediationWithResponse(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackplaneRemediateClusterIdRemediationWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).GetBackplaneRemediateClusterIdRemediationWithResponse), varargs...)
 }
 
 // GetCloudConsoleWithResponse mocks base method.
@@ -376,6 +456,26 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) HeadBackplaneClusterClus
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeadBackplaneClusterClusterIdWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).HeadBackplaneClusterClusterIdWithResponse), varargs...)
 }
 
+// HeadBackplaneRemediateClusterIdRemediationWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) HeadBackplaneRemediateClusterIdRemediationWithResponse(arg0 context.Context, arg1, arg2 string, arg3 ...Openapi.RequestEditorFn) (*Openapi.HeadBackplaneRemediateClusterIdRemediationResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "HeadBackplaneRemediateClusterIdRemediationWithResponse", varargs...)
+	ret0, _ := ret[0].(*Openapi.HeadBackplaneRemediateClusterIdRemediationResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HeadBackplaneRemediateClusterIdRemediationWithResponse indicates an expected call of HeadBackplaneRemediateClusterIdRemediationWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) HeadBackplaneRemediateClusterIdRemediationWithResponse(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeadBackplaneRemediateClusterIdRemediationWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).HeadBackplaneRemediateClusterIdRemediationWithResponse), varargs...)
+}
+
 // LoginClusterWithResponse mocks base method.
 func (m *MockClientWithResponsesInterface) LoginClusterWithResponse(arg0 context.Context, arg1 string, arg2 ...Openapi.RequestEditorFn) (*Openapi.LoginClusterResponse, error) {
 	m.ctrl.T.Helper()
@@ -416,6 +516,26 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) OptionsBackplaneClusterC
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OptionsBackplaneClusterClusterIdWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).OptionsBackplaneClusterClusterIdWithResponse), varargs...)
 }
 
+// OptionsBackplaneRemediateClusterIdRemediationWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) OptionsBackplaneRemediateClusterIdRemediationWithResponse(arg0 context.Context, arg1, arg2 string, arg3 ...Openapi.RequestEditorFn) (*Openapi.OptionsBackplaneRemediateClusterIdRemediationResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "OptionsBackplaneRemediateClusterIdRemediationWithResponse", varargs...)
+	ret0, _ := ret[0].(*Openapi.OptionsBackplaneRemediateClusterIdRemediationResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OptionsBackplaneRemediateClusterIdRemediationWithResponse indicates an expected call of OptionsBackplaneRemediateClusterIdRemediationWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) OptionsBackplaneRemediateClusterIdRemediationWithResponse(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OptionsBackplaneRemediateClusterIdRemediationWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).OptionsBackplaneRemediateClusterIdRemediationWithResponse), varargs...)
+}
+
 // PatchBackplaneClusterClusterIdWithResponse mocks base method.
 func (m *MockClientWithResponsesInterface) PatchBackplaneClusterClusterIdWithResponse(arg0 context.Context, arg1 string, arg2 ...Openapi.RequestEditorFn) (*Openapi.PatchBackplaneClusterClusterIdResponse, error) {
 	m.ctrl.T.Helper()
@@ -434,6 +554,26 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) PatchBackplaneClusterClu
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchBackplaneClusterClusterIdWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).PatchBackplaneClusterClusterIdWithResponse), varargs...)
+}
+
+// PatchBackplaneRemediateClusterIdRemediationWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) PatchBackplaneRemediateClusterIdRemediationWithResponse(arg0 context.Context, arg1, arg2 string, arg3 ...Openapi.RequestEditorFn) (*Openapi.PatchBackplaneRemediateClusterIdRemediationResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PatchBackplaneRemediateClusterIdRemediationWithResponse", varargs...)
+	ret0, _ := ret[0].(*Openapi.PatchBackplaneRemediateClusterIdRemediationResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PatchBackplaneRemediateClusterIdRemediationWithResponse indicates an expected call of PatchBackplaneRemediateClusterIdRemediationWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) PatchBackplaneRemediateClusterIdRemediationWithResponse(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchBackplaneRemediateClusterIdRemediationWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).PatchBackplaneRemediateClusterIdRemediationWithResponse), varargs...)
 }
 
 // PostBackplaneClusterClusterIdWithResponse mocks base method.
@@ -456,6 +596,26 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) PostBackplaneClusterClus
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostBackplaneClusterClusterIdWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).PostBackplaneClusterClusterIdWithResponse), varargs...)
 }
 
+// PostBackplaneRemediateClusterIdRemediationWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) PostBackplaneRemediateClusterIdRemediationWithResponse(arg0 context.Context, arg1, arg2 string, arg3 ...Openapi.RequestEditorFn) (*Openapi.PostBackplaneRemediateClusterIdRemediationResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PostBackplaneRemediateClusterIdRemediationWithResponse", varargs...)
+	ret0, _ := ret[0].(*Openapi.PostBackplaneRemediateClusterIdRemediationResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PostBackplaneRemediateClusterIdRemediationWithResponse indicates an expected call of PostBackplaneRemediateClusterIdRemediationWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) PostBackplaneRemediateClusterIdRemediationWithResponse(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostBackplaneRemediateClusterIdRemediationWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).PostBackplaneRemediateClusterIdRemediationWithResponse), varargs...)
+}
+
 // PutBackplaneClusterClusterIdWithResponse mocks base method.
 func (m *MockClientWithResponsesInterface) PutBackplaneClusterClusterIdWithResponse(arg0 context.Context, arg1 string, arg2 ...Openapi.RequestEditorFn) (*Openapi.PutBackplaneClusterClusterIdResponse, error) {
 	m.ctrl.T.Helper()
@@ -476,6 +636,26 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) PutBackplaneClusterClust
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutBackplaneClusterClusterIdWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).PutBackplaneClusterClusterIdWithResponse), varargs...)
 }
 
+// PutBackplaneRemediateClusterIdRemediationWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) PutBackplaneRemediateClusterIdRemediationWithResponse(arg0 context.Context, arg1, arg2 string, arg3 ...Openapi.RequestEditorFn) (*Openapi.PutBackplaneRemediateClusterIdRemediationResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PutBackplaneRemediateClusterIdRemediationWithResponse", varargs...)
+	ret0, _ := ret[0].(*Openapi.PutBackplaneRemediateClusterIdRemediationResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PutBackplaneRemediateClusterIdRemediationWithResponse indicates an expected call of PutBackplaneRemediateClusterIdRemediationWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) PutBackplaneRemediateClusterIdRemediationWithResponse(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutBackplaneRemediateClusterIdRemediationWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).PutBackplaneRemediateClusterIdRemediationWithResponse), varargs...)
+}
+
 // TraceBackplaneClusterClusterIdWithResponse mocks base method.
 func (m *MockClientWithResponsesInterface) TraceBackplaneClusterClusterIdWithResponse(arg0 context.Context, arg1 string, arg2 ...Openapi.RequestEditorFn) (*Openapi.TraceBackplaneClusterClusterIdResponse, error) {
 	m.ctrl.T.Helper()
@@ -494,4 +674,24 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) TraceBackplaneClusterClu
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TraceBackplaneClusterClusterIdWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).TraceBackplaneClusterClusterIdWithResponse), varargs...)
+}
+
+// TraceBackplaneRemediateClusterIdRemediationWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) TraceBackplaneRemediateClusterIdRemediationWithResponse(arg0 context.Context, arg1, arg2 string, arg3 ...Openapi.RequestEditorFn) (*Openapi.TraceBackplaneRemediateClusterIdRemediationResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "TraceBackplaneRemediateClusterIdRemediationWithResponse", varargs...)
+	ret0, _ := ret[0].(*Openapi.TraceBackplaneRemediateClusterIdRemediationResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TraceBackplaneRemediateClusterIdRemediationWithResponse indicates an expected call of TraceBackplaneRemediateClusterIdRemediationWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) TraceBackplaneRemediateClusterIdRemediationWithResponse(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TraceBackplaneRemediateClusterIdRemediationWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).TraceBackplaneRemediateClusterIdRemediationWithResponse), varargs...)
 }

--- a/pkg/remediation/remediation.go
+++ b/pkg/remediation/remediation.go
@@ -1,0 +1,114 @@
+package remediation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	ocmsdk "github.com/openshift-online/ocm-sdk-go"
+	BackplaneApi "github.com/openshift/backplane-api/pkg/client"
+	"github.com/openshift/backplane-cli/pkg/backplaneapi"
+	"github.com/openshift/backplane-cli/pkg/cli/config"
+	"github.com/openshift/backplane-cli/pkg/ocm"
+	logger "github.com/sirupsen/logrus"
+	"k8s.io/client-go/rest"
+)
+
+// TODO are we missusing the backplane api package? We have generated functions like backplaneapi.CreateRemediationWithResponse which already reads the body. All the utils functions do read the body again. Failing my calls here.
+func DoCreateRemediation(api string, clusterID string, accessToken string, remediationName string) (proxyURI string, err error) {
+	client, err := backplaneapi.DefaultClientUtils.MakeBackplaneAPIClientWithAccessToken(api, accessToken)
+	if err != nil {
+		return "", fmt.Errorf("unable to create backplane api client")
+	}
+
+	logger.Debug("Sending request...")
+	resp, err := client.CreateRemediationWithResponse(context.TODO(), clusterID, &BackplaneApi.CreateRemediationParams{Remediation: remediationName})
+	if err != nil {
+		logger.Debug("unexpected...")
+		return "", err
+	}
+
+	// TODO figure out the error handling here
+	if resp.StatusCode() != http.StatusOK {
+		// logger.Debugf("Unmarshal error resp body: %s", resp.Body)
+		var dest BackplaneApi.Error
+		if err := json.Unmarshal(resp.Body, &dest); err != nil {
+			// Avoid squashing the HTTP response info with Unmarshal err...
+			logger.Debugf("Unmarshaled %s", *dest.Message)
+
+			bodyStr := strings.ReplaceAll(string(resp.Body[:]), "\n", " ")
+			err := fmt.Errorf("code:'%d'; failed to unmarshal response:'%s'; %w", resp.StatusCode(), bodyStr, err)
+			return "", err
+		}
+		return "", errors.New(*dest.Message)
+
+	}
+	return api + *resp.JSON200.ProxyUri, nil
+}
+
+// CreateRemediationWithConn can be used to programtically interact with backplaneapi
+func CreateRemediationWithConn(bp config.BackplaneConfiguration, ocmConnection *ocmsdk.Connection, clusterID string, remediationName string) (config *rest.Config, serviceAccountName string, err error) {
+	accessToken, err := ocm.DefaultOCMInterface.GetOCMAccessTokenWithConn(ocmConnection)
+	if err != nil {
+		return nil, "", err
+	}
+
+	bpAPIClusterURL, err := DoCreateRemediation(bp.URL, clusterID, *accessToken, remediationName)
+	if err != nil {
+		return nil, "", err
+	}
+
+	cfg := &rest.Config{
+		Host:        bpAPIClusterURL,
+		BearerToken: *accessToken,
+	}
+
+	if bp.ProxyURL != nil {
+		cfg.Proxy = func(r *http.Request) (*url.URL, error) {
+			return url.Parse(*bp.ProxyURL)
+		}
+	}
+	return cfg, "", nil
+}
+
+func DoDeleteRemediation(api string, clusterID string, accessToken string, remediation string) error {
+	client, err := backplaneapi.DefaultClientUtils.MakeBackplaneAPIClientWithAccessToken(api, accessToken)
+	if err != nil {
+		return fmt.Errorf("unable to create backplane api client")
+	}
+
+	resp, err := client.DeleteRemediationWithResponse(context.TODO(), clusterID, &BackplaneApi.DeleteRemediationParams{Remediation: &remediation})
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode() != http.StatusOK {
+		// logger.Debugf("Unmarshal error resp body: %s", resp.Body)
+		var dest BackplaneApi.Error
+		if err := json.Unmarshal(resp.Body, &dest); err != nil {
+			// Avoid squashing the HTTP response info with Unmarshal err...
+			logger.Debugf("Unmarshaled %s", *dest.Message)
+
+			bodyStr := strings.ReplaceAll(string(resp.Body[:]), "\n", " ")
+			err := fmt.Errorf("code:'%d'; failed to unmarshal response:'%s'; %w", resp.StatusCode(), bodyStr, err)
+			return err
+		}
+		return errors.New(*dest.Message)
+	}
+
+	return nil
+}
+
+// DeleteRemediationWithConn can be used to programtically interact with backplaneapi
+func DeleteRemediationWithConn(bp config.BackplaneConfiguration, ocmConnection *ocmsdk.Connection, clusterID string, remediationSA string) error {
+	accessToken, err := ocm.DefaultOCMInterface.GetOCMAccessTokenWithConn(ocmConnection)
+	if err != nil {
+		return err
+	}
+
+	return DoDeleteRemediation(bp.URL, clusterID, *accessToken, remediationSA)
+}

--- a/pkg/remediation/remediation.go
+++ b/pkg/remediation/remediation.go
@@ -51,15 +51,15 @@ func DoCreateRemediation(api string, clusterID string, accessToken string, remed
 }
 
 // CreateRemediationWithConn can be used to programtically interact with backplaneapi
-func CreateRemediationWithConn(bp config.BackplaneConfiguration, ocmConnection *ocmsdk.Connection, clusterID string, remediationName string) (config *rest.Config, serviceAccountName string, err error) {
+func CreateRemediationWithConn(bp config.BackplaneConfiguration, ocmConnection *ocmsdk.Connection, clusterID string, remediationName string) (config *rest.Config, err error) {
 	accessToken, err := ocm.DefaultOCMInterface.GetOCMAccessTokenWithConn(ocmConnection)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	bpAPIClusterURL, err := DoCreateRemediation(bp.URL, clusterID, *accessToken, remediationName)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	cfg := &rest.Config{
@@ -72,7 +72,7 @@ func CreateRemediationWithConn(bp config.BackplaneConfiguration, ocmConnection *
 			return url.Parse(*bp.ProxyURL)
 		}
 	}
-	return cfg, "", nil
+	return cfg, nil
 }
 
 func DoDeleteRemediation(api string, clusterID string, accessToken string, remediation string) error {
@@ -104,11 +104,11 @@ func DoDeleteRemediation(api string, clusterID string, accessToken string, remed
 }
 
 // DeleteRemediationWithConn can be used to programtically interact with backplaneapi
-func DeleteRemediationWithConn(bp config.BackplaneConfiguration, ocmConnection *ocmsdk.Connection, clusterID string, remediationSA string) error {
+func DeleteRemediationWithConn(bp config.BackplaneConfiguration, ocmConnection *ocmsdk.Connection, clusterID string, remediation string) error {
 	accessToken, err := ocm.DefaultOCMInterface.GetOCMAccessTokenWithConn(ocmConnection)
 	if err != nil {
 		return err
 	}
 
-	return DoDeleteRemediation(bp.URL, clusterID, *accessToken, remediationSA)
+	return DoDeleteRemediation(bp.URL, clusterID, *accessToken, remediation)
 }

--- a/pkg/utils/jwt.go
+++ b/pkg/utils/jwt.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/golang-jwt/jwt/v4"
 )
 
@@ -13,10 +15,6 @@ func GetStringFieldFromJWT(token string, field string) (string, error) {
 	jwtToken, _, err = parser.ParseUnverified(token, jwt.MapClaims{})
 	if err != nil {
 		return "", fmt.Errorf("failed to parse jwt")
-	}
-
-	if err != nil {
-		return "", err
 	}
 
 	claims, ok := jwtToken.Claims.(jwt.MapClaims)
@@ -35,4 +33,30 @@ func GetStringFieldFromJWT(token string, field string) (string, error) {
 	}
 
 	return claimString, nil
+}
+
+// GetUsernameFromJWT returns the username extracted from JWT token
+func GetUsernameFromJWT(token string) string {
+	var jwtToken *jwt.Token
+	var err error
+	parser := new(jwt.Parser)
+	jwtToken, _, err = parser.ParseUnverified(token, jwt.MapClaims{})
+	if err != nil {
+		return "anonymous"
+	}
+	claims, ok := jwtToken.Claims.(jwt.MapClaims)
+	if !ok {
+		return "anonymous"
+	}
+	claim, ok := claims["username"]
+	if !ok {
+		return "anonymous"
+	}
+	return claim.(string)
+}
+
+// GetContextNickname returns a nickname of a context
+func GetContextNickname(namespace, clusterNick, userNick string) string {
+	tokens := strings.SplitN(userNick, "/", 2)
+	return namespace + "/" + clusterNick + "/" + tokens[0]
 }

--- a/pkg/utils/jwt_test.go
+++ b/pkg/utils/jwt_test.go
@@ -52,3 +52,89 @@ func TestGetFieldFromJWT(t *testing.T) {
 		})
 	}
 }
+
+func TestGetUsernameFromJWT(t *testing.T) {
+	type testCase struct {
+		name  string
+		token string
+		want  string
+	}
+	tests := []testCase{
+		{
+			name:  "Get username",
+			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJyZWRoYXQuY29tIiwiZXhwIjoxMTIwODI4MzQ0LCJ1c2VybmFtZSI6InRlc3R1c2VyIn0.2uBp-c/dIUtipUsnT1J6zjkJNVlIE640ZbuCvWevWRQ",
+			want:  "testuser",
+		},
+		{
+			name:  "Get username when username field is missing",
+			token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjAsImV4cCI6MTcxNjY1MDA3MSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSJ9._CyJxncO4NBOH6a-Q_2oIVelCRZKJh9YiPBm4XEBZgI",
+			want:  "anonymous",
+		},
+		{
+			name:  "Invalid token",
+			token: "abcdefg",
+			want:  "anonymous",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetUsernameFromJWT(tt.token)
+			if got != tt.want {
+				t.Errorf("GetUsernameFromJWT() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TODO figure out this code and safely introduce sound error logic
+// These test got added when we moved the function out of login.go to reuse in remediation cmd
+// needs a careful revisit as to not break our flows
+func TestGetContextNickname(t *testing.T) {
+	type testCase struct {
+		name        string
+		namespace   string
+		clusterNick string
+		userNick    string
+		want        string
+	}
+	tests := []testCase{
+		{
+			name:        "GetContextNickname",
+			namespace:   "testNamespace",
+			clusterNick: "testClusterNick",
+			userNick:    "testUserNick",
+			want:        "testNamespace" + "/" + "testClusterNick" + "/" + "testUserNick",
+		},
+		{
+			name:        "GetContextNickname with empty userNick",
+			namespace:   "testNamespace",
+			clusterNick: "testClusterNick",
+			userNick:    "",
+			want:        "testNamespace" + "/" + "testClusterNick" + "/",
+		},
+		{
+			name:        "GetContextNickname with empty userNick and empty clusterNick",
+			namespace:   "testNamespace",
+			clusterNick: "",
+			userNick:    "",
+			want:        "testNamespace" + "/" + "/",
+		},
+		{
+			name:        "GetContextNickname with empty userNick and empty clusterNick and empty namespace",
+			namespace:   "",
+			clusterNick: "",
+			userNick:    "",
+			want:        "/" + "/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetContextNickname(tt.namespace, tt.clusterNick, tt.userNick)
+			if got != tt.want {
+				t.Errorf("GetContextNickname() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / Why we need it?
Adds commands to create and delete RBAC for CAD investigations.
This will enable CAD to access kube-api with per remediation scoped down permissions. 
These commands are only allowed for backplane roles which are configured to use remediations ( currently CAD and SREP, see https://gitlab.cee.redhat.com/service/backplane-api/-/merge_requests/378/diffs#c6d8d5258b671d72ca173652ee8826e678b71b62_10_14 )

To learn more about the remediation endpoint in backplane-api, see  https://gitlab.cee.redhat.com/service/backplane-api/-/merge_requests/378
### Which Jira/Github issue(s) does this PR fix?

https://issues.redhat.com/browse/OSD-25689

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [X] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [X] Ran unit tests locally
- [X] Validated the changes in a cluster
- [ ] Included documentation changes with PR
