### PR TITLE
Bump go version to 1.22.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # This is for CI test and should build on x86_64 environment
-FROM registry.access.redhat.com/ubi9/ubi:9.4-1214.1729773476 as base
+
+FROM registry.access.redhat.com/ubi9/ubi:9.4-947 as base
 
 ### Pre-install dependencies
 # These packages will end up in the final image
@@ -9,12 +10,16 @@ RUN yum --assumeyes install \
     && yum clean all;
 
 ### Build backplane-cli
-FROM registry.access.redhat.com/ubi9/ubi:9.4-1214.1729773476 as bp-cli-builder
+FROM registry.access.redhat.com/ubi9/ubi:9.4-947 as bp-cli-builder
 
 RUN yum install --assumeyes \
     make \
     git \
     go-toolset
+
+# This is a hack to install go1.22 version until ubi9 supports golang 1.22 
+RUN go install golang.org/dl/go1.22.7@latest
+RUN go env -w GOTOOLCHAIN=go1.22.7+auto
 
 ENV GOOS=linux GO111MODULE=on GOPROXY=https://proxy.golang.org 
 ENV GOBIN=/gobin GOPATH=/usr/src/go CGO_ENABLED=0
@@ -33,7 +38,7 @@ RUN cp ./ocm-backplane /out
 RUN chmod -R +x /out
 
 ### Build dependencies
-FROM registry.access.redhat.com/ubi9/ubi:9.4-1214.1729773476 as dep-builder
+FROM registry.access.redhat.com/ubi9/ubi:9.4-947 as dep-builder
 
 RUN yum install --assumeyes \
     jq \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/backplane-cli
 
-go 1.21
+go 1.22.7
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
### What type of PR is this?

feature
### What this PR does / Why we need it?
Bump go version to 1.22.7

**Note** :  ubi9/ubi image still not supporting golang 1.22 version and it may support in 9.5 version 

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_
https://issues.redhat.com/browse/OSD-24733 
### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [x] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
