### PR TITLE
Print cluster info aftger login

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ In this example, we will login to a cluster with id `123456abcdef` in production
   ```
   $ ocm backplane login <cluster> --service
   ```
+### Get Cluster information after login
+
+- Login to the target cluster via backplane and add --cluster-info flag
+ ```
+  $ ocm backplane cluster login <cluster> --cluster-info
+ ```
 
 ### Login to multiple clusters 
 

--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -48,6 +48,7 @@ var (
 		pd               string
 		defaultNamespace string
 		ohss             string
+		clusterInfo      bool
 	}
 
 	// loginType derive the login type based on flags and args
@@ -124,6 +125,11 @@ func init() {
 		"ohss",
 		"",
 		"Login using JIRA Id",
+	)
+	flags.BoolVar(
+		&args.clusterInfo,
+		"cluster-info",
+		false, "Print basic cluster information after login",
 	)
 
 }
@@ -204,6 +210,12 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 	logger.WithFields(logger.Fields{
 		"ID":   clusterID,
 		"Name": clusterName}).Infoln("Target cluster")
+
+	if args.clusterInfo {
+		if err := login.PrintClusterInfo(clusterID); err != nil {
+			return fmt.Errorf("failed to print cluster info: %v", err)
+		}
+	}
 
 	if globalOpts.Manager {
 		logger.WithField("Cluster ID", clusterID).Debugln("Finding managing cluster")

--- a/pkg/login/printClusterInfo.go
+++ b/pkg/login/printClusterInfo.go
@@ -1,0 +1,75 @@
+package login
+
+import (
+	"fmt"
+
+	"github.com/openshift/backplane-cli/pkg/ocm"
+	logger "github.com/sirupsen/logrus"
+)
+
+//displayClusterInfo retrieves and displays basic information about the target cluster.
+
+func PrintClusterInfo(clusterID string) error {
+	logger := logger.WithField("clusterID", clusterID)
+
+	// Retrieve cluster information
+	clusterInfo, err := ocm.DefaultOCMInterface.GetClusterInfoByID(clusterID)
+	if err != nil {
+		return fmt.Errorf("error retrieving cluster info: %w", err)
+	}
+
+	// Display cluster information
+	printClusterField("Cluster ID:", clusterInfo.ID())
+	printClusterField("Cluster Name:", clusterInfo.Name())
+	printClusterField("Cluster Status:", clusterInfo.State())
+	printClusterField("Cluster Region:", clusterInfo.Region().ID())
+	printClusterField("Cluster Provider:", clusterInfo.CloudProvider().ID())
+	printClusterField("Hypershift Enabled:", clusterInfo.Hypershift().Enabled())
+	printClusterField("Version:", clusterInfo.OpenshiftVersion())
+	GetLimitedSupportStatus(clusterID)
+	GetAccessProtectionStatus(clusterID)
+
+	logger.Info("Basic cluster information displayed.")
+	return nil
+}
+
+func GetAccessProtectionStatus(clusterID string) string {
+	ocmConnection, err := ocm.DefaultOCMInterface.SetupOCMConnection()
+	if err != nil {
+		logger.Error("Error setting up OCM connection: ", err)
+		return "Error setting up OCM connection: " + err.Error()
+	}
+	if ocmConnection != nil {
+		defer ocmConnection.Close()
+	}
+	enabled, err := ocm.DefaultOCMInterface.IsClusterAccessProtectionEnabled(ocmConnection, clusterID)
+	if err != nil {
+		fmt.Println("Error retrieving access protection status: ", err)
+		return "Error retrieving access protection status: " + err.Error()
+	}
+
+	accessProtectionStatus := "Disabled"
+	if enabled {
+		accessProtectionStatus = "Enabled"
+	}
+	fmt.Printf("%-25s %s\n", "Access Protection:", accessProtectionStatus)
+
+	return accessProtectionStatus
+}
+
+func GetLimitedSupportStatus(clusterID string) string {
+	clusterInfo, err := ocm.DefaultOCMInterface.GetClusterInfoByID(clusterID)
+	if err != nil {
+		return "Error retrieving cluster info: " + err.Error()
+	}
+	if clusterInfo.Status().LimitedSupportReasonCount() != 0 {
+		fmt.Printf("%-25s %s", "Limited Support Status: ", "Limited Support\n")
+	} else {
+		fmt.Printf("%-25s %s", "Limited Support Status: ", "Fully Supported\n")
+	}
+	return fmt.Sprintf("%d", clusterInfo.Status().LimitedSupportReasonCount())
+}
+
+func printClusterField(fieldName string, value interface{}) {
+	fmt.Printf("%-25s %v\n", fieldName, value)
+}

--- a/pkg/login/printClusterInfo_test.go
+++ b/pkg/login/printClusterInfo_test.go
@@ -1,0 +1,201 @@
+package login
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/backplane-cli/pkg/ocm"
+	ocmMock "github.com/openshift/backplane-cli/pkg/ocm/mocks"
+
+	ocmsdk "github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+var _ = Describe("PrintClusterInfo", func() {
+	var (
+		clusterID        string
+		buf              *bytes.Buffer
+		mockOcmInterface *ocmMock.MockOCMInterface
+		mockCtrl         *gomock.Controller
+		oldStdout        *os.File
+		r, w             *os.File
+		ocmConnection    *ocmsdk.Connection
+		clusterInfo      *cmv1.Cluster
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockOcmInterface = ocmMock.NewMockOCMInterface(mockCtrl)
+		ocmConnection = nil
+		ocm.DefaultOCMInterface = mockOcmInterface
+
+		clusterID = "test-cluster-id"
+		buf = new(bytes.Buffer)
+		log.SetOutput(buf)
+
+		// Redirect standard output to the buffer
+		oldStdout = os.Stdout
+		r, w, _ = os.Pipe()
+		os.Stdout = w
+	})
+
+	AfterEach(func() {
+		// Reset the ocm.DefaultOCMInterface to avoid side effects in other tests
+		ocm.DefaultOCMInterface = nil
+	})
+
+	Context("Cluster protection status", func() {
+		BeforeEach(func() {
+
+			clusterInfo, _ = cmv1.NewCluster().
+				ID(clusterID).
+				Name("Test Cluster").
+				CloudProvider(cmv1.NewCloudProvider().ID("aws")).
+				State(cmv1.ClusterState("ready")).
+				Region(cmv1.NewCloudRegion().ID("us-east-1")).
+				Hypershift(cmv1.NewHypershift().Enabled(false)).
+				OpenshiftVersion("4.14.8").
+				Status(cmv1.NewClusterStatus().LimitedSupportReasonCount(0)).
+				Build()
+
+			mockOcmInterface.EXPECT().GetClusterInfoByID(clusterID).Return(clusterInfo, nil).AnyTimes()
+			mockOcmInterface.EXPECT().SetupOCMConnection().Return(ocmConnection, nil).AnyTimes()
+		})
+
+		It("should print cluster information with access protection disabled", func() {
+			mockOcmInterface.EXPECT().IsClusterAccessProtectionEnabled(ocmConnection, clusterID).Return(false, nil).AnyTimes()
+
+			err := PrintClusterInfo(clusterID)
+			Expect(err).To(BeNil())
+
+			// Capture the output
+			w.Close()
+			os.Stdout = oldStdout
+			_, _ = buf.ReadFrom(r)
+
+			output := buf.String()
+			Expect(output).To(ContainSubstring(fmt.Sprintf("Cluster ID:               %s\n", clusterID)))
+			Expect(output).To(ContainSubstring("Cluster Name:             Test Cluster\n"))
+			Expect(output).To(ContainSubstring("Cluster Status:           ready\n"))
+			Expect(output).To(ContainSubstring("Cluster Region:           us-east-1\n"))
+			Expect(output).To(ContainSubstring("Cluster Provider:         aws\n"))
+			Expect(output).To(ContainSubstring("Hypershift Enabled:       false\n"))
+			Expect(output).To(ContainSubstring("Version:                  4.14.8\n"))
+			Expect(output).To(ContainSubstring("Limited Support Status:   Fully Supported\n"))
+			Expect(output).To(ContainSubstring("Access Protection:        Disabled\n"))
+		})
+
+		It("should print cluster information with access protection enabled", func() {
+			mockOcmInterface.EXPECT().IsClusterAccessProtectionEnabled(ocmConnection, clusterID).Return(true, nil).AnyTimes()
+
+			err := PrintClusterInfo(clusterID)
+			Expect(err).To(BeNil())
+
+			// Capture the output
+			w.Close()
+			os.Stdout = oldStdout
+			_, _ = buf.ReadFrom(r)
+
+			output := buf.String()
+			Expect(output).To(ContainSubstring(fmt.Sprintf("Cluster ID:               %s\n", clusterID)))
+			Expect(output).To(ContainSubstring("Cluster Name:             Test Cluster\n"))
+			Expect(output).To(ContainSubstring("Cluster Status:           ready\n"))
+			Expect(output).To(ContainSubstring("Cluster Region:           us-east-1\n"))
+			Expect(output).To(ContainSubstring("Cluster Provider:         aws\n"))
+			Expect(output).To(ContainSubstring("Hypershift Enabled:       false\n"))
+			Expect(output).To(ContainSubstring("Version:                  4.14.8\n"))
+			Expect(output).To(ContainSubstring("Limited Support Status:   Fully Supported\n"))
+			Expect(output).To(ContainSubstring("Access Protection:        Enabled\n"))
+		})
+	})
+
+	Context("Limited Support set to 0", func() {
+		BeforeEach(func() {
+
+			clusterInfo, _ = cmv1.NewCluster().
+				ID(clusterID).
+				Name("Test Cluster").
+				CloudProvider(cmv1.NewCloudProvider().ID("aws")).
+				State(cmv1.ClusterState("ready")).
+				Region(cmv1.NewCloudRegion().ID("us-east-1")).
+				Hypershift(cmv1.NewHypershift().Enabled(false)).
+				OpenshiftVersion("4.14.8").
+				Status(cmv1.NewClusterStatus().LimitedSupportReasonCount(0)).
+				Build()
+
+			mockOcmInterface.EXPECT().GetClusterInfoByID(clusterID).Return(clusterInfo, nil).AnyTimes()
+			mockOcmInterface.EXPECT().SetupOCMConnection().Return(ocmConnection, nil).AnyTimes()
+		})
+
+		It("should print if cluster is Fully Supported", func() {
+
+			mockOcmInterface.EXPECT().IsClusterAccessProtectionEnabled(ocmConnection, clusterID).Return(true, nil).AnyTimes()
+
+			err := PrintClusterInfo(clusterID)
+			Expect(err).To(BeNil())
+
+			// Capture the output
+			w.Close()
+			os.Stdout = oldStdout
+			_, _ = buf.ReadFrom(r)
+
+			output := buf.String()
+			Expect(output).To(ContainSubstring(fmt.Sprintf("Cluster ID:               %s\n", clusterID)))
+			Expect(output).To(ContainSubstring("Cluster Name:             Test Cluster\n"))
+			Expect(output).To(ContainSubstring("Cluster Status:           ready\n"))
+			Expect(output).To(ContainSubstring("Cluster Region:           us-east-1\n"))
+			Expect(output).To(ContainSubstring("Cluster Provider:         aws\n"))
+			Expect(output).To(ContainSubstring("Hypershift Enabled:       false\n"))
+			Expect(output).To(ContainSubstring("Version:                  4.14.8\n"))
+			Expect(output).To(ContainSubstring("Limited Support Status:   Fully Supported\n"))
+			Expect(output).To(ContainSubstring("Access Protection:        Enabled\n"))
+		})
+
+	})
+
+	Context("Limited Support set to 1", func() {
+		BeforeEach(func() {
+
+			clusterInfo, _ = cmv1.NewCluster().
+				ID(clusterID).
+				Name("Test Cluster").
+				CloudProvider(cmv1.NewCloudProvider().ID("aws")).
+				State(cmv1.ClusterState("ready")).
+				Region(cmv1.NewCloudRegion().ID("us-east-1")).
+				Hypershift(cmv1.NewHypershift().Enabled(false)).
+				OpenshiftVersion("4.14.8").
+				Status(cmv1.NewClusterStatus().LimitedSupportReasonCount(1)).
+				Build()
+
+			mockOcmInterface.EXPECT().GetClusterInfoByID(clusterID).Return(clusterInfo, nil).AnyTimes()
+			mockOcmInterface.EXPECT().SetupOCMConnection().Return(ocmConnection, nil).AnyTimes()
+		})
+
+		It("should print if cluster is Limited Support", func() {
+			mockOcmInterface.EXPECT().IsClusterAccessProtectionEnabled(ocmConnection, clusterID).Return(true, nil).AnyTimes()
+			err := PrintClusterInfo(clusterID)
+			Expect(err).To(BeNil())
+
+			// Capture the output
+			w.Close()
+			os.Stdout = oldStdout
+			_, _ = buf.ReadFrom(r)
+
+			output := buf.String()
+			Expect(output).To(ContainSubstring(fmt.Sprintf("Cluster ID:               %s\n", clusterID)))
+			Expect(output).To(ContainSubstring("Cluster Name:             Test Cluster\n"))
+			Expect(output).To(ContainSubstring("Cluster Status:           ready\n"))
+			Expect(output).To(ContainSubstring("Cluster Region:           us-east-1\n"))
+			Expect(output).To(ContainSubstring("Cluster Provider:         aws\n"))
+			Expect(output).To(ContainSubstring("Hypershift Enabled:       false\n"))
+			Expect(output).To(ContainSubstring("Version:                  4.14.8\n"))
+			Expect(output).To(ContainSubstring("Limited Support Status:   Limited Support\n"))
+			Expect(output).To(ContainSubstring("Access Protection:        Enabled\n"))
+		})
+	})
+})


### PR DESCRIPTION
### What type of PR is this?

feature to print cluster info after backplain login into a cluster

### What this PR does / Why we need it?

Helps to get basic info while troubleshooting 



### Which Jira/Github issue(s) does this PR fix?

(https://issues.redhat.com/browse/OSD-25315)

### Special notes for your reviewer

There a couple of things to mention:

1. It covers 49.7 % of code but fails when `PrintAccessProtectionStatus(clusterID)` is called as its required to mock ocmConnection

` Unexpected call to *mocks.MockOCMInterface.SetupOCMConnection([]) at /home/ydiakov/cards/osd-25315/attem_4/backplane-cli/pkg/login/printClusterInfoAfterLogin.go:40 because: there are no expected calls of the method "SetupOCMConnection" for that receiver`



### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
