### PR TITLE
Print cluster info by setting a flag in backplane config file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,13 +108,21 @@ In this example, we will login to a cluster with id `123456abcdef` in production
   ```
   $ ocm backplane login <cluster> --service
   ```
-### Get Cluster information after login
+### Get cluster information after login
 
-- Login to the target cluster via backplane and add --cluster-info flag
+- Login to the target cluster via backplane and add `--cluster-info` flag
  ```
   $ ocm backplane cluster login <cluster> --cluster-info
  ```
-
+- Set a `"display-cluster-info": true` flag in the backplane config for cluster info to be auto printed. 
+ > Note: `"display-cluster-info": true` has to be set as a `boolean` value.
+  
+ ```
+  {
+    "proxy-url": "your-proxy-url",
+    "display-cluster-info": true
+  }
+ ```
 ### Login to multiple clusters 
 
 Logging into multiple clusters via different terminal instances.

--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -217,6 +217,12 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 		}
 	}
 
+	if bpConfig.DisplayClusterInfo {
+		if err := login.PrintClusterInfo(clusterID); err != nil {
+			return fmt.Errorf("failed to print cluster info: %v", err)
+		}
+	}
+
 	if globalOpts.Manager {
 		logger.WithField("Cluster ID", clusterID).Debugln("Finding managing cluster")
 		var isHostedControlPlane bool

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -42,6 +42,7 @@ type BackplaneConfiguration struct {
 	JiraConfigForAccessRequests AccessRequestsJiraConfiguration `json:"jira-config-for-access-requests"`
 	VPNCheckEndpoint            string                          `json:"vpn-check-endpoint"`
 	ProxyCheckEndpoint          string                          `json:"proxy-check-endpoint"`
+	DisplayClusterInfo          bool                            `json:"display-cluster-info"`
 }
 
 const (
@@ -150,6 +151,7 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 
 	bpConfig.SessionDirectory = viper.GetString("session-dir")
 	bpConfig.AssumeInitialArn = viper.GetString("assume-initial-arn")
+	bpConfig.DisplayClusterInfo = viper.GetBool("display-cluster-info")
 
 	// pagerDuty token is optional
 	pagerDutyAPIKey := viper.GetString("pd-key")

--- a/pkg/cli/config/config_test.go
+++ b/pkg/cli/config/config_test.go
@@ -30,6 +30,26 @@ func TestGetBackplaneConfig(t *testing.T) {
 			t.Errorf("expected to return the explicitly defined proxy %v instead of the default one %v", userDefinedProxy, config.ProxyURL)
 		}
 	})
+
+	t.Run("display cluster info is true", func(t *testing.T) {
+		viper.Set("display-cluster-info", true)
+		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("dummy data"))
+		}))
+
+		userDefinedProxy := "example-proxy"
+		t.Setenv("BACKPLANE_URL", svr.URL)
+		t.Setenv("HTTPS_PROXY", userDefinedProxy)
+		config, err := GetBackplaneConfiguration()
+		if err != nil {
+			t.Error(err)
+		}
+
+		if !config.DisplayClusterInfo {
+			t.Errorf("expected DisplayClusterInfo to be true, got %v", config.DisplayClusterInfo)
+		}
+	})
+
 }
 
 func TestGetBackplaneConnection(t *testing.T) {


### PR DESCRIPTION
### What type of PR is this?

This is an addition to https://github.com/openshift/backplane-cli/pull/561


This PR adds an ability to add a flag in the backplane config and the cluster info will be printed automatically every time without a need to set `--cluster-into` each time

Example
`
{
    "proxy-url": ["http://squid.corp.redhat.com:3128/","http://proxy2.squi-001.prod.rdu2.dc.redhat.com:3128/"],
    "display-cluster-info": true
}
`

### Which Jira/Github issue(s) does this PR fix?

[_Resolves #_
](https://issues.redhat.com/browse/OSD-25315)


