### PR TITLE
[OSD-25707] feat: print api error message

### DIFF
--- a/cmd/ocm-backplane/cloud/common.go
+++ b/cmd/ocm-backplane/cloud/common.go
@@ -265,7 +265,7 @@ func (cfg *QueryConfig) getIsolatedCredentials(ocmToken string) (aws.Credentials
 		return aws.Credentials{}, fmt.Errorf("failed to fetch arn sequence: %w", err)
 	}
 	if response.StatusCode != http.StatusOK {
-		return aws.Credentials{}, fmt.Errorf("failed to fetch arn sequence: %v", response.Status)
+		return aws.Credentials{}, fmt.Errorf("failed to fetch arn sequence: %w", utils.TryPrintAPIError(response, false))
 	}
 
 	bytes, err := io.ReadAll(response.Body)


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / Why we need it?

This PR improves the user experience when accessing the cloud console by displaying the returned error message. This enhancement benefits all users, **including those attempting to access lockbox-protected clusters**, by providing clearer error message.

The current error message looks to be sufficiently descriptive, but if adjustments are needed, I recommend updating the error message directly in the [Backplane API](https://gitlab.cee.redhat.com/service/backplane-api/-/blob/master/pkg/auth/authz.go?ref_type=heads#L269-274) for better long-term maintainability.

**Before this PR:**

```
$ ocm-backplane cloud console -b 2f75gfh5sebi2tho8j0pt22lr29ul83v
ERRO[0004] failed to get cloud console for cluster 2f75gfh5sebi2tho8j0pt22lr29ul83v: failed to assume role with isolated backplane flow: failed to fetch arn sequence: 403 Forbidden
```

**After this PR:**

```
$ ocm-backplane cloud console -b 2f75gfh5sebi2tho8j0pt22lr29ul83v
ERRO[0005] failed to get cloud console for cluster 2f75gfh5sebi2tho8j0pt22lr29ul83v: failed to assume role with isolated backplane flow: failed to fetch arn sequence: error from backplane: 
 Status Code: 403
 Message: no pending or approved access request:
consider running the following command to create one:
ocm-backplane accessrequest create 
```

### Which Jira/Github issue(s) does this PR fix?

Resolves [OSD-25707](https://issues.redhat.com/browse/OSD-25707)

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [X] This PR may not need unit tests

### Pre-checks (if applicable)
- [X] Ran unit tests locally
- [X] Validated the changes in a cluster
- [ ] Included documentation changes with PR
