### PR TITLE
OSD-27228: Modify tests so that they pass on macOS, fix issue with leaking file

### DIFF
--- a/pkg/elevate/elevate.go
+++ b/pkg/elevate/elevate.go
@@ -66,8 +66,8 @@ func RunElevate(argv []string) error {
 		return err
 	}
 
-	// As WriteKubeconfigToFile is also creating a tempory file reference by new KUBECONFIG variable setting,
-	// we need to take care of its cleanup
+	// As WriteKubeconfigToFile is also creating a temporary file referenced by new KUBECONFIG variable setting,
+	// we need to take care of it's cleanup
 	tempKubeconfigPath, _ := os.LookupEnv("KUBECONFIG")
 	defer func() {
 		logger.Debugln("Cleaning up temporary kubeconfig", tempKubeconfigPath)

--- a/pkg/elevate/elevate_test.go
+++ b/pkg/elevate/elevate_test.go
@@ -39,9 +39,7 @@ var fakeAPIConfig = api.Config{
 		},
 	},
 	AuthInfos: map[string]*api.AuthInfo{
-		"anonymous": {
-			LocationOfOrigin: "England",
-		},
+		"anonymous": {},
 	},
 	Contexts: map[string]*api.Context{
 		"default/test123/anonymous": {
@@ -115,9 +113,16 @@ func TestAddElevationReasonToRawKubeconfig(t *testing.T) {
 }
 
 func TestRunElevate(t *testing.T) {
-	// We do ot want to realy override any config files or remove them
+	// TODO: Utilize a fake filesystem for tests and stop relying on local system state
+	tmpDir, err := os.MkdirTemp("", "backplane-cli-tests")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
 
-	OsRemove = func(name string) error { return nil }
+	// We utilize the fact that elevate honors KUBECONFIG in order to not clobber the users real ~/.kube/config
+	kubeconfigPath := tmpDir + "config"
+	_ = os.Setenv("KUBECONFIG", kubeconfigPath)
 
 	t.Run("It returns an error if we cannot load the kubeconfig", func(t *testing.T) {
 		ExecCmd = exec.Command


### PR DESCRIPTION
### What type of PR is this?

_bug,cleanup_

### What this PR does / Why we need it?

I wanted to resolve a bug but was unable to even run the tests for this project on main from my macOS system. This does a few things to fix that:

- Update the assertions for what type of containerEngine you get in the `console` command to work across different runtimes
- Resolves an issue where we would leak a kubeconfig file in `pkg/elevate` because we were relying on the default behavior where a kubeconfig is written to the value of `LocationOfOrigin`

There are a lot of other things I noticed while in here that I would like to cleanup to make testing both easier to reason about, and rely less on local state. We should be using a mock filesystem, for example, and not actually modifying any local state (or relying on it).

Additionally, I removed some tests from `console` that were essentially testing the same behavior, ie a bad container engine passed.

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer

I ran `ocm-backplane console` with this locally to confirm all still works. I fundamentally only touched tests.

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [x] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
