### PR TITLE
[WIP] adding --replace flag to restart webconsole pod

### DIFF
--- a/cmd/ocm-backplane/main.go
+++ b/cmd/ocm-backplane/main.go
@@ -1,21 +1,21 @@
 package main
 
-/*
-Copyright © 2020 Red Hat, Inc.
+import (
+	"fmt"
+	"os"
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+	"github.com/openshift/backplane-cli/cmd/ocm-backplane/console"
+	logger "github.com/sirupsen/logrus"
+)
 
 func main() {
-	Execute()
+	// Set the logging level to Debug
+	logger.SetLevel(logger.DebugLevel)
+
+	// Your existing initialization code
+	rootCmd := console.NewConsoleCmd()
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
### What type of PR is this?

Feature

### What this PR does / Why we need it?

Addresses the issue with the web console pod failing to start if it is already running in a different terminal session

### Which Jira/Github issue(s) does this PR fix?

https://issues.redhat.com/browse/OSD-23459


Implemented as suggested in https://redhat-internal.slack.com/archives/C016S65RNG5/p1715785884588929


### Unit Test Coverage

Before writing the unit test, I would like to see if the functionality fits the purpose 

