### PR TITLE
OSD-27703: fix: Improve output for service and manager flags in login command

### DIFF
--- a/cmd/ocm-backplane/login/login_test.go
+++ b/cmd/ocm-backplane/login/login_test.go
@@ -385,6 +385,7 @@ var _ = Describe("Login command", func() {
 			globalOpts.Service = true
 			mockOcmInterface.EXPECT().GetOCMEnvironment().Return(ocmEnv, nil).AnyTimes()
 			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(trueClusterID, testClusterID, nil)
+			mockOcmInterface.EXPECT().GetManagingCluster(trueClusterID).Return(managingClusterID, managingClusterID, true, nil).AnyTimes() // isHostedControlPlane = true
 			mockOcmInterface.EXPECT().GetServiceCluster(trueClusterID).Return(serviceClusterID, serviceClusterName, nil)
 			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(serviceClusterID)).Return(false, nil).AnyTimes()
 			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil)


### PR DESCRIPTION
### What type of PR is this?

_feature_

### What this PR does / Why we need it?

### Which Jira/Github issue(s) does this PR fix?

- The PR improves the output message for service and manager flags for the login command. It provides user to directly export the related variables. For service flag, there was no output related to the namespace or manifestwork which has been added now

- The error message for login has been updated to clarify either management cluster or hive shard accordingly

Output
```
❯ go run ./cmd/ocm-backplane login $ID --service
A list of associated manifestwork for your given cluster can be found using:
	 oc get manifestworks -n <> -l api.openshift.com/id=$ID

The MC Namespace for the cluster can be exported using:
	export MC_NAME=<>

❯ go run ./cmd/ocm-backplane login $ID --manager
Execute the following command to export the list of associated namespaces for your given cluster
	export HIVE_NS=uhc-production-$ID

```
Note - I have hidden actual IDs from the output

_Resolves [OSD-27703](https://issues.redhat.com//browse/OSD-27703)_

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
