### PR TITLE
Fix remediation commands

### DIFF
--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -131,7 +131,6 @@ func init() {
 		"cluster-info",
 		false, "Print basic cluster information after login",
 	)
-	flags.StringVar(&args.remediation, "remediation", "", "The name of the remediation for which RBAC should get created")
 }
 
 // TODO there is something about the proxy config in relation to overriding with --url

--- a/cmd/ocm-backplane/remediation/remediation.go
+++ b/cmd/ocm-backplane/remediation/remediation.go
@@ -103,10 +103,7 @@ func runCreateRemediation(args []string, clusterKey string, urlFlag string) erro
 		return err
 	}
 
-	bpURL := globalOpts.BackplaneURL
-	if bpURL == "" {
-		bpURL = bpConfig.URL
-	}
+	bpURL := bpConfig.URL
 
 	clusterID := bpCluster.ClusterID
 
@@ -212,10 +209,7 @@ func runDeleteRemediation(args []string, clusterKey string, urlFlag string) erro
 		return err
 	}
 
-	bpURL := globalOpts.BackplaneURL
-	if bpURL == "" {
-		bpURL = bpConfig.URL
-	}
+	bpURL := bpConfig.URL
 
 	clusterID := bpCluster.ClusterID
 

--- a/cmd/ocm-backplane/remediation/remediation.go
+++ b/cmd/ocm-backplane/remediation/remediation.go
@@ -103,12 +103,15 @@ func runCreateRemediation(args []string, clusterKey string, urlFlag string) erro
 		return err
 	}
 
-	backplaneHost := bpConfig.URL
+	bpURL := globalOpts.BackplaneURL
+	if bpURL == "" {
+		bpURL = bpConfig.URL
+	}
 
 	clusterID := bpCluster.ClusterID
 
 	if urlFlag != "" {
-		backplaneHost = urlFlag
+		bpURL = urlFlag
 	}
 
 	// ======== Parsing Args ========
@@ -121,7 +124,23 @@ func runCreateRemediation(args []string, clusterKey string, urlFlag string) erro
 	if err != nil {
 		return err
 	}
-	proxyURI, err := remediation.DoCreateRemediation(backplaneHost, clusterID, *accessToken, remediationName)
+	// Add proxy URL to target cluster
+	proxyURL := globalOpts.ProxyURL
+	if proxyURL != "" {
+		err = backplaneapi.DefaultClientUtils.SetClientProxyURL(proxyURL)
+
+		if err != nil {
+			return err
+		}
+		logger.Debugf("Using backplane Proxy URL: %s\n", proxyURL)
+	}
+
+	if bpConfig.ProxyURL != nil {
+		proxyURL = *bpConfig.ProxyURL
+		logger.Debugln("backplane configuration file also contains a proxy url, using that one instead")
+		logger.Debugf("New backplane Proxy URL: %s\n", proxyURL)
+	}
+	proxyURI, err := remediation.DoCreateRemediation(bpURL, clusterID, *accessToken, remediationName)
 	// ======== Render Results ========
 	if err != nil {
 		return err
@@ -140,23 +159,6 @@ func runCreateRemediation(args []string, clusterKey string, urlFlag string) erro
 	targetContext := api.NewContext()
 
 	targetCluster.Server = proxyURI
-
-	// Add proxy URL to target cluster
-	proxyURL := globalOpts.ProxyURL
-	if proxyURL != "" {
-		err = backplaneapi.DefaultClientUtils.SetClientProxyURL(proxyURL)
-
-		if err != nil {
-			return err
-		}
-		logger.Debugf("Using backplane Proxy URL: %s\n", proxyURL)
-	}
-
-	if bpConfig.ProxyURL != nil {
-		proxyURL = *bpConfig.ProxyURL
-		logger.Debugln("backplane configuration file also contains a proxy url, using that one instead")
-		logger.Debugf("New backplane Proxy URL: %s\n", proxyURL)
-	}
 
 	logger.Debugln("Extracting target cluster ID and name")
 	clusterID, clusterName, err := ocm.DefaultOCMInterface.GetTargetCluster(clusterKey)
@@ -210,12 +212,15 @@ func runDeleteRemediation(args []string, clusterKey string, urlFlag string) erro
 		return err
 	}
 
-	backplaneHost := bpConfig.URL
+	bpURL := globalOpts.BackplaneURL
+	if bpURL == "" {
+		bpURL = bpConfig.URL
+	}
 
 	clusterID := bpCluster.ClusterID
 
 	if urlFlag != "" {
-		backplaneHost = urlFlag
+		bpURL = urlFlag
 	}
 
 	// ======== Parsing Args ========
@@ -228,8 +233,25 @@ func runDeleteRemediation(args []string, clusterKey string, urlFlag string) erro
 	if err != nil {
 		return err
 	}
+
+	// Add proxy URL to target cluster
+	proxyURL := globalOpts.ProxyURL
+	if proxyURL != "" {
+		err = backplaneapi.DefaultClientUtils.SetClientProxyURL(proxyURL)
+
+		if err != nil {
+			return err
+		}
+		logger.Debugf("Using backplane Proxy URL: %s\n", proxyURL)
+	}
+
+	if bpConfig.ProxyURL != nil {
+		proxyURL = *bpConfig.ProxyURL
+		logger.Debugln("backplane configuration file also contains a proxy url, using that one instead")
+		logger.Debugf("New backplane Proxy URL: %s\n", proxyURL)
+	}
 	// ======== Call Endpoint ========
-	err = remediation.DoDeleteRemediation(backplaneHost, clusterID, *accessToken, remediationSA)
+	err = remediation.DoDeleteRemediation(bpURL, clusterID, *accessToken, remediationSA)
 	// ======== Render Results ========
 	if err != nil {
 		return err


### PR DESCRIPTION
### What type of PR is this?

bug/cleanup, these new commands did not work before.
They were being tested and developed in parallel to backplane-apis remediation feature, which was subject to change.

The backplane feature is now live, so with these commands its possible to create and delete a "remediation" on a cluster.
For more on remediations see https://gitlab.cee.redhat.com/service/backplane-api#remediations

### What this PR does / Why we need it?

makes the remediation create and delete command work 

### Which Jira/Github issue(s) does this PR fix?
https://issues.redhat.com/browse/OSD-27272

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [X] Added unit tests
- [ ] Created jira card to add unit test
- [X] This PR may not need unit tests

### Pre-checks (if applicable)
- [X] Ran unit tests locally
- [X] Validated the changes in a cluster
- [ ] Included documentation changes with PR
