### PR TITLE
Convert integration HCP namesapce

### DIFF
--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -555,6 +555,10 @@ func listNamespaces(clusterID string, isHostedControlPlane bool) (map[string]str
 	}
 	envName := env.Name()
 
+	if envName == "integration" {
+		envName = "int"
+	}
+
 	clusterInfo, err := ocm.DefaultOCMInterface.GetClusterInfoByID(clusterID)
 	if err != nil {
 		return map[string]string{}, err


### PR DESCRIPTION
### What type of PR is this?

_(bug)_

### What this PR does / Why we need it?

context: https://redhat-internal.slack.com/archives/C0326L38PEH/p1739149657084669

- For reviewer:
```
./ocm-backplane login 2grfffik8udbvmnbckil30kd7koovam2 --manager

Execute the following command to export the list of associated namespaces for your given cluster
	export HCP_NAMESPACE=ocm-int-2grfffik8udbvmnbckil30kd7koovam2-danintdt
	export KLUSTERLET_NS=klusterlet-2grfffik8udbvmnbckil30kd7koovam2
	export HC_NAMESPACE=ocm-int-2grfffik8udbvmnbckil30kd7koovam2
```

- The corresponding cluster service code snippet [here](https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/blob/master/cmd/clusters-service/service/cluster_deployment_name_calculator.go#L35-39)