### PR TITLE
adds notsecret flag to hopefully stop false positives

### DIFF
--- a/pkg/utils/jwt_test.go
+++ b/pkg/utils/jwt_test.go
@@ -15,25 +15,25 @@ func TestGetFieldFromJWT(t *testing.T) {
 	tests := []testCase{
 		{
 			name:  "Get string field",
-			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c", // notsecret
 			field: "sub",
 			want:  "1234567890",
 		},
 		{
 			name:    "Get number field",
-			token:   "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjAsImV4cCI6MTcxNjY1MDA3MSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSJ9._CyJxncO4NBOH6a-Q_2oIVelCRZKJh9YiPBm4XEBZgI",
+			token:   "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjAsImV4cCI6MTcxNjY1MDA3MSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSJ9._CyJxncO4NBOH6a-Q_2oIVelCRZKJh9YiPBm4XEBZgI", // notsecret
 			field:   "iat",
 			wantErr: true,
 		},
 		{
 			name:    "Get field that doesn't exist",
-			token:   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+			token:   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c", // notsecret
 			field:   "foo",
 			wantErr: true,
 		},
 		{
 			name:    "Invalid token",
-			token:   "abcdefg",
+			token:   "abcdefg", // notsecret
 			field:   "foo",
 			wantErr: true,
 		},
@@ -62,17 +62,17 @@ func TestGetUsernameFromJWT(t *testing.T) {
 	tests := []testCase{
 		{
 			name:  "Get username",
-			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJyZWRoYXQuY29tIiwiZXhwIjoxMTIwODI4MzQ0LCJ1c2VybmFtZSI6InRlc3R1c2VyIn0.2uBp-c/dIUtipUsnT1J6zjkJNVlIE640ZbuCvWevWRQ",
+			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJyZWRoYXQuY29tIiwiZXhwIjoxMTIwODI4MzQ0LCJ1c2VybmFtZSI6InRlc3R1c2VyIn0.2uBp-c/dIUtipUsnT1J6zjkJNVlIE640ZbuCvWevWRQ", // notsecret
 			want:  "testuser",
 		},
 		{
 			name:  "Get username when username field is missing",
-			token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjAsImV4cCI6MTcxNjY1MDA3MSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSJ9._CyJxncO4NBOH6a-Q_2oIVelCRZKJh9YiPBm4XEBZgI",
+			token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjAsImV4cCI6MTcxNjY1MDA3MSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSJ9._CyJxncO4NBOH6a-Q_2oIVelCRZKJh9YiPBm4XEBZgI", // notsecret
 			want:  "anonymous",
 		},
 		{
 			name:  "Invalid token",
-			token: "abcdefg",
+			token: "abcdefg", // notsecret
 			want:  "anonymous",
 		},
 	}


### PR DESCRIPTION
### What type of PR is this?

_(bug/feature/cleanup/documentation/unit-test)_

cleanup

### What this PR does / Why we need it?

When I pulled the latest from upstream and pushed to my fork, I got an email from infosec about a potential breach. Once I confirmed that these are all test data and there's no actual secret information in these JWTs, I added the comment to ensure that these are hopefully ignored by the test screeners so that they don't flag as false-positives again.

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
