### PR TITLE
Adds check for additional backplane users at login

### DIFF
--- a/pkg/login/additional_login_detector.go
+++ b/pkg/login/additional_login_detector.go
@@ -1,0 +1,176 @@
+package login
+
+// Functions in this file are built to detect additional backplane logins on the same cluster, in order to inform
+// the user who is logging in if other roles may be currently logged in or have logged in recently.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+
+	logger "github.com/sirupsen/logrus"
+
+	authenticationapi "k8s.io/api/authentication/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	BackplaneUserNamespacePrefix = "openshift-backplane-"
+	CEE                          = "cee"
+	McsTierTwo                   = "mcs-tier-two"
+	LPSRE                        = "lpsre"
+	SREP                         = "srep"
+)
+
+var backplaneUserNamespacesToCheck []string = []string{
+	CEE,
+	McsTierTwo,
+	LPSRE,
+	SREP,
+}
+
+func FindOtherSessions(clientset kubernetes.Interface, config *rest.Config) (map[string]int, error) {
+	sessions := map[string]int{}
+
+	token, err := getTokenFromConfig(config)
+	if err != nil {
+		logger.Error("Unable to get token for self review to find other sessions")
+		return sessions, err
+	}
+
+	myUsername, err := whoami(clientset, token)
+	if err != nil {
+		logger.Error("Unable to determine who I am to find other sessions")
+		return sessions, err
+	}
+
+	myNS, myUser, err := splitServiceAccountUserString(myUsername)
+	if err != nil {
+		return sessions, err
+	}
+
+	for _, role := range backplaneUserNamespacesToCheck {
+		ns := BackplaneUserNamespacePrefix + role
+		saList, err := clientset.CoreV1().ServiceAccounts(ns).List(context.TODO(), metav1.ListOptions{
+			LabelSelector: "managed.openshift.io/backplane=true",
+		})
+		if err != nil {
+			logger.Warnf("Unable to list %s ServiceAccounts", role)
+		}
+		logger.Debugf("Found %d service accounts for %s: %+v", len(saList.Items), role, saList)
+
+		count := len(saList.Items)
+		// Remove me from the count if I'm already logged in
+		if ns == myNS {
+			found := false
+			for _, sa := range saList.Items {
+				if sa.Name == myUser {
+					found = true
+					break
+				}
+			}
+			if found {
+				count = count - 1
+			}
+		}
+
+		if count > 0 {
+			sessions[role] = count
+		}
+	}
+
+	return sessions, nil
+}
+
+func PrintSessions(w io.Writer, sessions map[string]int) {
+	if len(sessions) == 0 {
+		fmt.Fprintf(w, "There are no other backplane users logged in.\n")
+		return
+	}
+
+	fmt.Fprintf(w, "Checking for other backplane sessions:\n")
+	for sessionRole, sessionCount := range sessions {
+		fmt.Fprintf(w, "  - There are %d users logged in under the %s role.\n", sessionCount, sessionRole)
+	}
+}
+
+// Given a standard user account in a format similar to `system:serviceaccount:namespace:username`,
+// return the namespace and username and any potential error
+func splitServiceAccountUserString(user string) (string, string, error) {
+	userSlice := strings.Split(user, ":")
+	// meSlice should always be something like
+	// system, serviceaccount, openshift-backplane-role-name, username
+	if len(userSlice) < 4 {
+		return "", "", fmt.Errorf("error splitting user string. Could not parse %s", user)
+	}
+	myNS := userSlice[2]
+	myUser := userSlice[3]
+
+	logger.Debugf("I am %s:%s", myNS, myUser)
+
+	return myNS, myUser, nil
+}
+
+// Get the username of the current context from a valid authentication token
+func whoami(kubeclient kubernetes.Interface, token string) (string, error) {
+	result, err := kubeclient.AuthenticationV1().TokenReviews().Create(context.TODO(), &authenticationapi.TokenReview{
+		Spec: authenticationapi.TokenReviewSpec{
+			Token: token,
+		},
+	}, metav1.CreateOptions{})
+
+	if err != nil {
+		if k8serrors.IsForbidden(err) {
+			return getUsernameFromError(err)
+		}
+		return "", err
+	}
+
+	if result.Status.Error != "" {
+		return "", fmt.Errorf("unexpected status error from TokenReview: %v", result.Status.Error)
+	}
+
+	return result.Status.User.Username, nil
+}
+
+// Given a valid REST Config object, extract the token
+func getTokenFromConfig(config *rest.Config) (string, error) {
+	c, err := config.TransportConfig()
+	if err != nil {
+		return "", err
+	}
+
+	if c.HasTokenAuth() {
+		if config.BearerTokenFile != "" {
+			d, err := os.ReadFile(config.BearerTokenFile)
+			if err != nil {
+				return "", err
+			}
+			return string(d), nil
+		}
+
+		if config.BearerToken != "" {
+			return config.BearerToken, nil
+		}
+	}
+	return "", nil
+}
+
+// if we get a permissions error, it will tell us the username as part of the error string
+// so we can grab the username from that error string
+func getUsernameFromError(err error) (string, error) {
+	re := regexp.MustCompile(`^.* User "(.*)" cannot .*$`)
+	user := re.ReplaceAllString(err.Error(), "$1")
+	// if the user string after replacement equals the same string as the whole error, nothing
+	// was replaced and we should return an error here.
+	if user == err.Error() {
+		return "", fmt.Errorf("could not extract username from error string: %v", err)
+	}
+	return user, nil
+}

--- a/pkg/login/additional_login_detector_test.go
+++ b/pkg/login/additional_login_detector_test.go
@@ -1,0 +1,250 @@
+package login
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	authv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	ctest "k8s.io/client-go/testing"
+)
+
+var successfulTokenReviewResponse *authv1.TokenReview = &authv1.TokenReview{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "TokenReview",
+		APIVersion: "authentication.k8s.io/v1",
+	},
+	Status: authv1.TokenReviewStatus{
+		Authenticated: true,
+		Audiences:     []string{"ServiceAudience"},
+		User:          authv1.UserInfo{Username: "system:serviceaccount:openshift-backplane-srep:sre000"},
+	},
+}
+
+var _ = Describe("AdditionalLoginDetector", func() {
+	Describe("Validates printing logic", func() {
+		It("Prints that there is no users when an empty session map is provided", func() {
+			sessions := map[string]int{}
+			var output bytes.Buffer
+
+			PrintSessions(&output, sessions)
+			Expect(output.String()).Should(ContainSubstring("no other"))
+		})
+		It("Prints the roles correctly", func() {
+			var output bytes.Buffer
+			sessions := map[string]int{
+				"role_one":    2,
+				"anotherRole": 5,
+			}
+
+			PrintSessions(&output, sessions)
+			Expect(output.String()).Should(ContainSubstring("Checking for other"))
+			Expect(output.String()).Should(ContainSubstring("2 users logged in under the role_one"))
+			Expect(output.String()).Should(ContainSubstring("5 users logged in under the anotherRole"))
+		})
+	})
+
+	Describe("Validate service account user string splitting", func() {
+		It("Validates that an error is returned when a slice is too small", func() {
+			_, _, err := splitServiceAccountUserString("system:serviceaccount:myuser")
+			Expect(err).Should(HaveOccurred())
+		})
+
+		It("Validates that we return the correct namespace/user combo", func() {
+			ns, user, err := splitServiceAccountUserString("system:serviceaccount:myns:myuser")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ns).To(Equal("myns"))
+			Expect(user).To(Equal("myuser"))
+		})
+	})
+
+	Describe("Validate Username from Error", func() {
+		It("gets the username from a valid error message", func() {
+			providedErr := fmt.Errorf("Error: User \"system:serviceaccount:namespace:serviceaccountname\" cannot do the thing")
+			username, err := getUsernameFromError(providedErr)
+			Expect(username).To(Equal("system:serviceaccount:namespace:serviceaccountname"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("returns an error when the username cannot be parsed", func() {
+			providedErr := fmt.Errorf("Some Other Error")
+			username, err := getUsernameFromError(providedErr)
+
+			Expect(username).To(Equal(""))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("Validate Config Token Getter", func() {
+		It("gets a provided bearer token", func() {
+			cfg := &rest.Config{}
+			cfg.BearerToken = "abcdefg"
+
+			token, err := getTokenFromConfig(cfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(token).To(Equal("abcdefg"))
+		})
+
+		It("gets a provided bearer token from a file", func() {
+			// Create a temp dir and defer the cleanup of it
+			dir, err := os.MkdirTemp("", "testBearerToken")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(dir) // clean up
+
+			// create the bearer token file in the tmp dir
+			file := filepath.Join(dir, "bearerTokenfile")
+			err = os.WriteFile(file, []byte("mytoken"), 0666) //nolint:gosec
+			Expect(err).NotTo(HaveOccurred())
+
+			// Test the file reading
+			cfg := &rest.Config{}
+			cfg.BearerTokenFile = file
+
+			token, err := getTokenFromConfig(cfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(token).To(Equal("mytoken"))
+		})
+
+		It("returns an error if the file doesn't exist", func() {
+			fileLocation := "/tmp/12345/this_file_shouldnt_exist"
+
+			cfg := &rest.Config{}
+			cfg.BearerTokenFile = fileLocation
+
+			token, err := getTokenFromConfig(cfg)
+			Expect(err).To(HaveOccurred())
+			Expect(token).To(Equal(""))
+		})
+	})
+
+	Describe("validate the whoami token review", func() {
+		It("validates a good token", func() {
+			client := fake.NewSimpleClientset()
+			// We have to Prepend the reactor because of https://github.com/kubernetes/client-go/issues/500
+			client.PrependReactor("create", "tokenreviews", func(action ctest.Action) (handled bool, ret runtime.Object, err error) {
+				return true, successfulTokenReviewResponse, nil
+			})
+
+			whoami, err := whoami(client, "abcdefg")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(whoami).To(Equal("system:serviceaccount:openshift-backplane-srep:sre000"))
+		})
+
+		Context("Validate error handling", func() {
+			It("validates forbidden error", func() {
+				client := fake.NewSimpleClientset()
+				client.PrependReactor("create", "tokenreviews", func(action ctest.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, k8serrors.NewForbidden(schema.GroupResource{Group: "authentication.k8s.io", Resource: "TokenReview"}, "", fmt.Errorf("User \"system:serviceaccount:myns:user\" cannot do the thing"))
+				})
+
+				whoami, err := whoami(client, "abcdefg")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(whoami).To(Equal("system:serviceaccount:myns:user"))
+			})
+
+			It("validates non-forbidden error", func() {
+				expectedErr := fmt.Errorf("This is an error")
+				client := fake.NewSimpleClientset()
+				client.PrependReactor("create", "tokenreviews", func(action ctest.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, expectedErr
+				})
+
+				whoami, err := whoami(client, "abcdefg")
+				Expect(whoami).To(Equal(""))
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(expectedErr))
+			})
+
+			It("validates Status error", func() {
+				client := fake.NewSimpleClientset()
+				client.PrependReactor("create", "tokenreviews", func(action ctest.Action) (handled bool, ret runtime.Object, err error) {
+					tokenReview := &authv1.TokenReview{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "TokenReview",
+							APIVersion: "authentication.k8s.io/v1",
+						},
+						Status: authv1.TokenReviewStatus{
+							Error: "Some Error",
+						},
+					}
+					return true, tokenReview, nil
+				})
+
+				whoami, err := whoami(client, "abcdefg")
+				Expect(whoami).To(Equal(""))
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(fmt.Errorf("unexpected status error from TokenReview: Some Error")))
+			})
+		})
+	})
+
+	Describe("Validates Finding of other sessions", func() {
+		It("successfully returns a set of sessions", func() {
+			cfg := &rest.Config{}
+			cfg.BearerToken = "abcdefg"
+
+			client := fake.NewSimpleClientset(
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sre000",
+						Namespace: "openshift-backplane-srep",
+						Labels: map[string]string{
+							"managed.openshift.io/backplane": "true",
+						},
+					},
+				},
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abcdefghijk",
+						Namespace: "openshift-backplane-cee",
+						Labels: map[string]string{
+							"managed.openshift.io/backplane": "true",
+						},
+					},
+				},
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hijklmnop",
+						Namespace: "openshift-backplane-cee",
+						Labels: map[string]string{
+							"managed.openshift.io/backplane": "true",
+						},
+					},
+				},
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sre111",
+						Namespace: "openshift-backplane-srep",
+						Labels: map[string]string{
+							"managed.openshift.io/backplane": "true",
+						},
+					},
+				},
+			)
+			client.PrependReactor("create", "tokenreviews", func(action ctest.Action) (handled bool, ret runtime.Object, err error) {
+				return true, successfulTokenReviewResponse, nil
+			})
+
+			sessions, err := FindOtherSessions(client, cfg)
+			Expect(err).NotTo(HaveOccurred())
+			// We populate 2 cee SAs and 2 SRE SAs, so we expect
+			// the len of the sessions map to be 2 (cee, srep) and
+			// since we "are" sre000, we only expect a value of 1
+			// for the srep because we ignore ourself
+			Expect(len(sessions)).To(Equal(2))
+			Expect(sessions["cee"]).To(Equal(2))
+			Expect(sessions["srep"]).To(Equal(1))
+		})
+	})
+})


### PR DESCRIPTION
### What type of PR is this?

Feature

### What this PR does / Why we need it?

This adds a check after a successful login to tell the user about other backplane sessions that are currently on the cluster. This should add a bit of a check-and-balance for when MCS is looking at a cluster where SRE might already be paged for it, or conversely if you're responding to a page and see that there are a few other SRE sessions, it might tip you off to look at Service Logs or PD history to see why other SREs may be logged into this cluster already.

### Which Jira/Github issue(s) does this PR fix?

Resolves https://issues.redhat.com/browse/OSD-28832

### Special notes for your reviewer

Still a WIP - need to add additional tests and continue to test in different environments.

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [x] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
