### PR TITLE
[Test CI]Add off-VPN deny inline policy to prevent unauthorized access

### DIFF
--- a/cmd/ocm-backplane/cloud/common.go
+++ b/cmd/ocm-backplane/cloud/common.go
@@ -2,6 +2,8 @@ package cloud
 
 import (
 	"context"
+	"strings"
+
 	//nolint:gosec
 	"encoding/json"
 	"errors"
@@ -295,11 +297,49 @@ func (cfg *QueryConfig) getIsolatedCredentials(ocmToken string) (aws.Credentials
 		Credentials: NewStaticCredentialsProvider(seedCredentials.AccessKeyID, seedCredentials.SecretAccessKey, seedCredentials.SessionToken),
 	})
 
-	targetCredentials, err := AssumeRoleSequence(seedClient, assumeRoleArnSessionSequence, cfg.BackplaneConfiguration.ProxyURL, awsutil.DefaultSTSClientProviderFunc)
+	inlinePolicy, err := getTrustedIPInlinePolicy()
+	if err != nil {
+		return aws.Credentials{}, fmt.Errorf("failed to build inline policy: %w", err)
+	}
+
+	targetCredentials, err := AssumeRoleSequence(
+		seedClient,
+		assumeRoleArnSessionSequence,
+		cfg.BackplaneConfiguration.ProxyURL,
+		awsutil.DefaultSTSClientProviderFunc,
+		&inlinePolicy,
+	)
 	if err != nil {
 		return aws.Credentials{}, fmt.Errorf("failed to assume role sequence: %w", err)
 	}
 	return targetCredentials, nil
+}
+
+func getTrustedIPInlinePolicy() (awsutil.PolicyDocument, error) {
+	IPList, err := ocm.DefaultOCMInterface.GetTrustedIPList()
+	if err != nil {
+		return awsutil.PolicyDocument{}, fmt.Errorf("failed to fetch trusted IP list: %w", err)
+	}
+
+	sourceIPList := []string{}
+	for _, ip := range IPList.Items() {
+		if ip.Enabled() {
+			//This is hack for now to filter only proxy IP's
+			if strings.HasPrefix(ip.ID(), "209.") ||
+				strings.HasPrefix(ip.ID(), "66.") {
+				sourceIPList = append(sourceIPList, fmt.Sprintf("%s/24", ip.ID()))
+			}
+		}
+
+	}
+
+	ipAddress := awsutil.IPAddress{
+		SourceIp: sourceIPList,
+	}
+
+	policy := awsutil.NewPolicyDocument(awsutil.PolicyVersion, []awsutil.PolicyStatement{})
+
+	return policy.BuildPolicyWithRestrictedIP(ipAddress)
 }
 
 func isIsolatedBackplaneAccess(cluster *cmv1.Cluster, ocmConnection *ocmsdk.Connection) (bool, error) {

--- a/cmd/ocm-backplane/cloud/common_test.go
+++ b/cmd/ocm-backplane/cloud/common_test.go
@@ -1,8 +1,10 @@
 package cloud
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -17,6 +19,7 @@ import (
 	"github.com/openshift/backplane-cli/pkg/backplaneapi"
 	backplaneapiMock "github.com/openshift/backplane-cli/pkg/backplaneapi/mocks"
 	"github.com/openshift/backplane-cli/pkg/cli/config"
+	"github.com/openshift/backplane-cli/pkg/client/mocks"
 	"github.com/openshift/backplane-cli/pkg/ocm"
 	ocmMock "github.com/openshift/backplane-cli/pkg/ocm/mocks"
 )
@@ -27,6 +30,7 @@ var _ = Describe("getIsolatedCredentials", func() {
 		mockCtrl         *gomock.Controller
 		mockOcmInterface *ocmMock.MockOCMInterface
 		mockClientUtil   *backplaneapiMock.MockClientUtils
+		mockClient       *mocks.MockClientInterface
 
 		testOcmToken        string
 		testClusterID       string
@@ -34,6 +38,7 @@ var _ = Describe("getIsolatedCredentials", func() {
 		testSecretAccessKey string
 		testSessionToken    string
 		testQueryConfig     QueryConfig
+		fakeHTTPResp        *http.Response
 	)
 
 	BeforeEach(func() {
@@ -41,6 +46,8 @@ var _ = Describe("getIsolatedCredentials", func() {
 
 		mockOcmInterface = ocmMock.NewMockOCMInterface(mockCtrl)
 		ocm.DefaultOCMInterface = mockOcmInterface
+
+		mockClient = mocks.NewMockClientInterface(mockCtrl)
 
 		mockClientUtil = backplaneapiMock.NewMockClientUtils(mockCtrl)
 		backplaneapi.DefaultClientUtils = mockClientUtil
@@ -63,6 +70,17 @@ var _ = Describe("getIsolatedCredentials", func() {
 
 		cluster, _ := clusterBuilder.Build()
 		testQueryConfig = QueryConfig{OcmConnection: &sdk.Connection{}, BackplaneConfiguration: config.BackplaneConfiguration{URL: "test", AssumeInitialArn: "test"}, Cluster: cluster}
+
+		fakeHTTPResp = &http.Response{
+			Body: MakeIoReader(
+				`{"assumptionSequence":[{"name":"SRE-Role-Arn","arn":"arn:aws:iam::10000000:role/TEST_USER"},
+				{"name":"Org-Role-Arn","arn":"arn:aws:iam::10000000:role/TEST_USER"},
+				{"name":"Target-Role-Arn","arn":"arn:aws:iam::10000000:role/TEST_USER"}],
+				"customerRoleSessionName":"b7bb29e58495b17412e15701cea805b7"}`,
+			),
+			Header:     map[string][]string{},
+			StatusCode: http.StatusOK,
+		}
 	})
 
 	AfterEach(func() {
@@ -70,6 +88,7 @@ var _ = Describe("getIsolatedCredentials", func() {
 	})
 
 	Context("Execute getIsolatedCredentials", func() {
+
 		It("should fail if empty cluster ID is provided", func() {
 			clusterBuilder := cmv1.ClusterBuilder{}
 			clusterBuilder.ID("")
@@ -115,6 +134,31 @@ var _ = Describe("getIsolatedCredentials", func() {
 			_, err := testQueryConfig.getIsolatedCredentials(testOcmToken)
 			Expect(err.Error()).To(Equal("unable to extract email from given token: no field email on given token"))
 		})
+		It("should failed credentials with inline policy", func() {
+			ip1 := cmv1.NewTrustedIp().ID("209.10.10.10").Enabled(true)
+			ip2 := cmv1.NewTrustedIp().ID("200.20.20.20").Enabled(true)
+			expectedIPList, err := cmv1.NewTrustedIpList().Items(ip1, ip2).Build()
+			Expect(err).To(BeNil())
+			mockOcmInterface.EXPECT().GetTrustedIPList().Return(expectedIPList, nil)
+
+			StsClient = func(proxyURL *string) (*sts.Client, error) {
+				return &sts.Client{}, nil
+			}
+			AssumeRoleWithJWT = func(jwt string, roleArn string, stsClient stscreds.AssumeRoleWithWebIdentityAPIClient) (aws.Credentials, error) {
+				return aws.Credentials{
+					AccessKeyID:     testAccessKeyID,
+					SecretAccessKey: testSecretAccessKey,
+					SessionToken:    testSessionToken,
+				}, nil
+			}
+
+			mockClientUtil.EXPECT().GetBackplaneClient(testQueryConfig.BackplaneConfiguration.URL, testOcmToken, nil).Return(mockClient, nil)
+			mockClient.EXPECT().GetAssumeRoleSequence(context.TODO(), testClusterID).Return(fakeHTTPResp, nil)
+
+			_, err = testQueryConfig.getIsolatedCredentials(testOcmToken)
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).To(ContainSubstring("failed to assume role sequence:"))
+		})
 		It("should fail if error creating backplane api client", func() {
 			StsClient = func(proxyURL *string) (*sts.Client, error) {
 				return &sts.Client{}, nil
@@ -133,6 +177,22 @@ var _ = Describe("getIsolatedCredentials", func() {
 
 			_, err := testQueryConfig.getIsolatedCredentials(testOcmToken)
 			Expect(err.Error()).To(Equal("failed to create backplane client with access token: foo"))
+		})
+
+	})
+	Context("Execute getTrustedIpInlinePolicy", func() {
+		It("should Return inline policy with TrustedIP list", func() {
+			ip1 := cmv1.NewTrustedIp().ID("209.10.10.10").Enabled(true)
+			ip2 := cmv1.NewTrustedIp().ID("200.20.20.20").Enabled(true)
+			expectedIPList, err := cmv1.NewTrustedIpList().Items(ip1, ip2).Build()
+			Expect(err).To(BeNil())
+			mockOcmInterface.EXPECT().GetTrustedIPList().Return(expectedIPList, nil)
+			policy, err := getTrustedIPInlinePolicy()
+			//Only allow 209 IP
+			Expect(policy).To(ContainSubstring("209.10.10.10"))
+			//Not allow 200 IP
+			Expect(policy).NotTo(ContainSubstring("200.20.20.20"))
+			Expect(err).To(BeNil())
 		})
 	})
 })

--- a/pkg/awsutil/aws_suite_test.go
+++ b/pkg/awsutil/aws_suite_test.go
@@ -1,0 +1,13 @@
+package awsutil
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestIt(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AWS Util Test Suite")
+}

--- a/pkg/awsutil/iam.go
+++ b/pkg/awsutil/iam.go
@@ -1,0 +1,86 @@
+package awsutil
+
+import (
+	"encoding/json"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+const (
+	PolicyVersion = "2012-10-17"
+)
+
+type PolicyDocument struct {
+	Version   string            `json:"Version"`
+	Statement []PolicyStatement `json:"Statement"`
+}
+
+type PolicyStatement struct {
+	Sid       string            `json:"Sid"`        // Statement ID
+	Effect    string            `json:"Effect"`     // Allow or Deny
+	Action    []string          `json:"Action"`     // allowed or denied action
+	Principal map[string]string `json:",omitempty"` // principal that is allowed or denied
+	Resource  *string           `json:",omitempty"` // object or objects that the statement covers
+	Condition *Condition        `json:",omitempty"` // conditions for when a policy is in effect
+}
+
+type PolicyDocumentInterface interface {
+	String() (string, error)
+	BuildPolicyWithRestrictedIP(ipAddress IPAddress) (PolicyDocument, error)
+}
+
+type Condition struct {
+	//nolint NotIpAddress is required from AWS Policy
+	NotIpAddress IPAddress `json:"NotIpAddress"`
+}
+
+type IPAddress struct {
+	//nolint SourceIp is required from AWS Policy
+	SourceIp []string `json:"aws:SourceIp"`
+}
+
+func NewPolicyDocument(version string, statements []PolicyStatement) PolicyDocument {
+	return PolicyDocument{
+		Version:   version,
+		Statement: statements,
+	}
+}
+
+func (p PolicyDocument) String() string {
+	policyBytes, _ := json.Marshal(p)
+
+	return string(policyBytes)
+}
+
+func (p PolicyDocument) BuildPolicyWithRestrictedIP(ipAddress IPAddress) (PolicyDocument, error) {
+	condition := Condition{
+		NotIpAddress: ipAddress,
+	}
+
+	allAllow := NewPolicyStatement("AllowAll", "Allow", []string{"*"}).
+		AddResource(aws.String("*")).
+		AddCondition(nil)
+	denyIP := NewPolicyStatement("DenyIp", "Deny", []string{"*"}).
+		AddResource(aws.String("*")).
+		AddCondition(&condition)
+	p.Statement = []PolicyStatement{denyIP, allAllow}
+	return p, nil
+}
+
+func NewPolicyStatement(sid string, affect string, action []string) PolicyStatement {
+	return PolicyStatement{
+		Sid:    sid,
+		Effect: affect,
+		Action: action,
+	}
+}
+
+func (ps PolicyStatement) AddResource(resource *string) PolicyStatement {
+	ps.Resource = resource
+	return ps
+}
+
+func (ps PolicyStatement) AddCondition(condition *Condition) PolicyStatement {
+	ps.Condition = condition
+	return ps
+}

--- a/pkg/awsutil/iam_test.go
+++ b/pkg/awsutil/iam_test.go
@@ -1,0 +1,86 @@
+package awsutil
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AWS IAM Util tests", func() {
+
+	BeforeEach(func() {
+
+	})
+
+	AfterEach(func() {
+
+	})
+
+	Context("Test IAM policy document", func() {
+
+		It("Should return string policy", func() {
+			statements := []PolicyStatement{
+				{
+					Sid:       "AllowAll",
+					Effect:    "Allow",
+					Action:    []string{"*"},
+					Resource:  aws.String("*"),
+					Condition: nil,
+				},
+			}
+			expectedRawPolicy := `{"Version":"2012-10-17","Statement":[{"Sid":"AllowAll","Effect":"Allow","Action":["*"],"Resource":"*"}]}`
+
+			policy := NewPolicyDocument(PolicyVersion, statements)
+			rawPolicy := policy.String()
+			Expect(rawPolicy).NotTo(BeNil())
+			Expect(rawPolicy).To(Equal(expectedRawPolicy))
+		})
+
+		It("Should return All Allow policy", func() {
+
+			statement := NewPolicyStatement("AllowAll", "Allow", []string{"*"}).
+				AddResource(aws.String("*")).
+				AddCondition(nil)
+
+			expectedRawPolicy := `{"Version":"2012-10-17","Statement":[{"Sid":"AllowAll","Effect":"Allow","Action":["*"],"Resource":"*"}]}`
+
+			policy := NewPolicyDocument(PolicyVersion, []PolicyStatement{statement})
+			rawPolicy := policy.String()
+			Expect(statement).NotTo(BeNil())
+			Expect(rawPolicy).To(Equal(expectedRawPolicy))
+
+		})
+
+		It("Should return All Deny Policy", func() {
+
+			statement := NewPolicyStatement("AllowDeny", "Deny", []string{"*"}).
+				AddResource(aws.String("*")).
+				AddCondition(nil)
+
+			expectedRawPolicy := `{"Version":"2012-10-17","Statement":[{"Sid":"AllowDeny","Effect":"Deny","Action":["*"],"Resource":"*"}]}`
+
+			policy := NewPolicyDocument(PolicyVersion, []PolicyStatement{statement})
+			rawPolicy := policy.String()
+			Expect(statement).NotTo(BeNil())
+			Expect(rawPolicy).To(Equal(expectedRawPolicy))
+		})
+		It("Should return restricted IP policy", func() {
+
+			expectedRawPolicy := `{"Version":"2012-10-17","Statement":[{"Sid":"DenyIp","Effect":"Deny","Action":["*"],"Resource":"*",` +
+				`"Condition":{"NotIpAddress":{"aws:SourceIp":["100.10.10.10"]}}},{"Sid":"AllowAll","Effect":"Allow","Action":["*"],"Resource":"*"}]}`
+			sourceIPList := []string{"100.10.10.10"}
+
+			ipAddress := IPAddress{SourceIp: sourceIPList}
+			policy := NewPolicyDocument(PolicyVersion, []PolicyStatement{})
+
+			policy, err := policy.BuildPolicyWithRestrictedIP(ipAddress)
+			Expect(err).To(BeNil())
+			rawPolicy := policy.String()
+			fmt.Print(rawPolicy)
+			Expect(err).To(BeNil())
+			Expect(rawPolicy).To(Equal(expectedRawPolicy))
+		})
+	})
+})

--- a/pkg/ocm/mocks/ocmWrapperMock.go
+++ b/pkg/ocm/mocks/ocmWrapperMock.go
@@ -235,6 +235,21 @@ func (mr *MockOCMInterfaceMockRecorder) GetTargetCluster(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTargetCluster", reflect.TypeOf((*MockOCMInterface)(nil).GetTargetCluster), arg0)
 }
 
+// GetTrustedIPList mocks base method.
+func (m *MockOCMInterface) GetTrustedIPList() (*v10.TrustedIpList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTrustedIPList")
+	ret0, _ := ret[0].(*v10.TrustedIpList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTrustedIPList indicates an expected call of GetTrustedIPList.
+func (mr *MockOCMInterfaceMockRecorder) GetTrustedIPList() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTrustedIPList", reflect.TypeOf((*MockOCMInterface)(nil).GetTrustedIPList))
+}
+
 // IsClusterAccessProtectionEnabled mocks base method.
 func (m *MockOCMInterface) IsClusterAccessProtectionEnabled(arg0 *sdk.Connection, arg1 string) (bool, error) {
 	m.ctrl.T.Helper()

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -37,6 +37,7 @@ type OCMInterface interface {
 	GetClusterActiveAccessRequest(ocmConnection *ocmsdk.Connection, clusterID string) (*acctrspv1.AccessRequest, error)
 	CreateClusterAccessRequest(ocmConnection *ocmsdk.Connection, clusterID, reason, jiraIssueID, approvalDuration string) (*acctrspv1.AccessRequest, error)
 	CreateAccessRequestDecision(ocmConnection *ocmsdk.Connection, accessRequest *acctrspv1.AccessRequest, decision acctrspv1.DecisionDecision, justification string) (*acctrspv1.Decision, error)
+	GetTrustedIPList() (*cmv1.TrustedIpList, error)
 	SetupOCMConnection() (*ocmsdk.Connection, error)
 }
 
@@ -475,6 +476,23 @@ func (o *DefaultOCMInterfaceImpl) CreateAccessRequestDecision(ocmConnection *ocm
 	}
 
 	return accessRequestDecision, nil
+}
+
+func (o *DefaultOCMInterfaceImpl) GetTrustedIPList() (*cmv1.TrustedIpList, error) {
+	// Create the client for the OCM API
+	connection, err := o.SetupOCMConnection()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OCM connection: %v", err)
+	}
+	defer connection.Close()
+
+	responseTrustedIP, err := connection.ClustersMgmt().V1().TrustedIPAddresses().List().Send()
+	if err != nil {
+
+		return nil, err
+	}
+
+	return responseTrustedIP.Items(), nil
 }
 
 func getClusters(client *cmv1.ClustersClient, clusterKey string) ([]*cmv1.Cluster, error) {

--- a/pkg/ocm/ocm_suite_test.go
+++ b/pkg/ocm/ocm_suite_test.go
@@ -1,0 +1,13 @@
+package ocm
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestIt(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OCM Test Suite")
+}

--- a/pkg/ocm/ocm_test.go
+++ b/pkg/ocm/ocm_test.go
@@ -1,0 +1,49 @@
+package ocm
+
+import (
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	ocmMock "github.com/openshift/backplane-cli/pkg/ocm/mocks"
+)
+
+var _ = Describe("OCM Wrapper test", func() {
+
+	var (
+		mockCtrl *gomock.Controller
+
+		mockOcmInterface *ocmMock.MockOCMInterface
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+
+		mockOcmInterface = ocmMock.NewMockOCMInterface(mockCtrl)
+		mockOcmInterface.EXPECT().SetupOCMConnection().Return(nil, nil)
+
+		DefaultOCMInterface = mockOcmInterface
+	})
+
+	AfterEach(func() {
+
+	})
+
+	Context("Test OCM Wrapper", func() {
+
+		It("Should return trusted IPList", func() {
+			ip1 := cmv1.NewTrustedIp().ID("100.10.10.10")
+			ip2 := cmv1.NewTrustedIp().ID("200.20.20.20")
+			expectedIPList, _ := cmv1.NewTrustedIpList().Items(ip1, ip2).Build()
+			mockOcmInterface.EXPECT().GetTrustedIPList().Return(expectedIPList, nil).AnyTimes()
+			IPList, err := DefaultOCMInterface.GetTrustedIPList()
+			Expect(err).To(BeNil())
+			Expect(len(IPList.Items())).Should(Equal(2))
+		})
+		It("Should not return errors for empty trusted IPList", func() {
+			mockOcmInterface.EXPECT().GetTrustedIPList().Return(nil, nil).AnyTimes()
+			_, err := DefaultOCMInterface.GetTrustedIPList()
+			Expect(err).To(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
### What type of PR is this?

Feature

### What does this PR do / Why do we need it?

This PR prevents off-VPN cloud console/credentials access once STS token derived it VPN connection 

### Which Jira/Github issue(s) does this PR fix?
https://issues.redhat.com/browse/OSD-19789

### How to test 
* Get cloud console access via connecting to VPN 
* Check the available resources ( like ec2/cloudtrial)
* disconnect from the VPN 
* You shouldn't be able to access the resources 

_Resolves #_

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
