### PR TITLE
Bump Go 1.23.6 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN yum install --assumeyes \
     go-toolset
 
 # This is a hack to install go1.22 version until ubi9 supports golang 1.22 
-RUN go install golang.org/dl/go1.22.7@latest
-RUN go env -w GOTOOLCHAIN=go1.22.7+auto
+RUN go install golang.org/dl/go1.23.7@latest
+RUN go env -w GOTOOLCHAIN=go1.23.7+auto
 
 ENV GOOS=linux GO111MODULE=on GOPROXY=https://proxy.golang.org 
 ENV GOBIN=/gobin GOPATH=/usr/src/go CGO_ENABLED=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,19 @@ FROM registry.access.redhat.com/ubi9/ubi:9.5 as bp-cli-builder
 RUN yum install --assumeyes \
     make \
     git \
-    go-toolset
+    wget
 
-# This is a hack to install go1.22 version until ubi9 supports golang 1.22 
+# Install Go 1.23.7 properly
 RUN go install golang.org/dl/go1.23.7@latest
-RUN go env -w GOTOOLCHAIN=go1.23.7+auto
+RUN /root/go/bin/go1.23.7 download
 
+# Configure the env
+ENV PATH="/root/sdk/go1.23.7/bin:${PATH}"
+RUN go1.23.7 env -w GOTOOLCHAIN=go1.23.7+auto
+
+#Environment variables
 ENV GOOS=linux GO111MODULE=on GOPROXY=https://proxy.golang.org 
 ENV GOBIN=/gobin GOPATH=/usr/src/go CGO_ENABLED=0
-ENV PATH=/usr/local/go/bin/:${PATH}
 
 # Directory for the binary
 RUN mkdir /out

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,16 @@ FROM registry.access.redhat.com/ubi9/ubi:9.5 as bp-cli-builder
 RUN yum install --assumeyes \
     make \
     git \
-    wget
+    wget \
+    go-toolset
 
-# Install Go 1.23.7 properly
-RUN go install golang.org/dl/go1.23.7@latest
-RUN /root/go/bin/go1.23.7 download
+# Install Go 1.23.6 properly
+RUN go install golang.org/dl/go1.23.6@latest
+RUN /root/go/bin/go1.23.6 download
 
 # Configure the env
-ENV PATH="/root/sdk/go1.23.7/bin:${PATH}"
-RUN go1.23.7 env -w GOTOOLCHAIN=go1.23.7+auto
+ENV PATH="/root/sdk/go1.23.6/bin:${PATH}"
+RUN go env -w GOTOOLCHAIN=go1.23.6+auto
 
 #Environment variables
 ENV GOOS=linux GO111MODULE=on GOPROXY=https://proxy.golang.org 

--- a/Makefile
+++ b/Makefile
@@ -154,3 +154,31 @@ skopeo-push: image
 		--dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
 		"docker-daemon:${IMAGE_URI_LATEST}" \
 		"docker://${IMAGE_URI_LATEST}"
+
+.PHONY: help
+help:
+	@echo
+	@echo "================================================"
+	@echo "           ocm-backplane Makefile Help           "
+	@echo "================================================"
+	@echo
+	@echo "Targets:"
+	@echo "  lint        Install/Run golangci-lint checks"
+	@echo "  clean       Remove compiled binaries and build artifacts"
+	@echo "  build       Compile project (set ARCH= for cross-compilation)"
+	@echo "  install     Install binary system-wide (set ARCH= for architecture)"
+	@echo "  test        Run unit tests"
+	@echo "  cross-build Create multi-architecture binaries"
+	@echo "  image       Build container image"
+	@echo "  help        Show this help message"
+	@echo
+	@echo "Variables:"
+	@echo "  ARCH        Target architecture (e.g., amd64, arm64 - sets GOARCH)"
+	@echo "  GOOS        Target OS (default: linux)"
+	@echo
+	@echo "Examples:"
+	@echo "  make build ARCH=arm64       # Cross-compile for ARM64"
+	@echo "  make clean && make install  # Fresh install"
+	@echo "  GOOS=darwin make build      # Build for macOS"
+	@echo
+	

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/backplane-cli
 
-go 1.23.7
+go 1.23.6
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/backplane-cli
 
-go 1.22.7
+go 1.23.7
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
### What type of PR is this?
Hotfix 

### What this PR does / Why we need it?
This PR bump Go version 1.23 since backplane CI is already running on 1.23 version 

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [x] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [x] Included documentation changes with PR
