### PR TITLE
OSD-28786 : Bump ginkgo to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/openshift/backplane-cli
 
 go 1.23.6
+
 toolchain go1.24.1
 
 require (

--- a/pkg/info/info_test.go
+++ b/pkg/info/info_test.go
@@ -37,12 +37,12 @@ var _ = Describe("Info", func() {
 			info.Version = ""
 			mockBuildInfoService.EXPECT().GetBuildInfo().Return(&debug.BuildInfo{
 				Main: debug.Module{
-					Version: "v1.2.3",
+					Version: "v2.23.3",
 				},
 			}, true).Times(1)
 
 			version := info.DefaultInfoService.GetVersion()
-			Expect(version).To(Equal("1.2.3"))
+			Expect(version).To(Equal("2.23.3"))
 		})
 		It("Should return an unknown when no way to determine version", func() {
 			info.Version = ""


### PR DESCRIPTION
### What type of PR is this?
Enhancement
- [ ] Bug
- [ ] Feature
- [ ] Documentation
- [ ] Test Coverage
- [ ] Clean Up
- [x] Others

### What this PR does / Why we need it?
Bumps ginkgo to v2 from v1 

### Which Jira/Github issue(s) does this PR fix?
[OSD-28786](https://issues.redhat.com//browse/OSD-28786)

- Related Issue #
- Closes #
[OSD-28786](https://issues.redhat.com//browse/OSD-28786)

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
