### PR TITLE
[OSD-28995] Update codecov settings 

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -27,3 +27,4 @@ comment:
 
 ignore:
   - "**/mocks"
+  - "**/mocks/**"


### PR DESCRIPTION
### What type of PR is this?

- [ ] Bug
- [ ] Feature
- [ ] Documentation
- [ ] Test Coverage
- [ ] Clean Up
- [X] Improvement
### What this PR does / Why we need it?
It will improve the codecoverage of backplane-cli by excluding the mock files which are covered in codecov report
It will exclude files like pkg/ocm/mocks/ocmWrapperMock.go & pkg/backplaneapi/mocks/clientUtilsMock.go

![image](https://github.com/user-attachments/assets/a9a969c3-c516-4782-b29e-10f8e2cf94ba)

### Which Jira/Github issue(s) does this PR fix?

- Closes # [OSD-28995](https://issues.redhat.com/browse/OSD-28995)

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [X] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
