### PR TITLE
SREP-21: backplane API is now allocating a remediation instance id for each call to createRemediation

### DIFF
--- a/cmd/ocm-backplane/remediation/remediation_test.go
+++ b/cmd/ocm-backplane/remediation/remediation_test.go
@@ -37,14 +37,15 @@ var _ = Describe("New Remediation command", func() {
 		mockClientUtil   *backplaneapiMock.MockClientUtils
 		mockClient       *mocks.MockClientInterface
 
-		testClusterID       string
-		trueClusterID       string
-		testToken           string
-		testRemediationName string
-		fakeResp            *http.Response
-		bpConfigPath        string
-		backplaneAPIURI     string
-		ocmEnv              *cmv1.Environment
+		testClusterID             string
+		trueClusterID             string
+		testToken                 string
+		testRemediationName       string
+		testRemediationInstanceID string
+		fakeResp                  *http.Response
+		bpConfigPath              string
+		backplaneAPIURI           string
+		ocmEnv                    *cmv1.Environment
 	)
 
 	BeforeEach(func() {
@@ -81,7 +82,7 @@ var _ = Describe("New Remediation command", func() {
 		backplaneAPIURI = "https://shard.apps.example.com/"
 		testToken = "testToken"
 		testRemediationName = "remediationName"
-
+		testRemediationInstanceID = "remediationInstanceId"
 	})
 
 	AfterEach(func() {
@@ -104,7 +105,7 @@ var _ = Describe("New Remediation command", func() {
 			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterID)).Return(false, nil).AnyTimes()
 
 			mockClientUtil.EXPECT().MakeRawBackplaneAPIClientWithAccessToken(backplaneAPIURI, testToken).Return(mockClient, nil)
-			mockClient.EXPECT().CreateRemediation(context.TODO(), trueClusterID, &BackplaneApi.CreateRemediationParams{Remediation: testRemediationName}).Return(fakeResp, nil)
+			mockClient.EXPECT().CreateRemediation(context.TODO(), trueClusterID, &BackplaneApi.CreateRemediationParams{RemediationName: testRemediationName}).Return(fakeResp, nil)
 
 			err := runCreateRemediation([]string{testRemediationName}, testClusterID, backplaneAPIURI)
 
@@ -118,7 +119,7 @@ var _ = Describe("New Remediation command", func() {
 			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterID)).Return(false, nil).AnyTimes()
 
 			mockClientUtil.EXPECT().MakeRawBackplaneAPIClientWithAccessToken("http://uri2.example.com", testToken).Return(mockClient, nil)
-			mockClient.EXPECT().CreateRemediation(context.TODO(), trueClusterID, &BackplaneApi.CreateRemediationParams{Remediation: testRemediationName}).Return(fakeResp, nil)
+			mockClient.EXPECT().CreateRemediation(context.TODO(), trueClusterID, &BackplaneApi.CreateRemediationParams{RemediationName: testRemediationName}).Return(fakeResp, nil)
 
 			err := runCreateRemediation([]string{testRemediationName}, testClusterID, "http://uri2.example.com")
 
@@ -136,7 +137,7 @@ var _ = Describe("New Remediation command", func() {
 			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterID)).Return(false, nil).AnyTimes()
 
 			mockClientUtil.EXPECT().MakeRawBackplaneAPIClientWithAccessToken(backplaneAPIURI, testToken).Return(mockClient, nil)
-			mockClient.EXPECT().CreateRemediation(context.TODO(), trueClusterID, &BackplaneApi.CreateRemediationParams{Remediation: testRemediationName}).Return(fakeResp, nil)
+			mockClient.EXPECT().CreateRemediation(context.TODO(), trueClusterID, &BackplaneApi.CreateRemediationParams{RemediationName: testRemediationName}).Return(fakeResp, nil)
 
 			err := runCreateRemediation([]string{testRemediationName}, testClusterID, backplaneAPIURI)
 
@@ -186,9 +187,9 @@ var _ = Describe("New Remediation command", func() {
 			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterID)).Return(false, nil).AnyTimes()
 
 			mockClientUtil.EXPECT().MakeRawBackplaneAPIClientWithAccessToken(backplaneAPIURI, testToken).Return(mockClient, nil)
-			mockClient.EXPECT().DeleteRemediation(context.TODO(), trueClusterID, &BackplaneApi.DeleteRemediationParams{Remediation: &testRemediationName}).Return(fakeResp, nil)
+			mockClient.EXPECT().DeleteRemediation(context.TODO(), trueClusterID, &BackplaneApi.DeleteRemediationParams{RemediationInstanceId: testRemediationInstanceID}).Return(fakeResp, nil)
 
-			err := runDeleteRemediation([]string{testRemediationName}, testClusterID, backplaneAPIURI)
+			err := runDeleteRemediation([]string{testRemediationInstanceID}, testClusterID, backplaneAPIURI)
 
 			Expect(err).To(BeNil())
 		})
@@ -200,9 +201,9 @@ var _ = Describe("New Remediation command", func() {
 			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterID)).Return(false, nil).AnyTimes()
 
 			mockClientUtil.EXPECT().MakeRawBackplaneAPIClientWithAccessToken("https://uri2.example.com/", testToken).Return(mockClient, nil)
-			mockClient.EXPECT().DeleteRemediation(context.TODO(), trueClusterID, &BackplaneApi.DeleteRemediationParams{Remediation: &testRemediationName}).Return(fakeResp, nil)
+			mockClient.EXPECT().DeleteRemediation(context.TODO(), trueClusterID, &BackplaneApi.DeleteRemediationParams{RemediationInstanceId: testRemediationInstanceID}).Return(fakeResp, nil)
 
-			err := runDeleteRemediation([]string{testRemediationName}, testClusterID, "https://uri2.example.com/")
+			err := runDeleteRemediation([]string{testRemediationInstanceID}, testClusterID, "https://uri2.example.com/")
 
 			Expect(err).To(BeNil())
 		})

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/onsi/gomega v1.37.0
 	github.com/openshift-online/ocm-cli v1.0.5
 	github.com/openshift-online/ocm-sdk-go v0.1.465
-	github.com/openshift/backplane-api v0.0.0-20241127094828-0f66644ff53d
+	github.com/openshift/backplane-api v0.0.0-20250514095514-2aa57551ec70
 	github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -381,8 +381,8 @@ github.com/openshift-online/ocm-sdk-go v0.1.465 h1:RZr92sdcAKyLVcL19/RYOn6KVtspD
 github.com/openshift-online/ocm-sdk-go v0.1.465/go.mod h1:EOkylgH0bafd+SlU9YvMrIIxHJw0Hk1EnC7W1VZeW8I=
 github.com/openshift/api v0.0.0-20221018124113-7edcfe3c76cb h1:QsBjYe5UfHIZi/3SMzQBIjYDKnWqZxq50eQkBp9eUew=
 github.com/openshift/api v0.0.0-20221018124113-7edcfe3c76cb/go.mod h1:JRz+ZvTqu9u7t6suhhPTacbFl5K65Y6rJbNM7HjWA3g=
-github.com/openshift/backplane-api v0.0.0-20241127094828-0f66644ff53d h1:7Dx+1tKC8eegHGXTnrmMrV0QV68qHdOFFseQR5L3ej4=
-github.com/openshift/backplane-api v0.0.0-20241127094828-0f66644ff53d/go.mod h1:RuJZpJy45AJnkp7A0ZPTZhLOVkCGDLI6cGknKvp65LE=
+github.com/openshift/backplane-api v0.0.0-20250514095514-2aa57551ec70 h1:rUcdH93mEXHMviKxy1no2vFuQm0TiqA2vuCKnczeQ1k=
+github.com/openshift/backplane-api v0.0.0-20250514095514-2aa57551ec70/go.mod h1:RuJZpJy45AJnkp7A0ZPTZhLOVkCGDLI6cGknKvp65LE=
 github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c h1:CV76yFOTXmq9VciBR3Bve5ZWzSxdft7gaMVB3kS0rwg=
 github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c/go.mod h1:lFMO8mLHXWFzSdYvGNo8ivF9SfF6zInA8ZGw4phRnUE=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=


### PR DESCRIPTION
### What type of PR is this?

- [ ] Bug
- [X] Feature
- [ ] Documentation
- [ ] Test Coverage
- [ ] Clean Up
- [ ] Others

### What this PR does / Why we need it?

`ocm-backplane remediation create` is now returning a remediation instance id; this id will be used in place of the remediation name at `ocm-backplane remediation delete` time.

This will allow backplane to have several remediations with the same name in parallel without mixing up the resources created on the target cluster.

### Which Jira/Github issue(s) does this PR fix?

- Contributes to [SREP-21](https://issues.redhat.com//browse/SREP-21)

### Special notes for your reviewer

Depends on the following `backplane-api` change which will need to be referenced in `go.mod` & `go.sum` to have the code build successfully:
https://github.com/openshift/backplane-api/pull/19

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [X] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [X] Ran unit tests locally
- [X] Validated the changes in a cluster
- [ ] Included documentation changes with PR
