### PR TITLE
Use a singleton variable to hold the OCM connection.

### DIFF
--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -51,9 +51,13 @@ type DefaultOCMInterfaceImpl struct {
 }
 
 var DefaultOCMInterface OCMInterface = &DefaultOCMInterfaceImpl{}
+var singleOcmConnection *ocmsdk.Connection
 
 // SetupOCMConnection setups the ocm connection for all the other ocm requests
 func (o *DefaultOCMInterfaceImpl) SetupOCMConnection() (*ocmsdk.Connection, error) {
+	if singleOcmConnection != nil {
+		return singleOcmConnection, nil
+	}
 
 	envURL := os.Getenv("OCM_URL")
 	if envURL != "" {
@@ -76,7 +80,7 @@ func (o *DefaultOCMInterfaceImpl) SetupOCMConnection() (*ocmsdk.Connection, erro
 			return nil, err
 		}
 	}
-
+	singleOcmConnection = connection
 	return connection, nil
 }
 


### PR DESCRIPTION
### What type of PR is this?

- [X] Bug
- [ ] Feature
- [ ] Documentation
- [ ] Test Coverage
- [ ] Clean Up
- [ ] Others
### What this PR does / Why we need it?

Recreating the OCM connection breaks CAD.

This is a quick, untested way to simply reuse the same connection across the process once it has been setup.

### Which Jira/Github issue(s) does this PR fix?

- Related Issue #
- Closes #

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
