### PR TITLE
Add CAD stg and prod IP's to session policy

### DIFF
--- a/cmd/ocm-backplane/cloud/common.go
+++ b/cmd/ocm-backplane/cloud/common.go
@@ -390,7 +390,32 @@ func getTrustedIPList(connection *ocmsdk.Connection) (awsutil.IPAddress, error) 
 	sourceIPList := []string{}
 
 	for _, ip := range IPList.Items() {
-		sourceIPList = append(sourceIPList, fmt.Sprintf("%s/32", ip.ID()))
+		if ip.Enabled() {
+			// TODO:Update OCM GetTrustedIPList endpoint with trusted IP category( ex: VPN, Proxy etc)
+			//  which may help filter proxy IP's efficiently
+
+			//This is hack for now to filter only proxy IP's
+			if strings.HasPrefix(ip.ID(), "209.") ||
+				strings.HasPrefix(ip.ID(), "66.") ||
+				strings.HasPrefix(ip.ID(), "91.") {
+				sourceIPList = append(sourceIPList, fmt.Sprintf("%s/32", ip.ID()))
+			}
+
+			// Add cad stg IPS
+			if strings.HasPrefix(ip.ID(), "3.216") ||
+				strings.HasPrefix(ip.ID(), "34.227") ||
+				strings.HasPrefix(ip.ID(), "98.85") {
+				sourceIPList = append(sourceIPList, fmt.Sprintf("%s/32", ip.ID()))
+			}
+
+			// Add cad prd IPS
+			if strings.HasPrefix(ip.ID(), "34.193") ||
+				strings.HasPrefix(ip.ID(), "52.203") ||
+				strings.HasPrefix(ip.ID(), "54.145") {
+				sourceIPList = append(sourceIPList, fmt.Sprintf("%s/32", ip.ID()))
+			}
+		}
+
 	}
 
 	ipAddress := awsutil.IPAddress{

--- a/cmd/ocm-backplane/cloud/common_test.go
+++ b/cmd/ocm-backplane/cloud/common_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/openshift/backplane-cli/pkg/awsutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/openshift/backplane-cli/pkg/awsutil"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -268,7 +269,7 @@ var _ = Describe("getIsolatedCredentials", func() {
 			policy, _ := getTrustedIPInlinePolicy(IPList)
 			// Check all trusted IPs are allowed
 			Expect(policy).To(ContainSubstring("209.10.10.10"))
-			Expect(policy).To(ContainSubstring("200.20.20.20"))
+			Expect(policy).NotTo(ContainSubstring("200.20.20.20"))
 			Expect(err).To(BeNil())
 		})
 	})


### PR DESCRIPTION
### What type of PR is this?

- [x] Bug
- [ ] Feature
- [ ] Documentation
- [ ] Test Coverage
- [ ] Clean Up
- [ ] Others
### What this PR does / Why we need it?
Allowing all trusted IP lists exceeded the AWS policy character length, and it breaks the bacplane-cli sts assume-role process. This PR limited the number of IPs to keep the policy limit within AWS's valid character length. 

This PR revert back proxy IP filtering and add CAD stg and prod ips 

### Which Jira/Github issue(s) does this PR fix?

- Related Issue #
- Closes #

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
