### PR TITLE
SREP:608 - Adding dedicated ports and hosts for console and monitoring plugin

### DIFF
--- a/cmd/ocm-backplane/console/console.go
+++ b/cmd/ocm-backplane/console/console.go
@@ -621,7 +621,7 @@ func podmanRunMonitorPluginDedicated(containerName string, nginxConfPath string,
 		"--detach",
 		"--name", containerName,
 		"--publish", fmt.Sprintf("%s:%s:%s", host, port, port), // Expose dedicated port
-		"--mount", fmt.Sprintf("type=bind,source=%s,destination=/etc/nginx/nginx.conf,relabel=shared", nginxConfPath),
+		"--mount", fmt.Sprintf("type=bind,source=%s,destination=/etc/nginx/nginx.conf", nginxConfPath),
 	}
 	engRunArgs = append(engRunArgs, pluginArgs...)
 	logger.WithField("Command", fmt.Sprintf("`%s %s`", PODMAN, strings.Join(engRunArgs, " "))).Infoln("Running container")


### PR DESCRIPTION
### What type of PR is this?

- [x] Bug
- [ ] Feature
- [ ] Documentation
- [ ] Test Coverage
- [ ] Clean Up
- [ ] Others

### What this PR does / Why we need it?
Adds dedicated hosts and port for console and monitoring plugin to avoid port conflict that is causing the bug mentioned in SREP:608

### Which Jira/Github issue(s) does this PR fix?
https://issues.redhat.com/browse/SREP-608
- Related Issue #
- Closes #

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
