### PR TITLE
Make KUBEPS1 warning optional

### DIFF
--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -356,11 +356,12 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 	}
 	logger.Debugf("API Config Generated %+v \n", rc)
 
-	logger.Debugln("Check for PS1 ENV varible")
-	// Check PS1 env is set or not
-	EnvPs1, ok := os.LookupEnv(EnvPs1)
-	if !ok {
-		logger.Warn("Env KUBE_PS1_CLUSTER_FUNCTION is not detected. It is recommended to set PS1 to learn which cluster you are operating on, refer https://github.com/openshift/backplane-cli/blob/main/docs/PS1-setup.md", EnvPs1)
+	logger.Debugln("Check for PS1 ENV variable")
+	if bpConfig.DisplayKubePS1Warning() {
+		_, ok := os.LookupEnv(EnvPs1)
+		if !ok {
+			logger.Warn("Env KUBE_PS1_CLUSTER_FUNCTION is not detected. It is recommended to set PS1 to learn which cluster you are operating on, refer https://github.com/openshift/backplane-cli/blob/main/docs/PS1-setup.md")
+		}
 	}
 
 	// Add a new cluster & context & user

--- a/docs/PS1-setup.md
+++ b/docs/PS1-setup.md
@@ -1,6 +1,6 @@
 # How to setup PS1 in bash/zsh
 
-You can use the below methods to set the shell prompt, so you can learn which cluster operating on, like
+You can use the below methods to set the shell prompt, so you can easily see which cluster you are connected to, like:
 ~~~
 [user@user ~ (⎈ |stg/user-test-1.zlob.s1:default)]$ date
 Tue Sep  7 17:40:35 CST 2021
@@ -64,3 +64,9 @@ KUBE_PS1_BINARY=oc
 export KUBE_PS1_CLUSTER_FUNCTION=cluster_function
 PS1='[\u@\h \W $(kube_ps1)]\$ '
 ~~~
+
+
+## Disabling warning when PS1 is not configured
+
+If you would like to disable warnings from `ocm-backplane` when `kube-ps1` is not configured, you can set the
+`disable-kube-ps1-warning` value to `false` in your configuration file.


### PR DESCRIPTION
### What type of PR is this?

- [ ] Bug
- [x] Feature
- [ ] Documentation
- [ ] Test Coverage
- [ ] Clean Up
- [ ] Others
### What this PR does / Why we need it?
Adds an optional configuration option `disable-kube-ps1-warning` to be able to conditionally display the warning about setting up the `kube-ps1` function in your terminal.

The motivation for this is I have a custom terminal prompt that includes `~/.kube/config` context information, and desire for less warning output when I login to clusters.

I tested this behavior with default values (nil), and bool/string, which are handled by `viper` for us natively.

### Which Jira/Github issue(s) does this PR fix?

- Related Issue #
- Closes #

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [x] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
