### PR TITLE
OSD-29893 - Adding Fedramp compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ For more information about ocm plugins, please refer https://github.com/openshif
 
 The configuration file of backplane-cli is expected to be located at `$HOME/.config/backplane/config.json`.
 
+**Security Note:** This configuration file may store sensitive information such as PagerDuty API keys or JIRA tokens. It is recommended to ensure its permissions are restrictive (e.g., `chmod 600 $HOME/.config/backplane/config.json`) to protect this data.
+
 ## Setup bash/zsh prompt
 
 To setup the PS1(prompt) for bash/zsh, please follow [these instructions](https://github.com/openshift/backplane-cli/blob/main/docs/PS1-setup.md).
@@ -442,11 +444,11 @@ Please help us to improve. To contact the backplane team:
 ## Vulnerability Scanning with `govulncheck`
 
 As part of our continuous integration (CI) process, we've incorporated `govulncheck` to identify known vulnerabilities in the `backplane-cli` codebase.
-Following each CI execution, especially when PRs are submitted, a detailed vulnerability report can be found in `build-log.txt`. This is nested within
+In the CI environment (specifically the `ci/prow/scan-optional` test), vulnerability reports may be available as artifacts, potentially named `build-log.txt` or similar, within the test's artifact storage. This is nested within
 the `artifacts/test/` directory of the `ci/prow/scan-optional` test. To retrieve the report:
 - Click on `Details` next to `ci/prow/scan-optional` in a specific PR.
 - Click `Artifacts` at the top-right corner of the page.
-- Navigate to `artifacts/test/` to view the `build-log.txt` containing vulnerability information.
+- Navigate to `artifacts/test/` to view the `build-log.txt` (or similarly named file) containing vulnerability information.
 
 While some detected vulnerabilities might be non-blocking at the moment, they are still reported. We encourage both users and developers to thoroughly
 review these reports. If any Go packages are flagged, consider updating them to their fixed versions.
@@ -455,6 +457,8 @@ To manually execute a vulnerability scan locally, run the following command:
 ```
 make scan
 ```
+
+**Note on Local Scans:** Running `govulncheck` (e.g., via `make scan`) locally can be sensitive to the Go version and your development environment. If you encounter errors, ensure your Go version aligns with the one used in CI, or refer to the "Fixing Go Version Compatibility Issues" section. The `make scan` command currently prints output to standard output; it does not generate a `build-log.txt` file locally.
 
 ## Fixing Go Version Compatibility Issues
 When build failures occur due to Go version mismatches, follow these steps:

--- a/cmd/ocm-backplane/cloud/console.go
+++ b/cmd/ocm-backplane/cloud/console.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 
@@ -123,9 +124,19 @@ func runConsole(cmd *cobra.Command, argv []string) (err error) {
 
 	// ============Get Backplane URl ==========================
 	if consoleArgs.backplaneURL != "" { // Overwrite if parameter is set
+		parsedURL, parseErr := url.ParseRequestURI(consoleArgs.backplaneURL)
+		if parseErr != nil {
+			return fmt.Errorf("invalid --url: %v", parseErr)
+		}
+		if parsedURL.Scheme != "https" {
+			return fmt.Errorf("invalid --url '%s': scheme must be https", consoleArgs.backplaneURL)
+		}
 		backplaneConfiguration.URL = consoleArgs.backplaneURL
+		logger.Infof("Using backplane URL: %s\n", backplaneConfiguration.URL)
+	} else {
+		// Log the URL from config if custom one isn't provided
+		logger.Infof("Using backplane URL: %s\n", backplaneConfiguration.URL)
 	}
-	logger.Infof("Using backplane URL: %s\n", consoleArgs.backplaneURL)
 
 	// Initialize OCM connection
 	ocmConnection, err := ocm.DefaultOCMInterface.SetupOCMConnection()

--- a/cmd/ocm-backplane/cloud/console.go
+++ b/cmd/ocm-backplane/cloud/console.go
@@ -3,7 +3,6 @@ package cloud
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"os"
 	"strconv"
 
@@ -66,7 +65,7 @@ func init() {
 		&consoleArgs.backplaneURL,
 		"url",
 		"",
-		"URL of backplane API. Must be an HTTPS URL.",
+		"URL of backplane API.",
 	)
 	flags.StringVarP(
 		&consoleArgs.output,
@@ -124,13 +123,6 @@ func runConsole(cmd *cobra.Command, argv []string) (err error) {
 
 	// ============Get Backplane URl ==========================
 	if consoleArgs.backplaneURL != "" { // Overwrite if parameter is set
-		parsedURL, parseErr := url.ParseRequestURI(consoleArgs.backplaneURL)
-		if parseErr != nil {
-			return fmt.Errorf("invalid --url: %v", parseErr)
-		}
-		if parsedURL.Scheme != "https" {
-			return fmt.Errorf("invalid --url '%s': scheme must be https", consoleArgs.backplaneURL)
-		}
 		backplaneConfiguration.URL = consoleArgs.backplaneURL
 	}
 

--- a/cmd/ocm-backplane/cloud/console.go
+++ b/cmd/ocm-backplane/cloud/console.go
@@ -66,7 +66,7 @@ func init() {
 		&consoleArgs.backplaneURL,
 		"url",
 		"",
-		"URL of backplane API",
+		"URL of backplane API. Must be an HTTPS URL.",
 	)
 	flags.StringVarP(
 		&consoleArgs.output,

--- a/cmd/ocm-backplane/cloud/console.go
+++ b/cmd/ocm-backplane/cloud/console.go
@@ -132,11 +132,9 @@ func runConsole(cmd *cobra.Command, argv []string) (err error) {
 			return fmt.Errorf("invalid --url '%s': scheme must be https", consoleArgs.backplaneURL)
 		}
 		backplaneConfiguration.URL = consoleArgs.backplaneURL
-		logger.Infof("Using backplane URL: %s\n", backplaneConfiguration.URL)
-	} else {
-		// Log the URL from config if custom one isn't provided
-		logger.Infof("Using backplane URL: %s\n", backplaneConfiguration.URL)
 	}
+
+	logger.Infof("Using backplane URL: %s\n", backplaneConfiguration.URL)
 
 	// Initialize OCM connection
 	ocmConnection, err := ocm.DefaultOCMInterface.SetupOCMConnection()

--- a/cmd/ocm-backplane/cloud/credentials.go
+++ b/cmd/ocm-backplane/cloud/credentials.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	logger "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -92,6 +93,13 @@ func runCredentials(cmd *cobra.Command, argv []string) error {
 
 	// ============Get Backplane URl ==========================
 	if credentialArgs.backplaneURL != "" { // Overwrite if parameter is set
+		parsedURL, parseErr := url.ParseRequestURI(credentialArgs.backplaneURL)
+		if parseErr != nil {
+			return fmt.Errorf("invalid --url: %v", parseErr)
+		}
+		if parsedURL.Scheme != "https" {
+			return fmt.Errorf("invalid --url '%s': scheme must be https", credentialArgs.backplaneURL)
+		}
 		backplaneConfiguration.URL = credentialArgs.backplaneURL
 	}
 	logger.Infof("Using backplane URL: %s\n", backplaneConfiguration.URL)

--- a/cmd/ocm-backplane/cloud/credentials.go
+++ b/cmd/ocm-backplane/cloud/credentials.go
@@ -3,7 +3,6 @@ package cloud
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 
 	logger "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -42,7 +41,7 @@ func init() {
 		&credentialArgs.backplaneURL,
 		"url",
 		"",
-		"URL of backplane API. Must be an HTTPS URL.",
+		"URL of backplane API.",
 	)
 	flags.StringVarP(
 		&credentialArgs.output,
@@ -93,13 +92,6 @@ func runCredentials(cmd *cobra.Command, argv []string) error {
 
 	// ============Get Backplane URl ==========================
 	if credentialArgs.backplaneURL != "" { // Overwrite if parameter is set
-		parsedURL, parseErr := url.ParseRequestURI(credentialArgs.backplaneURL)
-		if parseErr != nil {
-			return fmt.Errorf("invalid --url: %v", parseErr)
-		}
-		if parsedURL.Scheme != "https" {
-			return fmt.Errorf("invalid --url '%s': scheme must be https", credentialArgs.backplaneURL)
-		}
 		backplaneConfiguration.URL = credentialArgs.backplaneURL
 	}
 	logger.Infof("Using backplane URL: %s\n", backplaneConfiguration.URL)

--- a/cmd/ocm-backplane/cloud/credentials.go
+++ b/cmd/ocm-backplane/cloud/credentials.go
@@ -42,7 +42,7 @@ func init() {
 		&credentialArgs.backplaneURL,
 		"url",
 		"",
-		"URL of backplane API",
+		"URL of backplane API. Must be an HTTPS URL.",
 	)
 	flags.StringVarP(
 		&credentialArgs.output,

--- a/cmd/ocm-backplane/config/config.go
+++ b/cmd/ocm-backplane/config/config.go
@@ -9,6 +9,7 @@ const (
 	URLConfigVar          = "url"
 	SessionConfigVar      = "session-dir"
 	PagerDutyAPIConfigVar = "pd-key"
+	GovcloudVar		  	  = "govcloud"
 )
 
 func NewConfigCmd() *cobra.Command {
@@ -23,6 +24,7 @@ url         Backplane API URL
 proxy-url   Squid proxy URL
 session-dir Backplane CLI session directory
 pd-key		PagerDuty API User Key
+govcloud    Set to true if used in FedRAMP
 `,
 		SilenceUsage: true,
 	}

--- a/cmd/ocm-backplane/config/get.go
+++ b/cmd/ocm-backplane/config/get.go
@@ -40,13 +40,16 @@ func getConfig(cmd *cobra.Command, args []string) error {
 		fmt.Printf("%s: %s\n", SessionConfigVar, config.SessionDirectory)
 	case PagerDutyAPIConfigVar:
 		fmt.Printf("%s: %s\n", PagerDutyAPIConfigVar, config.PagerDutyAPIKey)
+	case GovcloudVar:
+		fmt.Printf("%s: %t\n", GovcloudVar, config.Govcloud)
 	case "all":
 		fmt.Printf("%s: %s\n", URLConfigVar, config.URL)
 		fmt.Printf("%s: %s\n", ProxyURLConfigVar, proxyURL)
 		fmt.Printf("%s: %s\n", SessionConfigVar, config.SessionDirectory)
 		fmt.Printf("%s: %s\n", PagerDutyAPIConfigVar, config.PagerDutyAPIKey)
+		fmt.Printf("%s: %t\n", GovcloudVar, config.Govcloud)
 	default:
-		return fmt.Errorf("supported config variables are %s, %s, %s & %s", URLConfigVar, ProxyURLConfigVar, SessionConfigVar, PagerDutyAPIConfigVar)
+		return fmt.Errorf("supported config variables are %s, %s, %s, %s, & %s", URLConfigVar, ProxyURLConfigVar, SessionConfigVar, PagerDutyAPIConfigVar, GovcloudVar)
 	}
 
 	return nil

--- a/cmd/ocm-backplane/config/set.go
+++ b/cmd/ocm-backplane/config/set.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path"
 
+	"strconv"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/term"
@@ -52,6 +54,11 @@ func setConfig(cmd *cobra.Command, args []string) error {
 			bpConfig.PagerDutyAPIKey = pagerDutyAPIKey
 		}
 
+		if (viper.GetBool("govcloud")) {
+			bpConfig.Govcloud = true
+		} else {
+			bpConfig.Govcloud = false
+		}
 		bpConfig.SessionDirectory = viper.GetString("session-dir")
 		bpConfig.JiraToken = viper.GetString(config.JiraTokenViperKey)
 	}
@@ -93,8 +100,10 @@ func setConfig(cmd *cobra.Command, args []string) error {
 		bpConfig.PagerDutyAPIKey = args[1]
 	case config.JiraTokenViperKey:
 		bpConfig.JiraToken = args[1]
+	case GovcloudVar:
+		bpConfig.Govcloud, err = strconv.ParseBool(args[1])
 	default:
-		return fmt.Errorf("supported config variables are %s, %s, %s, %s & %s", URLConfigVar, ProxyURLConfigVar, SessionConfigVar, PagerDutyAPIConfigVar, config.JiraTokenViperKey)
+		return fmt.Errorf("supported config variables are %s, %s, %s, %s, %s & %s", URLConfigVar, ProxyURLConfigVar, SessionConfigVar, PagerDutyAPIConfigVar, config.JiraTokenViperKey, GovcloudVar)
 	}
 
 	viper.SetConfigType("json")
@@ -103,6 +112,7 @@ func setConfig(cmd *cobra.Command, args []string) error {
 	viper.Set(SessionConfigVar, bpConfig.SessionDirectory)
 	viper.Set(PagerDutyAPIConfigVar, bpConfig.PagerDutyAPIKey)
 	viper.Set(config.JiraTokenViperKey, bpConfig.JiraToken)
+	viper.Set(GovcloudVar, bpConfig.Govcloud)
 
 	err = viper.WriteConfigAs(configPath)
 	if err != nil {

--- a/cmd/ocm-backplane/config/set.go
+++ b/cmd/ocm-backplane/config/set.go
@@ -102,6 +102,9 @@ func setConfig(cmd *cobra.Command, args []string) error {
 		bpConfig.JiraToken = args[1]
 	case GovcloudVar:
 		bpConfig.Govcloud, err = strconv.ParseBool(args[1])
+		if err != nil {
+			return fmt.Errorf("invalid value for %s: %v", GovcloudVar, err)
+		}
 	default:
 		return fmt.Errorf("supported config variables are %s, %s, %s, %s, %s & %s", URLConfigVar, ProxyURLConfigVar, SessionConfigVar, PagerDutyAPIConfigVar, config.JiraTokenViperKey, GovcloudVar)
 	}

--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -164,13 +164,14 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 		"JiraDefaultIssueType":        bpConfig.JiraConfigForAccessRequests.DefaultIssueType,
 		"JiraProdProject":             bpConfig.JiraConfigForAccessRequests.ProdProject,
 		"JiraProdIssueType":           bpConfig.JiraConfigForAccessRequests.ProdIssueType,
+		"AssumeInitialArn":        	   bpConfig.AssumeInitialArn,
 		// ProxyURL is a pointer, so handle nil case
 		"ProxyURL": nil,
 	}
 	if bpConfig.ProxyURL != nil {
 		loggableBpConfig["ProxyURL"] = *bpConfig.ProxyURL
 	}
-	logger.Debugf("Backplane Config File (Non-Sensitive Fields): %+v \n", loggableBpConfig)
+	logger.Debugf("Backplane Config File: %+v \n", loggableBpConfig)
 
 	// login to the cluster based on login type
 	logger.Debugf("Extracting Backplane Cluster ID")

--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -150,28 +150,6 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 	if err != nil {
 		return err
 	}
-	// Log non-sensitive fields of BackplaneConfiguration
-	loggableBpConfig := map[string]interface{}{
-		"URL":                         bpConfig.URL,
-		"SessionDirectory":            bpConfig.SessionDirectory,
-		"ProdEnvName":                 bpConfig.ProdEnvName,
-		"JiraBaseURL":                 bpConfig.JiraBaseURL,
-		"VPNCheckEndpoint":            bpConfig.VPNCheckEndpoint,
-		"ProxyCheckEndpoint":          bpConfig.ProxyCheckEndpoint,
-		"DisplayClusterInfo":          bpConfig.DisplayClusterInfo,
-		"Govcloud":                    bpConfig.Govcloud,
-		"JiraDefaultProject":          bpConfig.JiraConfigForAccessRequests.DefaultProject,
-		"JiraDefaultIssueType":        bpConfig.JiraConfigForAccessRequests.DefaultIssueType,
-		"JiraProdProject":             bpConfig.JiraConfigForAccessRequests.ProdProject,
-		"JiraProdIssueType":           bpConfig.JiraConfigForAccessRequests.ProdIssueType,
-		"AssumeInitialArn":        	   bpConfig.AssumeInitialArn,
-		// ProxyURL is a pointer, so handle nil case
-		"ProxyURL": nil,
-	}
-	if bpConfig.ProxyURL != nil {
-		loggableBpConfig["ProxyURL"] = *bpConfig.ProxyURL
-	}
-	logger.Debugf("Backplane Config File: %+v \n", loggableBpConfig)
 
 	// login to the cluster based on login type
 	logger.Debugf("Extracting Backplane Cluster ID")

--- a/cmd/ocm-backplane/managedJob/createManagedJob.go
+++ b/cmd/ocm-backplane/managedJob/createManagedJob.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -180,6 +181,15 @@ func initParams(cmd *cobra.Command, argv []string) (err error) {
 	options.url, err = cmd.Flags().GetString("url")
 	if err != nil {
 		return err
+	}
+	if options.url != "" {
+		parsedURL, parseErr := url.ParseRequestURI(options.url)
+		if parseErr != nil {
+			return fmt.Errorf("invalid --url: %v", parseErr)
+		}
+		if parsedURL.Scheme != "https" {
+			return fmt.Errorf("invalid --url '%s': scheme must be https", options.url)
+		}
 	}
 
 	// init raw flag

--- a/cmd/ocm-backplane/managedJob/createManagedJob.go
+++ b/cmd/ocm-backplane/managedJob/createManagedJob.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"time"
 
@@ -181,15 +180,6 @@ func initParams(cmd *cobra.Command, argv []string) (err error) {
 	options.url, err = cmd.Flags().GetString("url")
 	if err != nil {
 		return err
-	}
-	if options.url != "" {
-		parsedURL, parseErr := url.ParseRequestURI(options.url)
-		if parseErr != nil {
-			return fmt.Errorf("invalid --url: %v", parseErr)
-		}
-		if parsedURL.Scheme != "https" {
-			return fmt.Errorf("invalid --url '%s': scheme must be https", options.url)
-		}
 	}
 
 	// init raw flag

--- a/cmd/ocm-backplane/script/describeScript.go
+++ b/cmd/ocm-backplane/script/describeScript.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/spf13/cobra"
 
@@ -53,12 +54,21 @@ func newDescribeScriptCmd() *cobra.Command {
 			}
 			// ======== Initialize backplaneURL == ========
 			backplaneHost := urlFlag
-			if backplaneHost == "" {
+			if backplaneHost != "" {
+				// Validate urlFlag if it's provided
+				parsedURL, parseErr := url.ParseRequestURI(urlFlag)
+				if parseErr != nil {
+					return fmt.Errorf("invalid --url: %v", parseErr)
+				}
+				if parsedURL.Scheme != "https" {
+					return fmt.Errorf("invalid --url '%s': scheme must be https", urlFlag)
+				}
+			} else {
+				// If urlFlag is empty, get it from cluster config
 				bpCluster, err := utils.DefaultClusterUtils.GetBackplaneCluster(clusterKey, urlFlag)
 				if err != nil {
 					return err
 				}
-
 				backplaneHost = bpCluster.BackplaneHost
 			}
 

--- a/cmd/ocm-backplane/script/describeScript.go
+++ b/cmd/ocm-backplane/script/describeScript.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 
 	"github.com/spf13/cobra"
 
@@ -54,17 +53,7 @@ func newDescribeScriptCmd() *cobra.Command {
 			}
 			// ======== Initialize backplaneURL == ========
 			backplaneHost := urlFlag
-			if backplaneHost != "" {
-				// Validate urlFlag if it's provided
-				parsedURL, parseErr := url.ParseRequestURI(urlFlag)
-				if parseErr != nil {
-					return fmt.Errorf("invalid --url: %v", parseErr)
-				}
-				if parsedURL.Scheme != "https" {
-					return fmt.Errorf("invalid --url '%s': scheme must be https", urlFlag)
-				}
-			} else {
-				// If urlFlag is empty, get it from cluster config
+			if backplaneHost == "" {
 				bpCluster, err := utils.DefaultClusterUtils.GetBackplaneCluster(clusterKey, urlFlag)
 				if err != nil {
 					return err

--- a/go.mod
+++ b/go.mod
@@ -140,7 +140,7 @@ require (
 	golang.org/x/net v0.37.0 // indirect
 	golang.org/x/oauth2 v0.25.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
-	golang.org/x/sys v0.32.0 // indirect
+	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/time v0.8.0 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -649,8 +649,8 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
-golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
+golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -31,6 +31,7 @@ type AccessRequestsJiraConfiguration struct {
 	ProjectToTransitionsNames map[string]JiraTransitionsNamesForAccessRequests `json:"project-to-transitions-names"`
 }
 
+
 // BackplaneConfiguration represents the configuration for backplane-cli.
 // Note: Please update the validateConfig function if there are any required keys added.
 type BackplaneConfiguration struct {
@@ -47,16 +48,19 @@ type BackplaneConfiguration struct {
 	ProxyCheckEndpoint          string                          `json:"proxy-check-endpoint"`
 	DisplayClusterInfo          bool                            `json:"display-cluster-info"`
 	DisableKubePS1Warning       bool                            `json:"disable-kube-ps1-warning"`
+	Govcloud                    bool                            `json:"govcloud"`
 }
 
 const (
-	prodEnvNameKey                 = "prod-env-name"
-	jiraBaseURLKey                 = "jira-base-url"
-	JiraTokenViperKey              = "jira-token"
-	JiraConfigForAccessRequestsKey = "jira-config-for-access-requests"
-	prodEnvNameDefaultValue        = "production"
-	JiraBaseURLDefaultValue        = "https://issues.redhat.com"
-	proxyTestTimeout               = 10 * time.Second
+	prodEnvNameKey                      = "prod-env-name"
+	jiraBaseURLKey                      = "jira-base-url"
+	JiraTokenViperKey                   = "jira-token"
+	JiraConfigForAccessRequestsKey      = "jira-config-for-access-requests"
+	prodEnvNameDefaultValue             = "production"
+	JiraBaseURLDefaultValue             = "https://issues.redhat.com"
+	proxyTestTimeout                    = 10 * time.Second
+	GovcloudDefaultValue           bool = false
+	GovcloudDefaultValueKey             = "govcloud"
 )
 
 var JiraConfigForAccessRequestsDefaultValue = AccessRequestsJiraConfiguration{
@@ -101,7 +105,7 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 	viper.SetDefault(prodEnvNameKey, prodEnvNameDefaultValue)
 	viper.SetDefault(jiraBaseURLKey, JiraBaseURLDefaultValue)
 	viper.SetDefault(JiraConfigForAccessRequestsKey, JiraConfigForAccessRequestsDefaultValue)
-
+	viper.SetDefault(GovcloudDefaultValueKey, GovcloudDefaultValue)
 	filePath, err := GetConfigFilePath()
 	if err != nil {
 		return bpConfig, err
@@ -114,6 +118,7 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 		// Load config file
 		viper.SetConfigFile(filePath)
 		viper.SetConfigType("json")
+		logger.Debugf("Reading config file %s", filePath)
 
 		if err := viper.ReadInConfig(); err != nil {
 			return bpConfig, err
@@ -124,10 +129,16 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 		logger.Warn(err)
 	}
 
-	// Check if user has explicitly defined proxy; it has higher precedence over the config file
-	err = viper.BindEnv("proxy-url", info.BackplaneProxyEnvName)
-	if err != nil {
-		return bpConfig, err
+	bpConfig.Govcloud = viper.GetBool("govcloud")
+
+	if !(bpConfig.Govcloud) {
+		// Check if user has explicitly defined proxy; it has higher precedence over the config file
+		err = viper.BindEnv("proxy-url", info.BackplaneProxyEnvName)
+		if err != nil {
+			return bpConfig, err
+		}
+	} else {
+		logger.Debug("This is govcloud, no proxy to use")
 	}
 
 	// Warn user if url defined in the config file
@@ -154,17 +165,26 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 		bpConfig.ProxyURL = &proxyURL
 	}
 
+	if (bpConfig.Govcloud) {
+		str := ""
+		bpConfig.ProxyURL = &str
+	}
+
 	bpConfig.SessionDirectory = viper.GetString("session-dir")
 	bpConfig.AssumeInitialArn = viper.GetString("assume-initial-arn")
 	bpConfig.DisplayClusterInfo = viper.GetBool("display-cluster-info")
 	bpConfig.DisableKubePS1Warning = viper.GetBool("disable-kube-ps1-warning")
 
-	// pagerDuty token is optional
-	pagerDutyAPIKey := viper.GetString("pd-key")
-	if pagerDutyAPIKey != "" {
-		bpConfig.PagerDutyAPIKey = pagerDutyAPIKey
+	// pagerDuty token is optional. Don't even check for FedRAMP
+	if !(bpConfig.Govcloud) {
+		pagerDutyAPIKey := viper.GetString("pd-key")
+		if pagerDutyAPIKey != "" {
+			bpConfig.PagerDutyAPIKey = pagerDutyAPIKey
+		} else {
+			logger.Info("No PagerDuty API Key configuration available. This will result in failure of `ocm-backplane login --pd <incident-id>` command.")
+		}
 	} else {
-		logger.Info("No PagerDuty API Key configuration available. This will result in failure of `ocm-backplane login --pd <incident-id>` command.")
+		logger.Debug("No PagerDuty API Key to use in govcloud")
 	}
 
 	// OCM prod env name is optional as there is a default value
@@ -190,9 +210,15 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 	}
 
 	// Load VPN and Proxy check endpoints from the local backplane configuration file
-	bpConfig.VPNCheckEndpoint = viper.GetString("vpn-check-endpoint")
-	bpConfig.ProxyCheckEndpoint = viper.GetString("proxy-check-endpoint")
-
+	// Don't even check for FedRAMP
+	if !(bpConfig.Govcloud) {
+		bpConfig.VPNCheckEndpoint = viper.GetString("vpn-check-endpoint")
+		bpConfig.ProxyCheckEndpoint = viper.GetString("proxy-check-endpoint")
+	} else {
+		logger.Debug("This is govcloud, no VPN and Proxy check endpoints to use")
+		bpConfig.VPNCheckEndpoint = ""
+		bpConfig.ProxyCheckEndpoint = ""
+	}
 	return bpConfig, nil
 }
 
@@ -309,9 +335,12 @@ loop:
 
 func validateConfig() error {
 
-	// Validate the proxy url
-	if viper.GetStringSlice("proxy-url") == nil && os.Getenv(info.BackplaneProxyEnvName) == "" {
-		return fmt.Errorf("proxy-url must be set explicitly in either config file or via the environment HTTPS_PROXY")
+	// No Proxy used in FedRAMP
+	if !(viper.GetBool("govcloud")) {
+		// Validate the proxy url
+		if viper.GetStringSlice("proxy-url") == nil && os.Getenv(info.BackplaneProxyEnvName) == "" {
+			return fmt.Errorf("proxy-url must be set explicitly in either config file or via the environment HTTPS_PROXY")
+		}
 	}
 
 	return nil

--- a/pkg/cli/globalflags/globalflags.go
+++ b/pkg/cli/globalflags/globalflags.go
@@ -17,7 +17,7 @@ func AddGlobalFlags(cmd *cobra.Command, opts *GlobalOptions) {
 		&opts.BackplaneURL,
 		"url",
 		"",
-		"URL of backplane API",
+		"URL of backplane API. Must be an HTTPS URL.",
 	)
 	cmd.PersistentFlags().StringVar(
 		&opts.ProxyURL,

--- a/pkg/cli/globalflags/globalflags.go
+++ b/pkg/cli/globalflags/globalflags.go
@@ -17,7 +17,7 @@ func AddGlobalFlags(cmd *cobra.Command, opts *GlobalOptions) {
 		&opts.BackplaneURL,
 		"url",
 		"",
-		"URL of backplane API. Must be an HTTPS URL.",
+		"URL of backplane API",
 	)
 	cmd.PersistentFlags().StringVar(
 		&opts.ProxyURL,

--- a/pkg/login/printClusterInfo.go
+++ b/pkg/login/printClusterInfo.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openshift/backplane-cli/pkg/ocm"
 	logger "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 //displayClusterInfo retrieves and displays basic information about the target cluster.
@@ -42,16 +43,20 @@ func GetAccessProtectionStatus(clusterID string) string {
 	if ocmConnection != nil {
 		defer ocmConnection.Close()
 	}
-	enabled, err := ocm.DefaultOCMInterface.IsClusterAccessProtectionEnabled(ocmConnection, clusterID)
-	if err != nil {
-		fmt.Println("Error retrieving access protection status: ", err)
-		return "Error retrieving access protection status: " + err.Error()
-	}
 
 	accessProtectionStatus := "Disabled"
-	if enabled {
-		accessProtectionStatus = "Enabled"
+
+	if !(viper.GetBool("govcloud")){
+		enabled, err := ocm.DefaultOCMInterface.IsClusterAccessProtectionEnabled(ocmConnection, clusterID)
+		if err != nil {
+			fmt.Println("Error retrieving access protection status: ", err)
+			return "Error retrieving access protection status: " + err.Error()
+		}
+		if enabled {
+			accessProtectionStatus = "Enabled"
+		}
 	}
+	
 	fmt.Printf("%-25s %s\n", "Access Protection:", accessProtectionStatus)
 
 	return accessProtectionStatus


### PR DESCRIPTION
### What type of PR is this?

- [X] Bug
- [X] Feature
- [X] Documentation
- [ ] Test Coverage
- [X] Clean Up
- [ ] Others
### What this PR does / Why we need it?
FedRAMP does not have a proxy and app-gate VPN is required.  This will remove the noise from the output for govcloud users.
A new config item is added to identify govcloud.  When `govcloud: true`

### Which Jira/Github issue(s) does this PR fix?
[OSD-29893](https://issues.redhat.com//browse/OSD-29893)

### Special notes for your reviewer
Debugging tests completed
```
{
    "version": "0.2.0",
    "configurations": [

        {
			"name": "Login-OSD-West",
            "type": "go",
            "request": "launch",
            "mode": "auto",
            "program": "/config/workspace/backplane-cli/cmd/ocm-backplane/",
			"env": {},
			"args": [
                "login",
                "--url=https://api-backplane-int.apps.REMOVED.q3zc.i1.devshiftusgov.com",
                "REMOVED",
                "--verbosity=debug"
             ]
        },
        {
			"name": "Login-backplane-no-debug",
            "type": "go",
            "request": "launch",
            "mode": "auto",
            "program": "/config/workspace/backplane-cli/cmd/ocm-backplane/",
			"env": {},
			"args": [
                "login",
                "--url=https://api-backplane-int.apps.REMOVED.q3zc.i1.devshiftusgov.com",
                "REMOVED"
             ]
        },
        {
			"name": "Login-rosa-West",
            "type": "go",
            "request": "launch",
            "mode": "auto",
            "program": "/config/workspace/backplane-cli/cmd/ocm-backplane/",
			"env": {},
			"args": [
                "login",
                "--url=https://api-backplane-int.apps.REMOVED.q3zc.i1.devshiftusgov.com",
                "dedgardev",
                "--verbosity=debug"
             ]
        },
        {
			"name": "Login-HCP-West",
            "type": "go",
            "request": "launch",
            "mode": "auto",
            "program": "/config/workspace/backplane-cli/cmd/ocm-backplane/",
			"env": {},
			"args": [
                "login",
                "--url=https://api-backplane-int.apps.REMOVED.q3zc.i1.devshiftusgov.com",
                "REMOVED",
                "--verbosity=debug"
             ]
        },
        {
			"name": "Login-rosa-East",
            "type": "go",
            "request": "launch",
            "mode": "auto",
            "program": "/config/workspace/backplane-cli/cmd/ocm-backplane/",
			"env": {},
			"args": [
                "login",
                "--url=https://api-backplane-int.apps.REMOVED.q3zc.i1.devshiftusgov.com",
                "rerojas-test",
                "--verbosity=debug"
             ]
        },
        {
			"name": "Status",
            "type": "go",
            "request": "launch",
            "mode": "auto",
            "program": "/config/workspace/backplane-cli/cmd/ocm-backplane/",
			"env": {},
			"args": [
                "status"
             ]
        },
        {
			"name": "Config-set",
            "type": "go",
            "request": "launch",
            "mode": "auto",
            "program": "/config/workspace/backplane-cli/cmd/ocm-backplane/",
			"env": {},
			"args": [
                "config",
                "set",
                "govcloud",
                "true"
             ]
        },
        {
			"name": "Config-get-all",
            "type": "go",
            "request": "launch",
            "mode": "auto",
            "program": "/config/workspace/backplane-cli/cmd/ocm-backplane/",
			"env": {},
			"args": [
                "config",
                "get",
                "all"
             ]
        },
        {
			"name": "Elevate-get-all-pods",
            "type": "go",
            "request": "launch",
            "mode": "auto",
            "program": "/config/workspace/backplane-cli/cmd/ocm-backplane/",
			"env": {},
			"args": [
                "elevate",
                "test",
                "--verbosity=debug",
                "--",
                "get",
                "pods",
                "-A"
             ]
        }    
    ]
}
```

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [X] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
