### PR TITLE
Fixed manifestwork fetch command in the service cluster

### DIFF
--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -276,7 +276,7 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 		if !isHostedControlPlane {
 			return fmt.Errorf("manifestworks are only available for hosted control plane clusters")
 		}
-		listManifestWork := fmt.Sprintf("oc get manifestworks -n %s -l api.openshift.com/id=%s", managingClusterName, targetClusterID)
+		listManifestWork := fmt.Sprintf("ocm backplane elevate -- oc get manifestworks -n %s -l api.openshift.com/id=%s", managingClusterName, targetClusterID)
 
 		fmt.Println("A list of associated manifestwork for your given cluster can be found using:")
 		fmt.Println("\t", listManifestWork)


### PR DESCRIPTION
### What type of PR is this?

- [*] Bug
- [ ] Feature
- [ ] Documentation
- [ ] Test Coverage
- [ ] Clean Up
- [ ] Others
### What this PR does / Why we need it?

Fixed manifestworks fetch command since it's only accessible via backplane admin 

### Which Jira/Github issue(s) does this PR fix?

- Related Issue #
- Closes #

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
