### PR TITLE
OSD-28505: feat(Update Backplane to show announcements during cluster login)

### DIFF
--- a/cmd/ocm-backplane/config/config.go
+++ b/cmd/ocm-backplane/config/config.go
@@ -23,6 +23,7 @@ url         Backplane API URL
 proxy-url   Squid proxy URL
 session-dir Backplane CLI session directory
 pd-key		PagerDuty API User Key
+plugins		Comma separated list of plugins. Currently supported plugins: handover-announcements
 `,
 		SilenceUsage: true,
 	}

--- a/cmd/ocm-backplane/config/get.go
+++ b/cmd/ocm-backplane/config/get.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -21,32 +22,43 @@ func newGetCmd() *cobra.Command {
 }
 
 func getConfig(cmd *cobra.Command, args []string) error {
-	config, err := config.GetBackplaneConfiguration()
+	bpConfig, err := config.GetBackplaneConfiguration()
 	if err != nil {
 		return err
 	}
 
 	proxyURL := ""
-	if config.ProxyURL != nil {
-		proxyURL = *config.ProxyURL
+	if bpConfig.ProxyURL != nil {
+		proxyURL = *bpConfig.ProxyURL
 	}
 
 	switch args[0] {
 	case URLConfigVar:
-		fmt.Printf("%s: %s\n", URLConfigVar, config.URL)
+		fmt.Printf("%s: %s\n", URLConfigVar, bpConfig.URL)
 	case ProxyURLConfigVar:
 		fmt.Printf("%s: %s\n", ProxyURLConfigVar, proxyURL)
 	case SessionConfigVar:
-		fmt.Printf("%s: %s\n", SessionConfigVar, config.SessionDirectory)
+		fmt.Printf("%s: %s\n", SessionConfigVar, bpConfig.SessionDirectory)
 	case PagerDutyAPIConfigVar:
-		fmt.Printf("%s: %s\n", PagerDutyAPIConfigVar, config.PagerDutyAPIKey)
+		fmt.Printf("%s: %s\n", PagerDutyAPIConfigVar, bpConfig.PagerDutyAPIKey)
+	case config.PluginViperKey:
+		if len(bpConfig.PluginList) == 0 {
+			fmt.Println("No plugins configured")
+		} else {
+			fmt.Printf("%s: [%s]\n", config.PluginViperKey, strings.Join(bpConfig.PluginList, ","))
+		}
 	case "all":
-		fmt.Printf("%s: %s\n", URLConfigVar, config.URL)
+		fmt.Printf("%s: %s\n", URLConfigVar, bpConfig.URL)
 		fmt.Printf("%s: %s\n", ProxyURLConfigVar, proxyURL)
-		fmt.Printf("%s: %s\n", SessionConfigVar, config.SessionDirectory)
-		fmt.Printf("%s: %s\n", PagerDutyAPIConfigVar, config.PagerDutyAPIKey)
+		fmt.Printf("%s: %s\n", SessionConfigVar, bpConfig.SessionDirectory)
+		fmt.Printf("%s: %s\n", PagerDutyAPIConfigVar, bpConfig.PagerDutyAPIKey)
+		if len(bpConfig.PluginList) == 0 {
+			fmt.Println("No plugins configured")
+		} else {
+			fmt.Printf("%s: [%s]\n", config.PluginViperKey, strings.Join(bpConfig.PluginList, ","))
+		}
 	default:
-		return fmt.Errorf("supported config variables are %s, %s, %s & %s", URLConfigVar, ProxyURLConfigVar, SessionConfigVar, PagerDutyAPIConfigVar)
+		return fmt.Errorf("supported config variables are %s, %s, %s, %s & %s", URLConfigVar, ProxyURLConfigVar, SessionConfigVar, PagerDutyAPIConfigVar, config.PluginViperKey)
 	}
 
 	return nil

--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openshift/backplane-cli/pkg/login"
 	"github.com/openshift/backplane-cli/pkg/ocm"
 	"github.com/openshift/backplane-cli/pkg/pagerduty"
+	"github.com/openshift/backplane-cli/pkg/plugin/announcements"
 	"github.com/openshift/backplane-cli/pkg/utils"
 )
 
@@ -222,6 +223,16 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 	if bpConfig.DisplayClusterInfo {
 		if err := login.PrintClusterInfo(clusterID); err != nil {
 			return fmt.Errorf("failed to print cluster info: %v", err)
+		}
+	}
+
+	// If handover-announcements plugin is enabled
+	// Print related handover announcements before changing the cluster
+	if bpConfig.Plugins["handover-announcements"] {
+		logger.Debug("Plugin handover-announcements is enabled. Getting related handover ..")
+		err = announcements.HandoverAnnouncements(clusterID)
+		if err != nil {
+			logger.Debugf("Error in getting related handover announcements: %v", err)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.20.1
+	github.com/stretchr/testify v1.10.0
 	github.com/trivago/tgo v1.0.7
 	golang.org/x/term v0.31.0
 	gopkg.in/AlecAivazis/survey.v1 v1.8.8
@@ -42,6 +43,8 @@ require (
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/mock v0.5.0 // indirect
 	golang.org/x/tools v0.31.0 // indirect

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -196,11 +196,7 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 	bpConfig.VPNCheckEndpoint = viper.GetString("vpn-check-endpoint")
 	bpConfig.ProxyCheckEndpoint = viper.GetString("proxy-check-endpoint")
 
-	bpConfig.PluginList = viper.GetStringSlice("plugins")
-	bpConfig.Plugins = map[string]bool{}
-	for _, name := range bpConfig.PluginList {
-		bpConfig.Plugins[name] = true
-	}
+	bpConfig.LoadPlugins()
 
 	return bpConfig, nil
 }
@@ -403,4 +399,12 @@ func (config *BackplaneConfiguration) testHTTPRequestToBackplaneAPI() (bool, err
 	}
 
 	return true, nil
+}
+
+func (c *BackplaneConfiguration) LoadPlugins() {
+	c.PluginList = viper.GetStringSlice("plugins")
+	c.Plugins = make(map[string]bool, len(c.PluginList))
+	for _, name := range c.PluginList {
+		c.Plugins[name] = true
+	}
 }

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -47,6 +47,8 @@ type BackplaneConfiguration struct {
 	ProxyCheckEndpoint          string                          `json:"proxy-check-endpoint"`
 	DisplayClusterInfo          bool                            `json:"display-cluster-info"`
 	DisableKubePS1Warning       bool                            `json:"disable-kube-ps1-warning"`
+	PluginList                  []string                        `json:"plugins"`
+	Plugins                     map[string]bool                 `json:"-"`
 }
 
 const (
@@ -57,6 +59,7 @@ const (
 	prodEnvNameDefaultValue        = "production"
 	JiraBaseURLDefaultValue        = "https://issues.redhat.com"
 	proxyTestTimeout               = 10 * time.Second
+	PluginViperKey                 = "plugins"
 )
 
 var JiraConfigForAccessRequestsDefaultValue = AccessRequestsJiraConfiguration{
@@ -192,6 +195,12 @@ func GetBackplaneConfiguration() (bpConfig BackplaneConfiguration, err error) {
 	// Load VPN and Proxy check endpoints from the local backplane configuration file
 	bpConfig.VPNCheckEndpoint = viper.GetString("vpn-check-endpoint")
 	bpConfig.ProxyCheckEndpoint = viper.GetString("proxy-check-endpoint")
+
+	bpConfig.PluginList = viper.GetStringSlice("plugins")
+	bpConfig.Plugins = map[string]bool{}
+	for _, name := range bpConfig.PluginList {
+		bpConfig.Plugins[name] = true
+	}
 
 	return bpConfig, nil
 }

--- a/pkg/jira/mocks/jiraMock.go
+++ b/pkg/jira/mocks/jiraMock.go
@@ -35,9 +35,9 @@ func (m *MockIssueServiceInterface) EXPECT() *MockIssueServiceInterfaceMockRecor
 }
 
 // Create mocks base method.
-func (m *MockIssueServiceInterface) Create(arg0 *jira.Issue) (*jira.Issue, *jira.Response, error) {
+func (m *MockIssueServiceInterface) Create(issue *jira.Issue) (*jira.Issue, *jira.Response, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", arg0)
+	ret := m.ctrl.Call(m, "Create", issue)
 	ret0, _ := ret[0].(*jira.Issue)
 	ret1, _ := ret[1].(*jira.Response)
 	ret2, _ := ret[2].(error)
@@ -45,30 +45,30 @@ func (m *MockIssueServiceInterface) Create(arg0 *jira.Issue) (*jira.Issue, *jira
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockIssueServiceInterfaceMockRecorder) Create(arg0 interface{}) *gomock.Call {
+func (mr *MockIssueServiceInterfaceMockRecorder) Create(issue interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockIssueServiceInterface)(nil).Create), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockIssueServiceInterface)(nil).Create), issue)
 }
 
 // DoTransition mocks base method.
-func (m *MockIssueServiceInterface) DoTransition(arg0, arg1 string) (*jira.Response, error) {
+func (m *MockIssueServiceInterface) DoTransition(ticketID, transitionID string) (*jira.Response, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DoTransition", arg0, arg1)
+	ret := m.ctrl.Call(m, "DoTransition", ticketID, transitionID)
 	ret0, _ := ret[0].(*jira.Response)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DoTransition indicates an expected call of DoTransition.
-func (mr *MockIssueServiceInterfaceMockRecorder) DoTransition(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockIssueServiceInterfaceMockRecorder) DoTransition(ticketID, transitionID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoTransition", reflect.TypeOf((*MockIssueServiceInterface)(nil).DoTransition), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoTransition", reflect.TypeOf((*MockIssueServiceInterface)(nil).DoTransition), ticketID, transitionID)
 }
 
 // Get mocks base method.
-func (m *MockIssueServiceInterface) Get(arg0 string, arg1 *jira.GetQueryOptions) (*jira.Issue, *jira.Response, error) {
+func (m *MockIssueServiceInterface) Get(issueID string, options *jira.GetQueryOptions) (*jira.Issue, *jira.Response, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", arg0, arg1)
+	ret := m.ctrl.Call(m, "Get", issueID, options)
 	ret0, _ := ret[0].(*jira.Issue)
 	ret1, _ := ret[1].(*jira.Response)
 	ret2, _ := ret[2].(error)
@@ -76,15 +76,15 @@ func (m *MockIssueServiceInterface) Get(arg0 string, arg1 *jira.GetQueryOptions)
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockIssueServiceInterfaceMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockIssueServiceInterfaceMockRecorder) Get(issueID, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockIssueServiceInterface)(nil).Get), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockIssueServiceInterface)(nil).Get), issueID, options)
 }
 
 // GetTransitions mocks base method.
-func (m *MockIssueServiceInterface) GetTransitions(arg0 string) ([]jira.Transition, *jira.Response, error) {
+func (m *MockIssueServiceInterface) GetTransitions(id string) ([]jira.Transition, *jira.Response, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTransitions", arg0)
+	ret := m.ctrl.Call(m, "GetTransitions", id)
 	ret0, _ := ret[0].([]jira.Transition)
 	ret1, _ := ret[1].(*jira.Response)
 	ret2, _ := ret[2].(error)
@@ -92,15 +92,15 @@ func (m *MockIssueServiceInterface) GetTransitions(arg0 string) ([]jira.Transiti
 }
 
 // GetTransitions indicates an expected call of GetTransitions.
-func (mr *MockIssueServiceInterfaceMockRecorder) GetTransitions(arg0 interface{}) *gomock.Call {
+func (mr *MockIssueServiceInterfaceMockRecorder) GetTransitions(id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransitions", reflect.TypeOf((*MockIssueServiceInterface)(nil).GetTransitions), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransitions", reflect.TypeOf((*MockIssueServiceInterface)(nil).GetTransitions), id)
 }
 
 // Update mocks base method.
-func (m *MockIssueServiceInterface) Update(arg0 *jira.Issue) (*jira.Issue, *jira.Response, error) {
+func (m *MockIssueServiceInterface) Update(issue *jira.Issue) (*jira.Issue, *jira.Response, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", arg0)
+	ret := m.ctrl.Call(m, "Update", issue)
 	ret0, _ := ret[0].(*jira.Issue)
 	ret1, _ := ret[1].(*jira.Response)
 	ret2, _ := ret[2].(error)
@@ -108,7 +108,45 @@ func (m *MockIssueServiceInterface) Update(arg0 *jira.Issue) (*jira.Issue, *jira
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockIssueServiceInterfaceMockRecorder) Update(arg0 interface{}) *gomock.Call {
+func (mr *MockIssueServiceInterfaceMockRecorder) Update(issue interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockIssueServiceInterface)(nil).Update), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockIssueServiceInterface)(nil).Update), issue)
+}
+
+// MockIssueServiceGetter is a mock of IssueServiceGetter interface.
+type MockIssueServiceGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockIssueServiceGetterMockRecorder
+}
+
+// MockIssueServiceGetterMockRecorder is the mock recorder for MockIssueServiceGetter.
+type MockIssueServiceGetterMockRecorder struct {
+	mock *MockIssueServiceGetter
+}
+
+// NewMockIssueServiceGetter creates a new mock instance.
+func NewMockIssueServiceGetter(ctrl *gomock.Controller) *MockIssueServiceGetter {
+	mock := &MockIssueServiceGetter{ctrl: ctrl}
+	mock.recorder = &MockIssueServiceGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockIssueServiceGetter) EXPECT() *MockIssueServiceGetterMockRecorder {
+	return m.recorder
+}
+
+// GetIssueService mocks base method.
+func (m *MockIssueServiceGetter) GetIssueService() (*jira.IssueService, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIssueService")
+	ret0, _ := ret[0].(*jira.IssueService)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIssueService indicates an expected call of GetIssueService.
+func (mr *MockIssueServiceGetterMockRecorder) GetIssueService() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIssueService", reflect.TypeOf((*MockIssueServiceGetter)(nil).GetIssueService))
 }

--- a/pkg/plugin/announcements/announcements.go
+++ b/pkg/plugin/announcements/announcements.go
@@ -1,0 +1,67 @@
+package announcements
+
+import (
+	"fmt"
+
+	"github.com/openshift/backplane-cli/pkg/cli/config"
+)
+
+type fieldQuery struct {
+	Field    string
+	Operator string
+	Value    string
+}
+
+// relatedHandoverAnnouncements returns related handover announcements queried from JIRA
+func relatedHandoverAnnouncements(cluster *clusterRecord) error {
+	service, err := NewHandoverProjectService()
+	if err != nil {
+		return fmt.Errorf("failed to create project service: %v", err)
+	}
+	return relatedHandoverAnnouncementsWithService(cluster, service)
+}
+
+// helper to allow injection of mock in tests
+func relatedHandoverAnnouncementsWithService(cluster *clusterRecord, service issueSearcher) error {
+	projectKey := JiraHandoverAnnouncementProjectKey
+
+	baseQueries := []fieldQuery{
+		{Field: "Cluster ID", Value: cluster.ClusterID, Operator: "~"},
+		{Field: "Cluster ID", Value: cluster.ExternalID, Operator: "~"},
+	}
+	jql := buildJQL(projectKey, baseQueries)
+	issues, err := service.SearchIssues(jql)
+	if err != nil {
+		return fmt.Errorf("failed to get issues: %v", err)
+	}
+
+	extendedQueries := []fieldQuery{
+		{Field: "Cluster ID", Value: "None,N/A,All", Operator: "~*"},
+		{Field: "Customer Name", Value: cluster.OrgName, Operator: "~"},
+		{Field: "Products", Value: cluster.Product, Operator: "="},
+		{Field: "affectedVersion", Value: formatVersion(cluster.Version), Operator: "~"},
+	}
+
+	jql = buildJQL(projectKey, extendedQueries)
+	otherIssues, err := service.SearchIssues(jql)
+	if err != nil {
+		return fmt.Errorf("failed to get issues: %v", err)
+	}
+
+	fmt.Printf("Related Handover Announcements:\n")
+	for _, i := range otherIssues {
+		if isValidMatch(i, *cluster) {
+			issues = append(issues, i)
+		}
+	}
+
+	for _, i := range issues {
+		fmt.Printf("[%s]: %+v\n", i.Key, i.Fields.Summary)
+		fmt.Printf("- Link: %s/browse/%s\n\n", config.JiraBaseURLDefaultValue, i.Key)
+	}
+
+	if len(issues) == 0 {
+		fmt.Println("None")
+	}
+	return nil
+}

--- a/pkg/plugin/announcements/announcements_test.go
+++ b/pkg/plugin/announcements/announcements_test.go
@@ -1,0 +1,71 @@
+package announcements
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/andygrunwald/go-jira"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockIssueSearcher struct {
+	mock.Mock
+}
+
+func (m *mockIssueSearcher) SearchIssues(jql string) ([]jira.Issue, error) {
+	args := m.Called(jql)
+	return args.Get(0).([]jira.Issue), args.Error(1)
+}
+
+func TestRelatedHandoverAnnouncements_Success(t *testing.T) {
+	mockService := new(mockIssueSearcher)
+
+	cluster := &clusterRecord{
+		ClusterID:  "123",
+		ExternalID: "abc",
+		OrgName:    "Red Hat",
+		Product:    "OpenShift Dedicated",
+		Version:    "4.14.7",
+	}
+
+	baseIssues := []jira.Issue{
+		{Key: "JIRA-123", Fields: &jira.IssueFields{Summary: "Base issue"}},
+	}
+	extendedIssues := []jira.Issue{
+		{Key: "JIRA-456", Fields: &jira.IssueFields{
+			Summary: "Extended issue",
+			Unknowns: map[string]interface{}{
+				productCustomField: []interface{}{
+					map[string]interface{}{"value": "OpenShift Dedicated"},
+				},
+				customerNameCustomField: "Red Hat",
+			},
+			AffectsVersions: []*jira.AffectsVersion{{Name: "4.14.0"}},
+		}},
+	}
+
+	mockService.On("SearchIssues", mock.MatchedBy(func(jql string) bool {
+		return strings.Contains(jql, "Cluster ID")
+	})).Return(baseIssues, nil).Once()
+
+	mockService.On("SearchIssues", mock.MatchedBy(func(jql string) bool {
+		return strings.Contains(jql, "Customer Name")
+	})).Return(extendedIssues, nil).Once()
+
+	err := relatedHandoverAnnouncementsWithService(cluster, mockService)
+	assert.NoError(t, err)
+	mockService.AssertExpectations(t)
+}
+
+func TestRelatedHandoverAnnouncements_SearchFailure(t *testing.T) {
+	mockService := new(mockIssueSearcher)
+	mockService.On("SearchIssues", mock.Anything).Return([]jira.Issue{}, errors.New("search failed")).Once()
+
+	cluster := &clusterRecord{}
+
+	err := relatedHandoverAnnouncementsWithService(cluster, mockService)
+	assert.ErrorContains(t, err, "failed to get issues")
+	mockService.AssertExpectations(t)
+}

--- a/pkg/plugin/announcements/constants.go
+++ b/pkg/plugin/announcements/constants.go
@@ -1,0 +1,8 @@
+package announcements
+
+// Constants used in the plugin
+const (
+	JiraHandoverAnnouncementProjectKey = "SRE Platform HandOver Announcements"
+	productCustomField                 = "customfield_12319040"
+	customerNameCustomField            = "customfield_12310160"
+)

--- a/pkg/plugin/announcements/init.go
+++ b/pkg/plugin/announcements/init.go
@@ -1,0 +1,14 @@
+package announcements
+
+func HandoverAnnouncements(clusterKey string) error {
+	clusterRecord, err := createClusterRecord(clusterKey)
+	if err != nil {
+		return err
+	}
+
+	err = relatedHandoverAnnouncements(clusterRecord)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/plugin/announcements/ocm.go
+++ b/pkg/plugin/announcements/ocm.go
@@ -18,7 +18,7 @@ type clusterRecord struct {
 
 // Create a Cluster Record Object required for the handover announcements
 func createClusterRecord(clusterKey string) (*clusterRecord, error) {
-	var ClusterRecord *clusterRecord = &clusterRecord{}
+	var ClusterRecord = &clusterRecord{}
 	connection, err := ocm.DefaultOCMInterface.SetupOCMConnection()
 	if err != nil {
 		return ClusterRecord, fmt.Errorf("failed to create OCM connection: %v", err)

--- a/pkg/plugin/announcements/ocm.go
+++ b/pkg/plugin/announcements/ocm.go
@@ -1,0 +1,99 @@
+package announcements
+
+import (
+	"fmt"
+
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
+	"github.com/openshift/backplane-cli/pkg/ocm"
+)
+
+type clusterRecord struct {
+	ClusterID  string
+	ExternalID string
+	OrgName    string
+	Version    string
+	Product    string
+}
+
+// Create a Cluster Record Object required for the handover announcements
+func createClusterRecord(clusterKey string) (*clusterRecord, error) {
+	var ClusterRecord *clusterRecord = &clusterRecord{}
+	connection, err := ocm.DefaultOCMInterface.SetupOCMConnection()
+	if err != nil {
+		return ClusterRecord, fmt.Errorf("failed to create OCM connection: %v", err)
+	}
+	defer connection.Close()
+	// Directly Querying for the Cluster Object as this has been identified to be the correct one
+	res, err := connection.ClustersMgmt().V1().Clusters().Cluster(clusterKey).Get().Send()
+	if err != nil {
+		return ClusterRecord, fmt.Errorf("unable get get cluster status: %v", err)
+	}
+
+	cluster := res.Body()
+	org, err := getOrganization(connection, clusterKey)
+	if err != nil {
+		return ClusterRecord, fmt.Errorf("failed to get org '%s': %v", clusterKey, err)
+	}
+
+	ClusterRecord.ClusterID = cluster.ID()
+	ClusterRecord.ExternalID = cluster.ExternalID()
+	ClusterRecord.Version = cluster.Version().RawID()
+	ClusterRecord.Product = determineClusterProduct(cluster.Product().ID(), cluster.Hypershift().Enabled())
+	ClusterRecord.OrgName = org.Name()
+
+	return ClusterRecord, nil
+}
+
+// Get the organization for the cluster
+
+func getOrganization(connection *sdk.Connection, key string) (*amv1.Organization, error) {
+	subscription, err := getSubscription(connection, key)
+	if err != nil {
+		return nil, err
+	}
+	orgResponse, err := connection.AccountsMgmt().V1().Organizations().Organization(subscription.OrganizationID()).Get().Send()
+	if err != nil {
+		return nil, err
+	}
+	return orgResponse.Body(), nil
+}
+
+// Get the subscription for the cluster
+
+func getSubscription(connection *sdk.Connection, key string) (subscription *amv1.Subscription, err error) {
+	// Prepare the resources that we will be using:
+	subsResource := connection.AccountsMgmt().V1().Subscriptions()
+
+	// Try to find a matching subscription:
+	subsSearch := fmt.Sprintf(
+		"(display_name = '%s' or cluster_id = '%s' or external_cluster_id = '%s' or id = '%s')",
+		key, key, key, key)
+	subsListResponse, err := subsResource.List().Parameter("search", subsSearch).Send()
+	if err != nil {
+		err = fmt.Errorf("can't retrieve subscription for key '%s': %v", key, err)
+		return
+	}
+
+	// If there is exactly one matching subscription then return the corresponding cluster:
+	subsTotal := subsListResponse.Total()
+	if subsTotal == 1 {
+		return subsListResponse.Items().Get(0), nil
+	}
+
+	// If there are multiple subscriptions that match the key then we should report it as
+	// an error:
+	if subsTotal > 1 {
+		err = fmt.Errorf(
+			"there are %d subscriptions with cluster identifier or name '%s'",
+			subsTotal, key,
+		)
+		return
+	}
+	// If we are here then there are no subscriptions matching the passed key:
+	err = fmt.Errorf(
+		"there are no subscriptions with identifier or name '%s'",
+		key,
+	)
+	return
+}

--- a/pkg/plugin/announcements/projectservice.go
+++ b/pkg/plugin/announcements/projectservice.go
@@ -1,0 +1,33 @@
+package announcements
+
+import (
+	"github.com/andygrunwald/go-jira"
+	bpJira "github.com/openshift/backplane-cli/pkg/jira"
+)
+
+type HandoverProjectService struct {
+	jiraClient *jira.Client
+}
+
+type issueSearcher interface {
+	SearchIssues(jql string) ([]jira.Issue, error)
+}
+
+func NewHandoverProjectService() (*HandoverProjectService, error) {
+	client, err := bpJira.CreateJiraClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return &HandoverProjectService{jiraClient: client}, nil
+}
+
+func (ps *HandoverProjectService) SearchIssues(jql string) ([]jira.Issue, error) {
+	issues, _, err := ps.jiraClient.Issue.Search(jql, &jira.SearchOptions{
+		MaxResults: 50,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return issues, nil
+}

--- a/pkg/plugin/announcements/projectservice_test.go
+++ b/pkg/plugin/announcements/projectservice_test.go
@@ -1,0 +1,14 @@
+package announcements
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandoverProjectService_ImplementsIssueSearcher(t *testing.T) {
+	var _ issueSearcher = &HandoverProjectService{} // compile-time check
+
+	// No runtime tests here because this depends on external Jira client.
+	assert.True(t, true)
+}

--- a/pkg/plugin/announcements/utils.go
+++ b/pkg/plugin/announcements/utils.go
@@ -32,7 +32,8 @@ func hasProduct(items []interface{}, target string) bool {
 func buildJQL(projectKey string, filters []fieldQuery) string {
 	var conditions []string
 	for _, q := range filters {
-		if q.Operator == "~*" {
+		switch q.Operator {
+		case "~*":
 			values := strings.Split(q.Value, ",")
 			var orParts []string
 			for _, v := range values {
@@ -40,11 +41,13 @@ func buildJQL(projectKey string, filters []fieldQuery) string {
 					fmt.Sprintf(`(project = "%s" AND "%s" ~ "%s")`, projectKey, q.Field, strings.TrimSpace(v)))
 			}
 			conditions = append(conditions, "("+strings.Join(orParts, " OR ")+")")
-		} else if q.Operator == "in" {
+
+		case "in":
 			conditions = append(conditions,
 				fmt.Sprintf(`(project = "%s" AND "%s" in (%s))`, projectKey, q.Field, q.Value),
 			)
-		} else {
+
+		default:
 			conditions = append(conditions,
 				fmt.Sprintf(`(project = "%s" AND "%s" %s "%s")`, projectKey, q.Field, q.Operator, q.Value),
 			)
@@ -98,14 +101,12 @@ func isValidMatch(i jira.Issue, cluster clusterRecord) bool {
 	versionMatch := false
 	clusterFormattedVersion := formatVersion(cluster.Version)
 
-	if versionRaw != nil {
-		for _, v := range versionRaw {
-			if v != nil {
-				vFormatted := formatVersion(v.Name)
-				if vFormatted == clusterFormattedVersion || isIgnored(v.Name) {
-					versionMatch = true
-					break
-				}
+	for _, v := range versionRaw {
+		if v != nil {
+			vFormatted := formatVersion(v.Name)
+			if vFormatted == clusterFormattedVersion || isIgnored(v.Name) {
+				versionMatch = true
+				break
 			}
 		}
 	}

--- a/pkg/plugin/announcements/utils.go
+++ b/pkg/plugin/announcements/utils.go
@@ -1,0 +1,126 @@
+package announcements
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/andygrunwald/go-jira"
+)
+
+func determineClusterProduct(productID string, isHCP bool) (productName string) {
+	if productID == "rosa" && isHCP {
+		productName = "Red Hat OpenShift on AWS with Hosted Control Planes"
+	} else if productID == "rosa" {
+		productName = "Red Hat OpenShift on AWS"
+	} else if productID == "osd" {
+		productName = "OpenShift Dedicated"
+	}
+	return productName
+}
+
+func hasProduct(items []interface{}, target string) bool {
+	for _, item := range items {
+		if m, ok := item.(map[string]interface{}); ok {
+			if val, ok := m["value"].(string); ok && val == target {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func buildJQL(projectKey string, filters []fieldQuery) string {
+	var conditions []string
+	for _, q := range filters {
+		if q.Operator == "~*" {
+			values := strings.Split(q.Value, ",")
+			var orParts []string
+			for _, v := range values {
+				orParts = append(orParts,
+					fmt.Sprintf(`(project = "%s" AND "%s" ~ "%s")`, projectKey, q.Field, strings.TrimSpace(v)))
+			}
+			conditions = append(conditions, "("+strings.Join(orParts, " OR ")+")")
+		} else if q.Operator == "in" {
+			conditions = append(conditions,
+				fmt.Sprintf(`(project = "%s" AND "%s" in (%s))`, projectKey, q.Field, q.Value),
+			)
+		} else {
+			conditions = append(conditions,
+				fmt.Sprintf(`(project = "%s" AND "%s" %s "%s")`, projectKey, q.Field, q.Operator, q.Value),
+			)
+		}
+	}
+	return "(" + strings.Join(conditions, " OR ") + ") AND (labels is EMPTY OR labels not in (long-term))  AND status != Closed ORDER BY created DESC"
+}
+
+func formatVersion(version string) string {
+	versionParts := strings.Split(version, ".")
+	versionPrefix := version
+	if len(versionParts) >= 2 {
+		versionPrefix = fmt.Sprintf("%s.%s", versionParts[0], versionParts[1])
+	}
+	return versionPrefix
+}
+
+func isValidMatch(i jira.Issue, cluster clusterRecord) bool {
+	isIgnored := func(val string) bool {
+		val = strings.ToLower(strings.TrimSpace(val))
+		return val == "none" || val == "n/a" || val == "all" || val == ""
+	}
+
+	hasMatchingValue := func(items []interface{}, expected string) bool {
+		expected = strings.ToLower(strings.TrimSpace(expected))
+		for _, item := range items {
+			if m, ok := item.(map[string]interface{}); ok {
+				if val, ok := m["value"].(string); ok {
+					val = strings.ToLower(strings.TrimSpace(val))
+					if val == expected {
+						return true
+					}
+				}
+			}
+		}
+		return false
+	}
+
+	productRaw := i.Fields.Unknowns[productCustomField]
+	versionRaw := i.Fields.AffectsVersions
+	nameRaw := i.Fields.Unknowns[customerNameCustomField]
+
+	productMatch := false
+	if items, ok := productRaw.([]interface{}); ok {
+		productMatch = hasMatchingValue(items, cluster.Product)
+	}
+	if !productMatch {
+		return false
+	}
+
+	versionMatch := false
+	clusterFormattedVersion := formatVersion(cluster.Version)
+
+	if versionRaw != nil {
+		for _, v := range versionRaw {
+			if v != nil {
+				vFormatted := formatVersion(v.Name)
+				if vFormatted == clusterFormattedVersion || isIgnored(v.Name) {
+					versionMatch = true
+					break
+				}
+			}
+		}
+	}
+
+	nameMatch := false
+	if nameStr, ok := nameRaw.(string); ok {
+		parts := strings.Split(nameStr, ";")
+		for _, part := range parts {
+			val := strings.TrimSpace(part)
+			if val == cluster.OrgName || isIgnored(val) {
+				nameMatch = true
+				break
+			}
+		}
+	}
+
+	return versionMatch || (nameMatch && versionMatch)
+}

--- a/pkg/plugin/announcements/utils_test.go
+++ b/pkg/plugin/announcements/utils_test.go
@@ -1,0 +1,70 @@
+package announcements
+
+import (
+	"testing"
+
+	"github.com/andygrunwald/go-jira"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetermineClusterProduct(t *testing.T) {
+	assert.Equal(t, "Red Hat OpenShift on AWS with Hosted Control Planes", determineClusterProduct("rosa", true))
+	assert.Equal(t, "Red Hat OpenShift on AWS", determineClusterProduct("rosa", false))
+	assert.Equal(t, "OpenShift Dedicated", determineClusterProduct("osd", false))
+	assert.Equal(t, "", determineClusterProduct("unknown", false))
+}
+
+func TestHasProduct(t *testing.T) {
+	items := []interface{}{
+		map[string]interface{}{"value": "OpenShift Dedicated"},
+		map[string]interface{}{"value": "Something Else"},
+	}
+	assert.True(t, hasProduct(items, "OpenShift Dedicated"))
+	assert.False(t, hasProduct(items, "Unknown"))
+}
+
+func TestBuildJQL(t *testing.T) {
+	filters := []fieldQuery{
+		{Field: "Cluster ID", Operator: "~", Value: "abc"},
+		{Field: "Customer Name", Operator: "~", Value: "Red Hat"},
+	}
+	jql := buildJQL("TEST", filters)
+	assert.Contains(t, jql, `"Cluster ID" ~ "abc"`)
+	assert.Contains(t, jql, `"Customer Name" ~ "Red Hat"`)
+	assert.Contains(t, jql, "project = \"TEST\"")
+}
+
+func TestFormatVersion(t *testing.T) {
+	assert.Equal(t, "4.14", formatVersion("4.14.7"))
+	assert.Equal(t, "4.15", formatVersion("4.15"))
+	assert.Equal(t, "4.16", formatVersion("4.16.2.1"))
+	assert.Equal(t, "4.14", formatVersion("4.14"))
+}
+
+func TestIsValidMatch(t *testing.T) {
+	cluster := clusterRecord{
+		OrgName: "Red Hat",
+		Product: "OpenShift Dedicated",
+		Version: "4.14.7",
+	}
+
+	issue := jira.Issue{
+		Fields: &jira.IssueFields{
+			Unknowns: map[string]interface{}{
+				productCustomField: []interface{}{
+					map[string]interface{}{"value": "OpenShift Dedicated"},
+				},
+				customerNameCustomField: "Red Hat",
+			},
+			AffectsVersions: []*jira.AffectsVersion{{Name: "4.14.0"}},
+		},
+	}
+
+	assert.True(t, isValidMatch(issue, cluster))
+
+	issue.Fields.Unknowns[customerNameCustomField] = "Other"
+	assert.True(t, isValidMatch(issue, cluster)) // version match
+
+	issue.Fields.AffectsVersions = []*jira.AffectsVersion{}
+	assert.False(t, isValidMatch(issue, cluster))
+}


### PR DESCRIPTION
We are looking to migrate from the Handover Doc to a JIRA based Handover Board. This would allow to use JIRA queries to directly display related handover announcements at the time of login for the cluster based on ID, Customer Name, Version and Product.



### What type of PR is this?

- [ ] Bug
- [X] Feature
- [ ] Documentation
- [ ] Test Coverage
- [ ] Clean Up
- [ ] Others
### What this PR does / Why we need it?
This PR adds the functionality to query JIRA and print the related announcements for the cluster

### Which Jira/Github issue(s) does this PR fix?

- Related Issue [OSD-28505](https://issues.redhat.com//browse/OSD-28505)
- Closes #

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
