### PR TITLE
[SREP-710] Capture the SIGINT in the backplane CLI.

### DIFF
--- a/cmd/ocm-backplane/cloud/ssm.go
+++ b/cmd/ocm-backplane/cloud/ssm.go
@@ -8,7 +8,9 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
@@ -241,12 +243,28 @@ func startSSMsession(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("failed to serialize session details: %w", err)
 	}
 
+	signals := make(chan (os.Signal), 1)
+	signal.Notify(signals, syscall.SIGINT)
+
 	// Start the ssm-session using the session-manager-plugin
 	cmdArgs := []string{"session-manager-plugin", string(sessionJSON), creds.Region, "StartSession"}
 	pluginCmd := ExecCommand(cmdArgs[0], cmdArgs[1:]...) //#nosec G204: Command arguments are trusted
 	pluginCmd.Stdout = os.Stdout
 	pluginCmd.Stderr = os.Stderr
 	pluginCmd.Stdin = os.Stdin
+
+	// We capture the SIGINT signal and send it to the PID of the subprocess
+	//
+	// FIXME? We probably don't need to unregister the signal handler as once the subprocess returns the parent process also gets terminated.
+	go func() {
+		<-signals
+		if pluginCmd.Process != nil {
+			err := syscall.Kill(pluginCmd.Process.Pid, syscall.SIGINT)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Could not deliver SIGINT to child-process: %d", pluginCmd.Process.Pid)
+			}
+		}
+	}()
 
 	return pluginCmd.Run()
 }


### PR DESCRIPTION
When using SSM via backplane, we don't want SIGINT to be handled by the backplane-cli, but by the subprocess.

### What type of PR is this?

- [X] Bug
- [ ] Feature
- [ ] Documentation
- [ ] Test Coverage
- [ ] Clean Up
- [ ] Others
### What this PR does / Why we need it?

Forwards SIGINT in the SSM command to the subprocess.

### Which Jira/Github issue(s) does this PR fix?

- Related Issue #
- Closes #

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [X] Validated the changes in a cluster
- [ ] Included documentation changes with PR
