### PR TITLE
[SREP-943] docs: add guideline for semver release

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,3 +41,6 @@ fix: fix timezone convertion
 - [ ] Validated the changes in a cluster
 - [ ] Included documentation changes with PR
 - [ ] Backward compatible
+
+<!-- Keep the below label to auto squash commits -->
+/label tide/merge-method-squash

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,22 @@
+<!--
+PR Title Format (please follow):
+
+[Ticket(optional)] type: short description
+
+Examples:
+[SREP-1234] feat: add gcp cloud support
+fix: fix timezone convertion
+-->
+
 ### What type of PR is this?
 
-- [ ] Bug
-- [ ] Feature
-- [ ] Documentation
-- [ ] Test Coverage
-- [ ] Clean Up
-- [ ] Others
+- [ ] fix (Bug Fix)
+- [ ] feat (New Feature)
+- [ ] docs (Documentation)
+- [ ] test (Test Coverage)
+- [ ] chore (Clean Up / Maintenance Tasks)
+- [ ] other (Anything that doesn't fit the above)
+
 ### What this PR does / Why we need it?
 
 ### Which Jira/Github issue(s) does this PR fix?
@@ -29,3 +40,4 @@
 - [ ] Ran unit tests locally
 - [ ] Validated the changes in a cluster
 - [ ] Included documentation changes with PR
+- [ ] Backward compatible

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,8 +255,7 @@ If the PR is a new feature with tests, use the type `feat`.
 | Use lowercase (except proper nouns) | `add support for OCM login`       | `Add Support For OCM Login`    |
 
 ### Squash
-After raising the PR, add a comment:
+The PR template has the below line to squash commits by default, please keep it:
 ```
 /label tide/merge-method-squash
 ```
-so that the commits will be squashed once the PR is merged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,3 +215,48 @@ if err != nil {
 #### Validate arguments
 
 Validate the arguments/inputs at the earliest possible.
+
+
+## Pull Request Guideline
+
+Guideline for making a Pull Request (PR) in the backplane-cli repo.
+
+### Title
+The title should follow this format:
+```
+[Ticket] type: short description
+```
+Example: `[PROJ-123] feat: add SSM support`
+
+#### Ticket number
+The ticket number is optional. If no associated ticket, the title can be `feat: add SSM support`.
+
+#### Type
+
+| Type   | Description                                |
+|--------|--------------------------------------------|
+| feat   | A new feature or capability                |
+| fix    | A bug fix or correction                    |
+| chore  | Maintenance tasks, config, or dependencies |
+| docs   | Documentation-only changes                 |
+| test   | Adding or updating tests                   |
+| other  | Anything that doesn't fit the above types  |
+
+If the PR is a new feature with tests, use the type `feat`.
+
+
+#### Short Description
+
+| Rule                                | Example ✅                         | Example ❌                      |
+|-------------------------------------|-----------------------------------|---------------------------------|
+| Use imperative mood (command form)  | `add login endpoint`              | `added login endpoint`         |
+| Be concise and specific             | `handle missing token error`      | `make login better`            |
+| Do not end with a period            | `refactor cloud service`          | `refactor cloud service.`      |
+| Use lowercase (except proper nouns) | `add support for OCM login`       | `Add Support For OCM Login`    |
+
+### Squash
+After raising the PR, add a comment:
+```
+/label tide/merge-method-squash
+```
+so that the commits will be squashed once the PR is merged.

--- a/Makefile
+++ b/Makefile
@@ -73,10 +73,13 @@ lint: getlint
 	$(GOPATH)/bin/golangci-lint run --timeout 5m
 
 ensure-goreleaser:
-	@ls $(GOPATH)/bin/goreleaser 1>/dev/null || go install github.com/goreleaser/goreleaser@${GORELEASER_VERSION}
+	@command -v goreleaser >/dev/null 2>&1 || go install github.com/goreleaser/goreleaser@${GORELEASER_VERSION}
 
 release: ensure-goreleaser
 	goreleaser release --rm-dist
+
+release-with-note: ensure-goreleaser
+	goreleaser release --rm-dist --release-notes="$(NOTE)"
 
 test:
 	go test -v $(TESTOPTS) ./...
@@ -181,4 +184,3 @@ help:
 	@echo "  make clean && make install  # Fresh install"
 	@echo "  GOOS=darwin make build      # Build for macOS"
 	@echo
-	

--- a/docs/release.md
+++ b/docs/release.md
@@ -93,6 +93,12 @@ Increase `Patch` when:
 
 Create a tag on the latest main.
 
+Determine a version number based on the above section. For example,
+```bash
+VERSION="v0.2.0"
+```
+**Note:** We follow [semver](https://semver.org/) for versioning. Release tags are expected to be suffixed with a `v` for consistent naming; For example, `v1.0.0`.
+
 ```bash
 git fetch upstream
 git checkout upstream/main
@@ -100,7 +106,6 @@ git tag -a ${VERSION} -m "release ${VERSION}"
 git push upstream $VERSION
 ```
 
-**Note:** We follow [semver](https://semver.org/) for versioning. Release tags are expected to be suffixed with a `v` for consistent naming; For example, `v1.0.0`.
 
 Run goreleaser to build the binaries and create the release page.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -72,21 +72,22 @@ END {
 ```
 This saves the grouped commits in `/tmp/release-note.md`, please review and modify the release note file.
 
-Increase `Major` when:
-- It has changes that breaks backward compatibility:
-    - For example, refactoring the CLI which changes the subcommand and argument format.
-    - The user need to use a new command to perform a task which the old command no longer works.
+Increase `Major`:
+- When it has changes that break backward compatibility:
+   - For example, the CLI has been refactored and the same command in the old version is not longer working with the new CLI version.
+   - If the new CLI is compatible with the old command, we don't consider it as a breaking change and we shouldn't change the major version.
+   - We should try to provide backward compatibility to avoid frequent major version bump.
 - Reset `Minor` and `Patch` to 0.
 
 Increase `Minor` when:
-- It adds a new feature:
+- When it adds a new feature:
     - For example, adding a new subcommand, adding a new functionality to a subcommand.
     - The same commands in the old version can still work in the new version.
 - Keep `Major` unchanged, and reset `Patch` to 0.
 
-Increase `Patch` when:
-- It has a bug fix that doesn't change the expected behaviors of a subcommand.
-- It has dependency updates.
+Increase `Patch`:
+- When it has a bug fix that doesn't change the expected behaviors of a subcommand.
+- Or it has dependency updates.
 - Keep `Major` and `Minor` unchanged.
 
 ### Cutting a new release

--- a/docs/release.md
+++ b/docs/release.md
@@ -28,6 +28,67 @@ cd backplane-cli
 git remote add upstream https://github.com/openshift/backplane-cli.git
 ```
 
+### Determine a new version
+backplane-cli follows [semver](https://semver.org/). The version is in format `v[Major].[Minor].[Patch]`.
+
+- MAJOR version when you make incompatible API changes
+- MINOR version when you add functionality in a backward compatible manner
+- PATCH version when you make backward compatible bug fixes
+
+Review the commits since last release:
+```
+$ git fetch upstream
+
+$ git log $(git describe --tags --abbrev=0 upstream/main)..upstream/main --pretty=format:"%h %s" |
+gawk '
+{
+  # Extract the commit message without the hash and ticket prefix
+  # Pattern: hash + space + [ticket] + space + type + ":"
+  # Example: "a1b2c3d [PROJ-123] feat: some message"
+
+  # Remove the hash and space
+  msg = substr($0, index($0,$2))
+
+  # Regex to extract type: after "] " followed by letters, colon
+  if (match(msg, /\] *([a-z]+):/, m)) {
+    type = m[1]
+    groups[type] = groups[type] "\n- " $0
+  } else {
+    groups["others"] = groups["others"] "\n- " $0
+  }
+}
+END {
+  order = "feat fix chore docs test others"
+  split(order, o)
+  for (i in o) {
+    t = o[i]
+    if (t in groups) {
+      print "## " toupper(substr(t,1,1)) substr(t,2)
+      print groups[t] "\n"
+    }
+  }
+}
+'  > /tmp/release-note.md
+```
+This saves the grouped commits in `/tmp/release-note.md`, please review and modify the release note file.
+
+Increase `Major` when:
+- It has changes that breaks backward compatibility:
+    - For example, refactoring the CLI which changes the subcommand and argument format.
+    - The user need to use a new command to perform a task which the old command no longer works.
+- Reset `Minor` and `Patch` to 0.
+
+Increase `Minor` when:
+- It adds a new feature:
+    - For example, adding a new subcommand, adding a new functionality to a subcommand.
+    - The same commands in the old version can still work in the new version.
+- Keep `Major` unchanged, and reset `Patch` to 0.
+
+Increase `Patch` when:
+- It has a bug fix that doesn't change the expected behaviors of a subcommand.
+- It has dependency updates.
+- Keep `Major` and `Minor` unchanged.
+
 ### Cutting a new release
 
 Create a tag on the latest main.
@@ -45,7 +106,7 @@ Run goreleaser to build the binaries and create the release page.
 
 ```bash
 git checkout upstream/main
-make release
+make release-with-note NOTE=/tmp/release-note.md
 ```
 
 A new release will show up in the [releases](https://github.com/openshift/backplane-cli/releases) page.


### PR DESCRIPTION
### What type of PR is this?

- [ ] Bug
- [ ] Feature
- [x] Documentation
- [ ] Test Coverage
- [ ] Clean Up
- [ ] Others
### What this PR does / Why we need it?
This PR add a guideline for how we should apply semver practice in backplane-cli.
- Add a PR guideline in CONTRIBUTING.MD. We should specify the type of the PR in the title, so that when the maintainer cut a new release, they can clearly see what kind of changes have been made since the last release.
- Add steps in release.md for maintainer to generate a grouped release note, so that they can decide how to bump the version accordingly.
- Add a target `release-with-note` in Makefile for specifying a custom release note.

### Which Jira/Github issue(s) does this PR fix?
https://issues.redhat.com/browse/SREP-943

### Special notes for your reviewer

Example of release note using the new guideline:
```
## Feat
77b402c Add domain checks for isolated backplane access in isIsolatedBackplaneAccess function
9123aab OSD-29893 - Adding Fedramp compatibility (#693)

## Fix
4e89950 Capture the SIGINT in the backplane CLI.
c959d4f VerifyIPTrusted error message
ebde738 Fixed manifestwork fetch command

## Docs
d200c19 fix format
133c3b0 make clear alias situation
e3cde83 Add a contributing doc for UX guide

## Chore
3a4aca1 Adding Shawn to the maintainers group
35c0096 add user a7vicky as reviewer
8db6767 (origin/bump_kustomize, bump_kustomize) Bump sigs.k8s.io/kustomize/api from 0.18.0 to 0.20.0
b3be040 Bump github.com/aws/aws-sdk-go-v2/service/ssm from 1.59.3 to 1.60.0
b53a57b Add entry for github.com/openshift-online/ocm-cli v1.0.6 to go.sum
cf401ed Bump sigs.k8s.io/yaml from 1.4.0 to 1.5.0
69ab631 Remove redundant entry for github.com/openshift-online/ocm-cli v1.0.6 from go.sum
df91b8b Bump github.com/aws/aws-sdk-go-v2/config from 1.29.16 to 1.29.17
751b56c Bump github.com/aws/aws-sdk-go-v2/credentials from 1.17.69 to 1.17.70
78e22f7 Bump github.com/aws/aws-sdk-go-v2/service/ssm from 1.59.2 to 1.59.3
277686c Bump github.com/openshift-online/ocm-sdk-go from 0.1.467 to 0.1.469
e1e4118 Bump github.com/aws/aws-sdk-go-v2/service/ssm from 1.59.1 to 1.59.2
6b5f488 Bump github.com/aws/aws-sdk-go-v2/config from 1.29.15 to 1.29.16
8d51f49 Bump github.com/aws/aws-sdk-go-v2/credentials from 1.17.68 to 1.17.69
72cdcbf Bump github.com/openshift-online/ocm-sdk-go from 0.1.465 to 0.1.467
a682893 Bump github.com/aws/aws-sdk-go-v2/service/ssm from 1.59.0 to 1.59.1
233314d Bump github.com/aws/aws-sdk-go-v2/config from 1.29.14 to 1.29.15
a5d8f41 Bump github.com/openshift-online/ocm-cli from 1.0.5 to 1.0.6
0d10939 Bump ubi9 from 9.5 to 9.6
a470e98 Bump golang.org/x/term from 0.31.0 to 0.32.0
```
In this case, we can see there's a new feat in this new release.

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [x] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [x] Included documentation changes with PR
