### PR TITLE
[SREP-993] fix: pass env for 4.17+ monitor plugin

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -24,7 +24,7 @@ type ContainerEngine interface {
 	PutFileToMount(filename string, content []byte) error
 	StopContainer(containerName string) error
 	RunConsoleContainer(containerName string, port string, consoleArgs []string, envVars []EnvVar) error
-	RunMonitorPlugin(containerName string, consoleContainerName string, nginxConf string, pluginArgs []string) error
+	RunMonitorPlugin(containerName string, consoleContainerName string, nginxConf string, pluginArgs []string, envVars []EnvVar) error
 	ContainerIsExist(containerName string) (bool, error)
 }
 

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -119,4 +119,89 @@ var _ = Describe("console container implementation", func() {
 		})
 	})
 
+	Context("when running monitoring plugin container in podman", func() {
+		It("should pass argments and environment variable to podman if specified", func() {
+			ce := podmanMac{}
+			mockOcmInterface.EXPECT().GetPullSecret().Return(pullSecret, nil).AnyTimes()
+			capturedCommands = nil
+			args := []string{"arg1"}
+			envvars := []EnvVar{{Key: "testkey", Value: "testval"}}
+			err := ce.RunMonitorPlugin("monitoring-plugin-1234", "console-1234", "/tmp/nginx.conf", args, envvars)
+			Expect(err).To(BeNil())
+			Expect(len(capturedCommands)).To(Equal(1))
+			fullCommand := strings.Join(capturedCommands[0], " ")
+			// arg
+			Expect(fullCommand).To(ContainSubstring("arg1"))
+			// env var
+			Expect(fullCommand).To(ContainSubstring("--env"))
+			Expect(fullCommand).To(ContainSubstring("testkey=testval"))
+		})
+		It("should not mount the nginx conf file if the path is empty - Mac", func() {
+			ce := podmanMac{}
+			mockOcmInterface.EXPECT().GetPullSecret().Return(pullSecret, nil).AnyTimes()
+			capturedCommands = nil
+			args := []string{"arg1"}
+			envvars := []EnvVar{{Key: "testkey", Value: "testval"}}
+			err := ce.RunMonitorPlugin("monitoring-plugin-1234", "console-1234", "", args, envvars)
+			Expect(err).To(BeNil())
+			Expect(len(capturedCommands)).To(Equal(1))
+			fullCommand := strings.Join(capturedCommands[0], " ")
+			Expect(fullCommand).ToNot(ContainSubstring("--mount"))
+		})
+		It("should not mount the nginx conf file if the path is empty - Linux", func() {
+			ce := podmanLinux{}
+			mockOcmInterface.EXPECT().GetPullSecret().Return(pullSecret, nil).AnyTimes()
+			capturedCommands = nil
+			args := []string{"arg1"}
+			envvars := []EnvVar{{Key: "testkey", Value: "testval"}}
+			err := ce.RunMonitorPlugin("monitoring-plugin-1234", "console-1234", "", args, envvars)
+			Expect(err).To(BeNil())
+			Expect(len(capturedCommands)).To(Equal(1))
+			fullCommand := strings.Join(capturedCommands[0], " ")
+			Expect(fullCommand).ToNot(ContainSubstring("--mount"))
+		})
+	})
+
+	Context("when running monitoring plugin container in docker", func() {
+		It("should pass argments and environment variable to docker if specified", func() {
+			ce := dockerLinux{}
+			mockOcmInterface.EXPECT().GetPullSecret().Return(pullSecret, nil).AnyTimes()
+			capturedCommands = nil
+			args := []string{"arg1"}
+			envvars := []EnvVar{{Key: "testkey", Value: "testval"}}
+			err := ce.RunMonitorPlugin("monitoring-plugin-1234", "console-1234", "/tmp/nginx.conf", args, envvars)
+			Expect(err).To(BeNil())
+			Expect(len(capturedCommands)).To(Equal(1))
+			fullCommand := strings.Join(capturedCommands[0], " ")
+			// arg
+			Expect(fullCommand).To(ContainSubstring("arg1"))
+			// env var
+			Expect(fullCommand).To(ContainSubstring("--env"))
+			Expect(fullCommand).To(ContainSubstring("testkey=testval"))
+		})
+		It("should not mount the nginx conf file if the path is empty - Linux", func() {
+			ce := dockerLinux{}
+			mockOcmInterface.EXPECT().GetPullSecret().Return(pullSecret, nil).AnyTimes()
+			capturedCommands = nil
+			args := []string{"arg1"}
+			envvars := []EnvVar{{Key: "testkey", Value: "testval"}}
+			err := ce.RunMonitorPlugin("monitoring-plugin-1234", "console-1234", "", args, envvars)
+			Expect(err).To(BeNil())
+			Expect(len(capturedCommands)).To(Equal(1))
+			fullCommand := strings.Join(capturedCommands[0], " ")
+			Expect(fullCommand).ToNot(ContainSubstring("--volume"))
+		})
+		It("should not mount the nginx conf file if the path is empty - Mac", func() {
+			ce := dockerMac{}
+			mockOcmInterface.EXPECT().GetPullSecret().Return(pullSecret, nil).AnyTimes()
+			capturedCommands = nil
+			args := []string{"arg1"}
+			envvars := []EnvVar{{Key: "testkey", Value: "testval"}}
+			err := ce.RunMonitorPlugin("monitoring-plugin-1234", "console-1234", "", args, envvars)
+			Expect(err).To(BeNil())
+			Expect(len(capturedCommands)).To(Equal(1))
+			fullCommand := strings.Join(capturedCommands[0], " ")
+			Expect(fullCommand).ToNot(ContainSubstring("--volume"))
+		})
+	})
 })

--- a/pkg/container/mocks/containerEngineMock.go
+++ b/pkg/container/mocks/containerEngineMock.go
@@ -92,17 +92,17 @@ func (mr *MockContainerEngineMockRecorder) RunConsoleContainer(arg0, arg1, arg2,
 }
 
 // RunMonitorPlugin mocks base method.
-func (m *MockContainerEngine) RunMonitorPlugin(arg0, arg1, arg2 string, arg3 []string) error {
+func (m *MockContainerEngine) RunMonitorPlugin(arg0, arg1, arg2 string, arg3 []string, arg4 []container.EnvVar) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunMonitorPlugin", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "RunMonitorPlugin", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RunMonitorPlugin indicates an expected call of RunMonitorPlugin.
-func (mr *MockContainerEngineMockRecorder) RunMonitorPlugin(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockContainerEngineMockRecorder) RunMonitorPlugin(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunMonitorPlugin", reflect.TypeOf((*MockContainerEngine)(nil).RunMonitorPlugin), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunMonitorPlugin", reflect.TypeOf((*MockContainerEngine)(nil).RunMonitorPlugin), arg0, arg1, arg2, arg3, arg4)
 }
 
 // StopContainer mocks base method.


### PR DESCRIPTION
### What type of PR is this?

- [x] Bug
- [ ] Feature
- [ ] Documentation
- [ ] Test Coverage
- [ ] Clean Up
- [ ] Others
### What this PR does / Why we need it?

This PR applies the changes in https://github.com/openshift/backplane-cli/pull/718 and add corresponding unit tests.

From OCP 4.17, the monitoring plugin in console no longer require nginx, instead, we should pass a PORT environment variable for it to listen.

This is to fix the issue in https://issues.redhat.com/browse/SREP-608 

### Which Jira/Github issue(s) does this PR fix?

https://issues.redhat.com/browse/SREP-993

### Special notes for your reviewer

- Tested locally with MacOS/Podman, works for 4.16 and 4.19 clusters.


### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [x] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
