### PR TITLE
[SREP-1559] feat: check that when used, proxy url starts with http and do proxy hostname dns lookup to confirm connectivity

### DIFF
--- a/pkg/cli/config/config_test.go
+++ b/pkg/cli/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -83,6 +84,89 @@ func TestGetBackplaneConnection(t *testing.T) {
 
 		if err != nil {
 			t.Failed()
+		}
+	})
+
+	t.Run("should pass for valid http proxy URL", func(t *testing.T) {
+		proxyURL := "http://www.example.com"
+		config := BackplaneConfiguration{URL: "https://api.example.com", ProxyURL: &proxyURL}
+		_, err := config.testHTTPRequestToBackplaneAPI()
+		
+		// Should not get scheme validation error (DNS lookup error is expected)
+		if err != nil && strings.Contains(err.Error(), "proxy URL scheme must be http or https") {
+			t.Errorf("unexpected scheme validation error: %v", err)
+		}
+	})
+
+	t.Run("should pass for valid https proxy URL", func(t *testing.T) {
+		proxyURL := "https://www.example.com"
+		config := BackplaneConfiguration{URL: "https://api.example.com", ProxyURL: &proxyURL}
+		_, err := config.testHTTPRequestToBackplaneAPI()
+		
+		// Should not get scheme validation error (DNS lookup error is expected)
+		if err != nil && strings.Contains(err.Error(), "proxy URL scheme must be http or https") {
+			t.Errorf("unexpected scheme validation error: %v", err)
+		}
+	})
+
+	t.Run("should fail for proxy URL without scheme", func(t *testing.T) {
+		proxyURL := "www.example.com"
+		config := BackplaneConfiguration{URL: "https://api.example.com", ProxyURL: &proxyURL}
+		_, err := config.testHTTPRequestToBackplaneAPI()
+		
+		if err == nil {
+			t.Errorf("expected error but got none")
+		} else if !strings.Contains(err.Error(), "proxy URL scheme must be http or https, got:") {
+			t.Errorf("expected scheme validation error, got: %s", err.Error())
+		}
+	})
+
+	t.Run("should fail for ftp proxy URL", func(t *testing.T) {
+		proxyURL := "ftp://www.example.com"
+		config := BackplaneConfiguration{URL: "https://api.example.com", ProxyURL: &proxyURL}
+		_, err := config.testHTTPRequestToBackplaneAPI()
+		
+		if err == nil {
+			t.Errorf("expected error but got none")
+		} else if !strings.Contains(err.Error(), "proxy URL scheme must be http or https, got: ftp") {
+			t.Errorf("expected scheme validation error for ftp, got: %s", err.Error())
+		}
+	})
+
+	t.Run("should fail on DNS lookup error", func(t *testing.T) {
+		// Mock DNS lookup to return an error
+		originalLookupHost := lookupHost
+		lookupHost = func(hostname string) ([]string, error) {
+			return nil, fmt.Errorf("DNS resolution failed")
+		}
+		defer func() { lookupHost = originalLookupHost }()
+
+		proxyURL := "https://proxy.example.com"
+		config := BackplaneConfiguration{URL: "https://api.example.com", ProxyURL: &proxyURL}
+		_, err := config.testHTTPRequestToBackplaneAPI()
+		
+		if err == nil {
+			t.Errorf("expected DNS lookup error but got none")
+		} else if !strings.Contains(err.Error(), "DNS lookup failed for proxy hostname") {
+			t.Errorf("expected DNS lookup error, got: %s", err.Error())
+		}
+	})
+
+	t.Run("should pass on successful DNS lookup", func(t *testing.T) {
+		// Mock DNS lookup to succeed
+		originalLookupHost := lookupHost
+		lookupHost = func(hostname string) ([]string, error) {
+			return []string{"192.168.1.1"}, nil
+		}
+		defer func() { lookupHost = originalLookupHost }()
+
+		proxyURL := "https://proxy.example.com"
+		config := BackplaneConfiguration{URL: "https://api.example.com", ProxyURL: &proxyURL}
+		_, err := config.testHTTPRequestToBackplaneAPI()
+		
+		// Should not get DNS lookup error (HTTP request error is expected)
+		if err != nil && strings.Contains(err.Error(), "DNS lookup failed for proxy hostname") {
+			t.Errorf("unexpected DNS lookup error: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
with this change testHTTPRequestToBackplaneAPI,  checks that when used, proxy url starts with http and does proxy hostname dns lookup to confirm connectivity so user can clearly spot if there's an issue with config or connectivty