### PR TITLE
SREP-1333: Implement list all scripts without permission filtering

### DIFF
--- a/cmd/ocm-backplane/script/listScripts_test.go
+++ b/cmd/ocm-backplane/script/listScripts_test.go
@@ -184,5 +184,164 @@ var _ = Describe("list script command", func() {
 
 			Expect(err).ToNot(BeNil())
 		})
+
+		It("should display scripts for different groups - CEE user scenario", func() {
+			ceeUserResp := &http.Response{
+				Body: MakeIoReader(`[
+{
+  "allowedGroups":["CEE"],
+  "author":"CEE Team",
+  "canonicalName":"CEE/debug-pod",
+  "description":"Debug pod issues",
+  "language":"Bash",
+  "path":"cee/debug",
+  "permalink":"https://link1",
+  "rbac": {}
+},
+{
+  "allowedGroups":["CEE", "SRE"],
+  "author":"Platform Team",
+  "canonicalName":"platform/cluster-health",
+  "description":"Check cluster health",
+  "language":"Python",
+  "path":"platform/health",
+  "permalink":"https://link2",
+  "rbac": {}
+},
+{
+  "allowedGroups":["SRE"],
+  "author":"SRE Team",
+  "canonicalName":"SRE/node-drain",
+  "description":"Drain cluster nodes",
+  "language":"Bash",
+  "path":"sre/drain",
+  "permalink":"https://link3",
+  "rbac": {}
+}
+]`),
+				Header:     map[string][]string{},
+				StatusCode: http.StatusOK,
+			}
+			ceeUserResp.Header.Add("Content-Type", "json")
+
+			mockOcmInterface.EXPECT().GetOCMEnvironment().Return(ocmEnv, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(trueClusterID, testClusterID, nil)
+			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterID)).Return(false, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil).AnyTimes()
+			mockClientUtil.EXPECT().MakeRawBackplaneAPIClient(gomock.Any()).Return(mockClient, nil)
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(trueClusterID, testClusterID, nil)
+			mockClient.EXPECT().GetScriptsByCluster(gomock.Any(), trueClusterID, &bpclient.GetScriptsByClusterParams{}).Return(ceeUserResp, nil)
+
+			sut.SetArgs([]string{"list", testJobID, "--cluster-id", testClusterID})
+			err := sut.Execute()
+
+			Expect(err).To(BeNil())
+		})
+
+		It("should display scripts with --all flag showing allowed groups - DevOps user scenario", func() {
+			devOpsUserResp := &http.Response{
+				Body: MakeIoReader(`[
+{
+  "allowedGroups":["DevOps"],
+  "author":"DevOps Team",
+  "canonicalName":"devops/deploy-monitoring",
+  "description":"Deploy monitoring stack",
+  "language":"Python",
+  "path":"devops/monitoring",
+  "permalink":"https://link4",
+  "rbac": {}
+},
+{
+  "allowedGroups":["DevOps", "Platform"],
+  "author":"Platform Team",
+  "canonicalName":"platform/backup-etcd",
+  "description":"Backup etcd database",
+  "language":"Bash",
+  "path":"platform/backup",
+  "permalink":"https://link5",
+  "rbac": {}
+},
+{
+  "allowedGroups":["Admin"],
+  "author":"Admin Team",
+  "canonicalName":"admin/emergency-shutdown",
+  "description":"Emergency cluster shutdown",
+  "language":"Bash",
+  "path":"admin/shutdown",
+  "permalink":"https://link6",
+  "rbac": {}
+}
+]`),
+				Header:     map[string][]string{},
+				StatusCode: http.StatusOK,
+			}
+			devOpsUserResp.Header.Add("Content-Type", "json")
+
+			mockOcmInterface.EXPECT().GetOCMEnvironment().Return(ocmEnv, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(trueClusterID, testClusterID, nil)
+			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterID)).Return(false, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil).AnyTimes()
+			mockClientUtil.EXPECT().MakeRawBackplaneAPIClient(gomock.Any()).Return(mockClient, nil)
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(trueClusterID, testClusterID, nil)
+			mockClient.EXPECT().GetAllScriptsByCluster(gomock.Any(), trueClusterID).Return(devOpsUserResp, nil)
+
+			sut.SetArgs([]string{"list", testJobID, "--cluster-id", testClusterID, "--all"})
+			err := sut.Execute()
+
+			Expect(err).To(BeNil())
+		})
+
+		It("should show different scripts for Support team member", func() {
+			supportUserResp := &http.Response{
+				Body: MakeIoReader(`[
+{
+  "allowedGroups":["Support"],
+  "author":"Support Team",
+  "canonicalName":"support/collect-logs",
+  "description":"Collect diagnostic logs",
+  "language":"Python",
+  "path":"support/logs",
+  "permalink":"https://link7",
+  "rbac": {}
+},
+{
+  "allowedGroups":["Support", "CEE"],
+  "author":"Support Team",
+  "canonicalName":"support/network-debug",
+  "description":"Debug network connectivity",
+  "language":"Bash",
+  "path":"support/network",
+  "permalink":"https://link8",
+  "rbac": {}
+},
+{
+  "allowedGroups":["Support", "SRE", "CEE"],
+  "author":"Multi Team",
+  "canonicalName":"shared/must-gather",
+  "description":"Collect must-gather data",
+  "language":"Bash",
+  "path":"shared/gather",
+  "permalink":"https://link9",
+  "rbac": {}
+}
+]`),
+				Header:     map[string][]string{},
+				StatusCode: http.StatusOK,
+			}
+			supportUserResp.Header.Add("Content-Type", "json")
+
+			mockOcmInterface.EXPECT().GetOCMEnvironment().Return(ocmEnv, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(trueClusterID, testClusterID, nil)
+			mockOcmInterface.EXPECT().IsClusterHibernating(gomock.Eq(trueClusterID)).Return(false, nil).AnyTimes()
+			mockOcmInterface.EXPECT().GetOCMAccessToken().Return(&testToken, nil).AnyTimes()
+			mockClientUtil.EXPECT().MakeRawBackplaneAPIClient(gomock.Any()).Return(mockClient, nil)
+			mockOcmInterface.EXPECT().GetTargetCluster(testClusterID).Return(trueClusterID, testClusterID, nil)
+			mockClient.EXPECT().GetAllScriptsByCluster(gomock.Any(), trueClusterID).Return(supportUserResp, nil)
+
+			sut.SetArgs([]string{"list", testJobID, "--cluster-id", testClusterID, "--all"})
+			err := sut.Execute()
+
+			Expect(err).To(BeNil())
+		})
 	})
 })

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/onsi/gomega v1.38.2
 	github.com/openshift-online/ocm-cli v1.0.8
 	github.com/openshift-online/ocm-sdk-go v0.1.477
-	github.com/openshift/backplane-api v0.0.0-20250514095514-2aa57551ec70
+	github.com/openshift/backplane-api v0.0.0-20250910081446-754f683c5de6
 	github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -384,8 +384,8 @@ github.com/openshift-online/ocm-sdk-go v0.1.477 h1:D+5O8HVpdG5JkQ4S5R8ps7u5hqGUN
 github.com/openshift-online/ocm-sdk-go v0.1.477/go.mod h1:2tZbWTJc6oTQcUJbbzTDVPme6wYALksisvoCKgMvlUo=
 github.com/openshift/api v0.0.0-20221018124113-7edcfe3c76cb h1:QsBjYe5UfHIZi/3SMzQBIjYDKnWqZxq50eQkBp9eUew=
 github.com/openshift/api v0.0.0-20221018124113-7edcfe3c76cb/go.mod h1:JRz+ZvTqu9u7t6suhhPTacbFl5K65Y6rJbNM7HjWA3g=
-github.com/openshift/backplane-api v0.0.0-20250514095514-2aa57551ec70 h1:rUcdH93mEXHMviKxy1no2vFuQm0TiqA2vuCKnczeQ1k=
-github.com/openshift/backplane-api v0.0.0-20250514095514-2aa57551ec70/go.mod h1:RuJZpJy45AJnkp7A0ZPTZhLOVkCGDLI6cGknKvp65LE=
+github.com/openshift/backplane-api v0.0.0-20250910081446-754f683c5de6 h1:zLkj2ajeilrVZ5tNyeYRGw80tKP+S5uTN2nTItoDgW0=
+github.com/openshift/backplane-api v0.0.0-20250910081446-754f683c5de6/go.mod h1:RuJZpJy45AJnkp7A0ZPTZhLOVkCGDLI6cGknKvp65LE=
 github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c h1:CV76yFOTXmq9VciBR3Bve5ZWzSxdft7gaMVB3kS0rwg=
 github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c/go.mod h1:lFMO8mLHXWFzSdYvGNo8ivF9SfF6zInA8ZGw4phRnUE=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=

--- a/pkg/client/mocks/ClientWithResponsesMock.go
+++ b/pkg/client/mocks/ClientWithResponsesMock.go
@@ -242,6 +242,26 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) GetAllJobsWithResponse(c
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllJobsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).GetAllJobsWithResponse), varargs...)
 }
 
+// GetAllScriptsByClusterWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) GetAllScriptsByClusterWithResponse(ctx context.Context, clusterId string, reqEditors ...Openapi.RequestEditorFn) (*Openapi.GetAllScriptsByClusterResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, clusterId}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetAllScriptsByClusterWithResponse", varargs...)
+	ret0, _ := ret[0].(*Openapi.GetAllScriptsByClusterResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAllScriptsByClusterWithResponse indicates an expected call of GetAllScriptsByClusterWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) GetAllScriptsByClusterWithResponse(ctx, clusterId any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, clusterId}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllScriptsByClusterWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).GetAllScriptsByClusterWithResponse), varargs...)
+}
+
 // GetAssumeRoleSequenceWithResponse mocks base method.
 func (m *MockClientWithResponsesInterface) GetAssumeRoleSequenceWithResponse(ctx context.Context, clusterId string, reqEditors ...Openapi.RequestEditorFn) (*Openapi.GetAssumeRoleSequenceResponse, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--
PR Title Format (please follow):

[Ticket(optional)] type: short description

Examples:
[SREP-1234] feat: add gcp cloud support
fix: fix timezone convertion
-->

### What type of PR is this?

- [ ] fix (Bug Fix)
- [x] feat (New Feature)
- [ ] docs (Documentation)
- [x] test (Test Coverage)
- [x] chore (Clean Up / Maintenance Tasks)
- [ ] other (Anything that doesn't fit the above)

### What this PR does / Why we need it?

Implements a new --all flag for the script list command that allows listing all available scripts without permission filtering. This feature enables users to see the complete catalog of scripts available, along with their allowed groups, providing better visibility into script availability across different user roles.

The implementation is supported by the new GetAllScriptsByCluster API endpoint and enhances the UI to display allowed groups when the --all flag is used.

### Which Jira/Github issue(s) does this PR fix?

- Closes [SREP-1333](https://issues.redhat.com//browse/SREP-1333)

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [x] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
- [ ] Backward compatible

<!-- Keep the below label to auto squash commits -->
/label tide/merge-method-squash
