### PR TITLE
fix: Fix critical CIDR range verification bug in verifyIPTrusted func

### DIFF
--- a/cmd/ocm-backplane/cloud/common.go
+++ b/cmd/ocm-backplane/cloud/common.go
@@ -470,11 +470,11 @@ func checkEgressIPImpl(client *http.Client, url string) (net.IP, error) {
 
 func verifyIPTrusted(ip net.IP, trustedIPs awsutil.IPAddress) error {
 	for _, trustedIP := range trustedIPs.SourceIp {
-		parsedIP, _, err := net.ParseCIDR(trustedIP)
+		_, network, err := net.ParseCIDR(trustedIP)
 		if err != nil {
-			return fmt.Errorf("failed to parse the given trusted IP: %w", err)
+			return fmt.Errorf("failed to parse trusted IP CIDR %s: %w", trustedIP, err)
 		}
-		if parsedIP.Equal(ip) {
+		if network.Contains(ip) {
 			return nil
 		}
 	}

--- a/cmd/ocm-backplane/cloud/common_test.go
+++ b/cmd/ocm-backplane/cloud/common_test.go
@@ -325,21 +325,110 @@ var _ = Describe("getIsolatedCredentials", func() {
 			}
 		})
 
-		It("should return nil if IP included in trusted list", func() {
+		It("should return nil if IP exactly matches single host CIDR", func() {
 			ip = net.ParseIP("192.168.1.1")
 			err := verifyIPTrusted(ip, trustedIPs)
 			Expect(err).To(BeNil())
 		})
+
+		It("should return nil if IP is within large CIDR range", func() {
+			ip = net.ParseIP("10.1.2.3")
+			err := verifyIPTrusted(ip, trustedIPs)
+			Expect(err).To(BeNil())
+		})
+
+		It("should return nil if IP is at start of CIDR range", func() {
+			ip = net.ParseIP("10.0.0.0")
+			err := verifyIPTrusted(ip, trustedIPs)
+			Expect(err).To(BeNil())
+		})
+
+		It("should return nil if IP is at end of CIDR range", func() {
+			ip = net.ParseIP("10.255.255.255")
+			err := verifyIPTrusted(ip, trustedIPs)
+			Expect(err).To(BeNil())
+		})
+
 		It("should return error if IP not included in trusted list", func() {
 			ip = net.ParseIP("172.16.0.1")
 			err := verifyIPTrusted(ip, trustedIPs)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("client IP 172.16.0.1 is not in the trusted IP range"))
 		})
-		It("should return an error if give the wrong format", func() {
+
+		It("should return error for IP just outside CIDR range", func() {
+			ip = net.ParseIP("192.168.1.2") // Outside 192.168.1.1/32
+			err := verifyIPTrusted(ip, trustedIPs)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("client IP 192.168.1.2 is not in the trusted IP range"))
+		})
+
+		It("should return error for IP in different network class", func() {
+			ip = net.ParseIP("9.255.255.255") // Just outside 10.0.0.0/8
+			err := verifyIPTrusted(ip, trustedIPs)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("client IP 9.255.255.255 is not in the trusted IP range"))
+		})
+
+		It("should return an error if given invalid CIDR format", func() {
 			trustedIPs.SourceIp = []string{"invalid-cidr"}
 			ip = net.ParseIP("192.168.1.1")
 			err := verifyIPTrusted(ip, trustedIPs)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to parse trusted IP CIDR invalid-cidr"))
+		})
+
+		It("should handle mixed CIDR ranges correctly", func() {
+			trustedIPs.SourceIp = []string{
+				"192.168.1.0/24",   // Subnet
+				"172.16.5.10/32",   // Single host
+				"10.0.0.0/16",      // Large range
+			}
+
+			// Test IPs within each range
+			testCases := []struct {
+				testIP    string
+				shouldPass bool
+				desc      string
+			}{
+				{"192.168.1.1", true, "IP in /24 subnet"},
+				{"192.168.1.254", true, "IP at end of /24 subnet"},
+				{"192.168.2.1", false, "IP outside /24 subnet"},
+				{"172.16.5.10", true, "Exact match for /32"},
+				{"172.16.5.11", false, "IP adjacent to /32"},
+				{"10.0.5.5", true, "IP in /16 range"},
+				{"10.1.0.0", false, "IP outside /16 range"},
+			}
+
+			for _, tc := range testCases {
+				ip = net.ParseIP(tc.testIP)
+				err := verifyIPTrusted(ip, trustedIPs)
+				if tc.shouldPass {
+					Expect(err).To(BeNil(), "Expected %s to pass: %s", tc.testIP, tc.desc)
+				} else {
+					Expect(err).To(HaveOccurred(), "Expected %s to fail: %s", tc.testIP, tc.desc)
+					Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("client IP %s is not in the trusted IP range", tc.testIP)))
+				}
+			}
+		})
+
+		It("should handle IPv6 CIDR ranges", func() {
+			trustedIPs.SourceIp = []string{
+				"2001:db8::/32",
+				"::1/128", // IPv6 localhost
+			}
+
+			// Test IPv6 addresses
+			ip = net.ParseIP("2001:db8::1")
+			err := verifyIPTrusted(ip, trustedIPs)
+			Expect(err).To(BeNil())
+
+			ip = net.ParseIP("::1")
+			err = verifyIPTrusted(ip, trustedIPs)
+			Expect(err).To(BeNil())
+
+			ip = net.ParseIP("2001:db9::1") // Outside range
+			err = verifyIPTrusted(ip, trustedIPs)
 			Expect(err).To(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
…tion

The verifyIPTrusted function had a critical security vulnerability where it only checked if the client IP exactly matched the network address of CIDR ranges, rather than checking if the IP falls within the CIDR range.

Changes:
- Replace parsedIP.Equal(ip) with network.Contains(ip) for proper CIDR validation
- Improve error message to include the problematic CIDR string for better debugging
- Add comprehensive test coverage with 7 new test cases covering:
  * Single host CIDR ranges (/32)
  * Large CIDR ranges (/8, /16, /24)
  * Boundary testing (start/end of ranges)
  * Negative cases (IPs outside ranges)
  * Invalid CIDR format handling
  * Mixed CIDR scenarios
  * IPv6 CIDR support

Before: Only IPs that exactly matched the network address were trusted
After: All IPs within the specified CIDR ranges are properly validated

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--
PR Title Format (please follow):

[Ticket(optional)] type: short description

Examples:
[SREP-1234] feat: add gcp cloud support
fix: fix timezone convertion
-->

### What type of PR is this?

- [x] fix (Bug Fix)
- [ ] feat (New Feature)
- [ ] docs (Documentation)
- [ ] test (Test Coverage)
- [ ] chore (Clean Up / Maintenance Tasks)
- [ ] other (Anything that doesn't fit the above)

### What this PR does / Why we need it?

### Which Jira/Github issue(s) does this PR fix?

- Related Issue #
- Closes #

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [x] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
- [ ] Backward compatible

<!-- Keep the below label to auto squash commits -->
/label tide/merge-method-squash
