### PR TITLE
[SREP-3071] Update go runtime to 1.25.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/backplane-cli
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
### What type of PR is this?

- [ ] fix (Bug Fix)
- [ ] feat (New Feature)
- [ ] docs (Documentation)
- [ ] test (Test Coverage)
- [ ] chore (Clean Up / Maintenance Tasks)
- [x] other (Anything that doesn't fit the above)

### What this PR does / Why we need it?

Update Go to 1.25.5 to mitigate [CVE-2025-61727](https://www.cve.org/CVERecord?id=CVE-2025-61727).

### Which Jira/Github issue(s) does this PR fix?

- Related Issue [SREP-3071](https://issues.redhat.com/browse/SREP-3071)

### Special notes for your reviewer

### Unit Test Coverage
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [x] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
- [x] Backward compatible

<!-- Keep the below label to auto squash commits -->
/label tide/merge-method-squash


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go runtime version to 1.25.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->