### PR TITLE
fix: remove duplicated error message for cloud console

### DIFF
--- a/cmd/ocm-backplane/cloud/common.go
+++ b/cmd/ocm-backplane/cloud/common.go
@@ -333,15 +333,7 @@ func (cfg *QueryConfig) getIsolatedCredentials(ocmToken string) (aws.Credentials
 		if readErr == nil {
 			bodyStr = strings.TrimSpace(string(bodyBytes))
 		}
-		// Restore the body for TryPrintAPIError to parse it
-		if readErr == nil {
-			response.Body = io.NopCloser(strings.NewReader(bodyStr))
-		}
-		apiErr := utils.TryPrintAPIError(response, false)
-		if apiErr != nil {
-			return aws.Credentials{}, fmt.Errorf("failed to fetch arn sequence: %w (response body: %s)", apiErr, bodyStr)
-		}
-		return aws.Credentials{}, fmt.Errorf("failed to fetch arn sequence: status %s (response body: %s)", response.Status, bodyStr)
+		return aws.Credentials{}, fmt.Errorf("failed to fetch arn sequence:\nStatus: %s\nResponse body: %s", response.Status, bodyStr)
 	}
 
 	bytes, err := io.ReadAll(response.Body)

--- a/cmd/ocm-backplane/cloud/common_test.go
+++ b/cmd/ocm-backplane/cloud/common_test.go
@@ -283,7 +283,7 @@ var _ = Describe("getIsolatedCredentials", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to fetch arn sequence:"))
 			// Verify the response body is included in the error message
-			Expect(err.Error()).To(ContainSubstring("response body:"))
+			Expect(err.Error()).To(ContainSubstring("Response body:"))
 			Expect(err.Error()).To(ContainSubstring("Internal server error"))
 		})
 		It("should fail if error creating backplane api client", func() {

--- a/docs/macOS.md
+++ b/docs/macOS.md
@@ -1,0 +1,53 @@
+# Running backplane-cli on macOS Apple Silicon
+
+The `ocm backplane console` command runs the console container locally using the same container image as the logged-in cluster, which is typically built for Linux/amd64. For better compatibility and performance on macOS with Apple Silicon (M1/M2/M3), you should configure Podman to use `Rosetta` instead of `QEMU` for x86_64 emulation.
+
+## Steps to Configure Podman with Rosetta
+
+### 1. Update Podman
+
+Ensure you have the latest version of Podman installed:
+
+```bash
+brew upgrade podman
+```
+
+Alternatively, download the latest installer from [podman.io](https://podman.io/).
+
+### 2. Configure Rosetta Support
+
+Edit `~/.config/containers/containers.conf` to specify the provider and enable Rosetta:
+
+```ini
+[machine]
+provider = "applehv"
+rosetta = true
+```
+
+### 3. Recreate the Podman Machine
+
+Remove the existing VM and create a new one. **Warning:** This will erase all existing container images and data.
+
+```bash
+podman machine reset
+podman machine init
+podman machine start
+```
+
+### 4. Verify Rosetta is Enabled
+
+Check that Rosetta is properly configured:
+
+```bash
+# Verify Rosetta is enabled in machine configuration
+podman machine inspect --format '{{.Rosetta}}'
+# Expected output: true
+
+# Enable Rosetta activation
+podman machine ssh "sudo touch /etc/containers/enable-rosetta"
+podman machine ssh "sudo systemctl restart rosetta-activation.service"
+
+# Verify Rosetta is available in binfmt
+podman machine ssh "ls /proc/sys/fs/binfmt_misc/"
+# Expected output should include 'rosetta' in the list
+```


### PR DESCRIPTION
<!--
PR Title Format (please follow):

[Ticket(optional)] type: short description

Examples:
[SREP-1234] feat: add gcp cloud support
fix: fix timezone convertion
-->

### What type of PR is this?

- [x] fix (Bug Fix)
- [ ] feat (New Feature)
- [ ] docs (Documentation)
- [ ] test (Test Coverage)
- [ ] chore (Clean Up / Maintenance Tasks)
- [ ] other (Anything that doesn't fit the above)

### What this PR does / Why we need it?

The backplane cloud console error message is duplicated, removing the formatted one and keep the raw response.

Before:
```
ERRO[0008] failed to get cloud console for cluster xxxxxxx: failed to assume role with isolated backplane flow: failed to fetch arn sequence: error from backplane: 
 Status Code: 403
 Message: no pending or approved access request:
consider running the following command to create one:
ocm-backplane accessrequest create (response body: {"statusCode":403,"message":"no pending or approved access request:\nconsider running the following command to create one:\nocm-backplane accessrequest create"})
```

After:
```
./ocm-backplane cloud console xxxxxx
ERRO[0010] failed to get cloud console for cluster xxxxxxx: failed to assume role with isolated backplane flow: failed to fetch arn sequence:
Status: 403 Forbidden
Response body: {"statusCode":403,"message":"no pending or approved access request:\nconsider running the following command to create one:\nocm-backplane accessrequest create"} 
```

### Which Jira/Github issue(s) does this PR fix?

- Related Issue #
- Closes #

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [x] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
- [ ] Backward compatible

<!-- Keep the below label to auto squash commits -->
/label tide/merge-method-squash


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive macOS setup guide for configuring Podman on Apple Silicon with Rosetta support to ensure x86_64 compatibility when running the backplane console container.

* **Bug Fixes**
  * Enhanced error message formatting for API error responses to improve user feedback clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->