### PR TITLE
Fix Jira integration for Atlassian Cloud migration

### DIFF
--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -44,6 +44,7 @@ type BackplaneConfiguration struct {
 	PagerDutyAPIKey             string                          `json:"pd-key"`
 	JiraBaseURL                 string                          `json:"jira-base-url"`
 	JiraToken                   string                          `json:"jira-token"`
+	JiraEmail                   string                          `json:"jira-email"`
 	JiraConfigForAccessRequests AccessRequestsJiraConfiguration `json:"jira-config-for-access-requests"`
 	VPNCheckEndpoint            string                          `json:"vpn-check-endpoint"`
 	ProxyCheckEndpoint          string                          `json:"proxy-check-endpoint"`
@@ -58,9 +59,10 @@ const (
 	JiraBaseURLKey                      = "jira-base-url"
 	AssumeInitialArnKey                 = "assume-initial-arn"
 	JiraTokenViperKey                   = "jira-token"
+	JiraEmailViperKey                   = "jira-email"
 	JiraConfigForAccessRequestsKey      = "jira-config-for-access-requests"
 	prodEnvNameDefaultValue             = "production"
-	JiraBaseURLDefaultValue             = "https://issues.redhat.com"
+	JiraBaseURLDefaultValue             = "https://redhat.atlassian.net"
 	proxyTestTimeout                    = 10 * time.Second
 	GovcloudDefaultValue           bool = false
 	GovcloudDefaultValueKey             = "govcloud"
@@ -230,6 +232,13 @@ func GetBackplaneConfigurationWithConn(ocmConn *ocmsdk.Connection) (bpConfig Bac
 	bpConfig.JiraToken = os.Getenv(info.BackplaneJiraAPITokenEnvName)
 	if bpConfig.JiraToken == "" {
 		bpConfig.JiraToken = viper.GetString(JiraTokenViperKey)
+	}
+
+	// JIRA email is required for Atlassian Cloud basic auth
+	// JIRA_EMAIL env var takes precedence, fallback to config file
+	bpConfig.JiraEmail = os.Getenv(info.BackplaneJiraEmailEnvName)
+	if bpConfig.JiraEmail == "" {
+		bpConfig.JiraEmail = viper.GetString(JiraEmailViperKey)
 	}
 
 	// JIRA config for access requests is optional as there is a default value

--- a/pkg/cli/config/config_test.go
+++ b/pkg/cli/config/config_test.go
@@ -75,6 +75,86 @@ func TestGetBackplaneConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("it reads JIRA email from JIRA_EMAIL environment variable when config file is empty", func(t *testing.T) {
+		viper.Reset()
+		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("dummy data"))
+		}))
+
+		expectedEmail := "user@redhat.com"
+		userDefinedProxy := "example-proxy"
+		t.Setenv("BACKPLANE_URL", svr.URL)
+		t.Setenv("HTTPS_PROXY", userDefinedProxy)
+		t.Setenv("JIRA_EMAIL", expectedEmail)
+
+		config, err := GetBackplaneConfiguration()
+		if err != nil {
+			t.Error(err)
+		}
+
+		if config.JiraEmail != expectedEmail {
+			t.Errorf("expected JiraEmail to be %s, got %s", expectedEmail, config.JiraEmail)
+		}
+	})
+
+	t.Run("JIRA_EMAIL environment variable takes precedence over config file value", func(t *testing.T) {
+		viper.Reset()
+		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("dummy data"))
+		}))
+
+		configEmail := "config@redhat.com"
+		envEmail := "env@redhat.com"
+
+		t.Setenv("BACKPLANE_URL", svr.URL)
+		t.Setenv("JIRA_EMAIL", envEmail)
+
+		// Simulate config file value
+		viper.Set(JiraEmailViperKey, configEmail)
+
+		config, err := GetBackplaneConfiguration()
+		if err != nil {
+			t.Error(err)
+		}
+
+		if config.JiraEmail != envEmail {
+			t.Errorf("expected environment variable email to take precedence: expected %s, got %s", envEmail, config.JiraEmail)
+		}
+	})
+
+	t.Run("JiraEmail falls back to config file when JIRA_EMAIL env var is not set", func(t *testing.T) {
+		viper.Reset()
+
+		tmpDir := t.TempDir()
+		configPath := tmpDir + "/config.json"
+		configContent := `{
+			"jira-email": "configfile@redhat.com"
+		}`
+		err := os.WriteFile(configPath, []byte(configContent), 0600)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Setenv("BACKPLANE_CONFIG", configPath)
+
+		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("dummy data"))
+		}))
+		defer svr.Close()
+
+		t.Setenv("BACKPLANE_URL", svr.URL)
+		t.Setenv("HTTPS_PROXY", "example-proxy")
+
+		config, err := GetBackplaneConfiguration()
+		if err != nil {
+			t.Error(err)
+		}
+
+		if config.JiraEmail != "configfile@redhat.com" {
+			t.Errorf("expected JiraEmail from config file, got %s", config.JiraEmail)
+		}
+	})
+
 	t.Run("JIRA_API_TOKEN environment variable takes precedence over config file JIRA token", func(t *testing.T) {
 		viper.Reset()
 		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -15,6 +15,7 @@ const (
 	BackplaneConfigPathEnvName = "BACKPLANE_CONFIG"
 	BackplaneKubeconfigEnvName = "KUBECONFIG"
 	BackplaneJiraAPITokenEnvName = "JIRA_API_TOKEN" //nolint:gosec
+	BackplaneJiraEmailEnvName   = "JIRA_EMAIL"
 
 	// Configuration
 	BackplaneConfigDefaultFilePath = ".config/backplane"

--- a/pkg/jira/issueService.go
+++ b/pkg/jira/issueService.go
@@ -86,11 +86,16 @@ func createIssueService() (*jira.IssueService, error) {
 	}
 
 	if bpConfig.JiraToken == "" {
-		return nil, fmt.Errorf("JIRA token is not defined, consider defining it running 'ocm-backplane config set %s <token value>'", config.JiraTokenViperKey)
+		return nil, fmt.Errorf("JIRA API token is not defined, consider defining it running 'ocm-backplane config set %s <token value>'", config.JiraTokenViperKey)
 	}
 
-	transport := jira.PATAuthTransport{
-		Token: bpConfig.JiraToken,
+	if bpConfig.JiraEmail == "" {
+		return nil, fmt.Errorf("JIRA email is not defined, consider defining it running 'ocm-backplane config set %s <email>' or setting the JIRA_EMAIL environment variable", config.JiraEmailViperKey)
+	}
+
+	transport := jira.BasicAuthTransport{
+		Username: bpConfig.JiraEmail,
+		Password: bpConfig.JiraToken,
 	}
 
 	jiraClient, err := jira.NewClient(transport.Client(), bpConfig.JiraBaseURL)

--- a/pkg/jira/ohssService.go
+++ b/pkg/jira/ohssService.go
@@ -2,7 +2,7 @@ package jira
 
 import (
 	"fmt"
-	"strings"
+	"net/url"
 
 	"github.com/andygrunwald/go-jira"
 )
@@ -72,8 +72,9 @@ func (j *OHSSService) formatIssue(issue jira.Issue) (formatIssue OHSSIssue, err 
 		formatIssue.Title = issue.Fields.Summary
 	}
 	if issue.Self != "" {
-		selfSlice := strings.SplitAfter(issue.Self, ".com")
-		formatIssue.WebURL = fmt.Sprintf("%s/browse/%s", selfSlice[0], issue.Key)
+		if u, err := url.Parse(issue.Self); err == nil {
+			formatIssue.WebURL = fmt.Sprintf("%s://%s/browse/%s", u.Scheme, u.Host, issue.Key)
+		}
 	}
 
 	return formatIssue, nil

--- a/pkg/jira/ohssService_test.go
+++ b/pkg/jira/ohssService_test.go
@@ -62,5 +62,47 @@ var _ = Describe("Jira", func() {
 			Expect(err).NotTo(BeNil())
 			Expect(err.Error()).To(Equal("no matching issue for issueID:OHSS-1000"))
 		})
+
+		It("Should parse Atlassian Cloud .net Self URL into WebURL", func() {
+			testIssue.Key = testOHSSID
+			testIssue.Self = "https://redhat.atlassian.net/rest/api/2/issue/12345"
+			mockIssueService.EXPECT().Get(testOHSSID, nil).Return(&testIssue, nil, nil).Times(1)
+
+			issue, err := ohssService.GetIssue(testOHSSID)
+			Expect(err).To(BeNil())
+			Expect(issue.WebURL).To(Equal("https://redhat.atlassian.net/browse/OHSS-1000"))
+		})
+
+		It("Should parse legacy .com Self URL into WebURL", func() {
+			testIssue.Key = testOHSSID
+			testIssue.Self = "https://issues.redhat.com/rest/api/2/issue/12345"
+			mockIssueService.EXPECT().Get(testOHSSID, nil).Return(&testIssue, nil, nil).Times(1)
+
+			issue, err := ohssService.GetIssue(testOHSSID)
+			Expect(err).To(BeNil())
+			Expect(issue.WebURL).To(Equal("https://issues.redhat.com/browse/OHSS-1000"))
+		})
+
+		It("Should return empty WebURL when Self is empty", func() {
+			testIssue.Key = testOHSSID
+			testIssue.Self = ""
+			mockIssueService.EXPECT().Get(testOHSSID, nil).Return(&testIssue, nil, nil).Times(1)
+
+			issue, err := ohssService.GetIssue(testOHSSID)
+			Expect(err).To(BeNil())
+			Expect(issue.WebURL).To(Equal(""))
+		})
+
+		It("Should extract ClusterID from custom field", func() {
+			issueFields.Unknowns = map[string]interface{}{
+				CustomFieldClusterID: "abc-123-def-456",
+			}
+			testIssue.Fields = issueFields
+			mockIssueService.EXPECT().Get(testOHSSID, nil).Return(&testIssue, nil, nil).Times(1)
+
+			issue, err := ohssService.GetIssue(testOHSSID)
+			Expect(err).To(BeNil())
+			Expect(issue.ClusterID).To(Equal("abc-123-def-456"))
+		})
 	})
 })


### PR DESCRIPTION
## Problem

Red Hat migrated Jira from on-prem (`https://issues.redhat.com`) to Atlassian Cloud (`https://redhat.atlassian.net`). This broke `ocm-backplane accessrequest create` — users receive a 403 when the CLI tries to create Jira notification issues because:

1. The default Jira base URL still pointed to the old on-prem instance
2. PAT (Personal Access Token) authentication is not supported by Atlassian Cloud — it requires Basic Auth (email + API token)
3. URL parsing in `ohssService.go` hardcoded a `.com` domain suffix via `strings.SplitAfter(issue.Self, ".com")`, which breaks for `.net` domains

## Practical Impact

SREs have been unable to use AccessRequests since the Jira migration a few weeks ago. SREs were unaware they were able to break-glass to access clusters when AccessRequests were not working, resulting in delayed incident response and cluster access issues.

## Changes

- **`pkg/cli/config/config.go`**: Update default `JiraBaseURL` to `https://redhat.atlassian.net`. Add `JiraEmail` field to `BackplaneConfiguration` with `JIRA_EMAIL` env var support and config file fallback.
- **`pkg/info/info.go`**: Add `BackplaneJiraEmailEnvName` constant for the `JIRA_EMAIL` environment variable.
- **`pkg/jira/issueService.go`**: Switch from `jira.PATAuthTransport` to `jira.BasicAuthTransport` using email + API token. Add validation for missing `JiraEmail`.
- **`pkg/jira/ohssService.go`**: Replace brittle `strings.SplitAfter(issue.Self, ".com")` with `net/url.Parse()` for domain-agnostic URL construction.

### New Tests
- **`pkg/jira/ohssService_test.go`**: Tests for Atlassian Cloud `.net` URL parsing, legacy `.com` URL parsing, empty `Self` field, and `ClusterID` custom field extraction.
- **`pkg/cli/config/config_test.go`**: Tests for `JIRA_EMAIL` env var loading, env var precedence over config file, and config file fallback.

## User Migration

After this change, users need to configure their Jira email:
```bash
ocm-backplane config set jira-email user@redhat.com
```
Or via environment variable:
```bash
export JIRA_EMAIL=user@redhat.com
```

## Context

- Slack thread (SRE report): https://redhat-internal.slack.com/archives/CCX9DB894/p1774993570377999
- Jira card: https://redhat.atlassian.net/browse/SREP-4316
- Slack thread (IAM discussion): https://redhat-internal.slack.com/archives/C0A8S4L99C2/p1775002180233219
- osdctl fix for same issue: https://github.com/openshift/osdctl/commit/54dbc7aefe1f2efdef5c8959f99309fb4412187c
- Companion MR (backplane-api config update): https://gitlab.cee.redhat.com/service/backplane-api/-/merge_requests/857

## Test Plan

- [x] `go test ./pkg/jira/...` — 7/7 pass
- [x] `go test ./pkg/cli/config/...` — all pass
- [x] `go test ./pkg/accessrequest/...` — all pass
- [ ] Manual test: `ocm-backplane accessrequest create` with `JIRA_EMAIL` and `JIRA_API_TOKEN` set against a cluster with access protection enabled