### PR TITLE
[SREP-3695] docs: add a doc for macOS setup

### DIFF
--- a/docs/macOS.md
+++ b/docs/macOS.md
@@ -1,0 +1,53 @@
+# Running backplane-cli on macOS Apple Silicon
+
+The `ocm backplane console` command runs the console container locally using the same container image as the logged-in cluster, which is typically built for Linux/amd64. For better compatibility and performance on macOS with Apple Silicon (M1/M2/M3), you should configure Podman to use `Rosetta` instead of `QEMU` for x86_64 emulation.
+
+## Steps to Configure Podman with Rosetta
+
+### 1. Update Podman
+
+Ensure you have the latest version of Podman installed:
+
+```bash
+brew upgrade podman
+```
+
+Alternatively, download the latest installer from [podman.io](https://podman.io/).
+
+### 2. Configure Rosetta Support
+
+Edit `~/.config/containers/containers.conf` to specify the provider and enable Rosetta:
+
+```ini
+[machine]
+provider = "applehv"
+rosetta = true
+```
+
+### 3. Recreate the Podman Machine
+
+Remove the existing VM and create a new one. **Warning:** This will erase all existing container images and data.
+
+```bash
+podman machine reset
+podman machine init
+podman machine start
+```
+
+### 4. Verify Rosetta is Enabled
+
+Check that Rosetta is properly configured:
+
+```bash
+# Verify Rosetta is enabled in machine configuration
+podman machine inspect --format '{{.Rosetta}}'
+# Expected output: true
+
+# Enable Rosetta activation
+podman machine ssh "sudo touch /etc/containers/enable-rosetta"
+podman machine ssh "sudo systemctl restart rosetta-activation.service"
+
+# Verify Rosetta is available in binfmt
+podman machine ssh "ls /proc/sys/fs/binfmt_misc/"
+# Expected output should include 'rosetta' in the list
+```


### PR DESCRIPTION

### What type of PR is this?

- [ ] fix (Bug Fix)
- [ ] feat (New Feature)
- [x] docs (Documentation)
- [ ] test (Test Coverage)
- [ ] chore (Clean Up / Maintenance Tasks)
- [ ] other (Anything that doesn't fit the above)

### What this PR does / Why we need it?
Some console containers fail to start on macOS. Investigation shows it is a problem with x86 emulation on ARM chips. Tested that using the Rosetta emulation can solve the problem.

### Which Jira/Github issue(s) does this PR fix?
https://redhat.atlassian.net/browse/SREP-3695

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
- [ ] Backward compatible

<!-- Keep the below label to auto squash commits -->
/label tide/merge-method-squash
