### PR TITLE
SREP-4720: fix stale jira custom fields

### DIFF
--- a/pkg/jira/ohssService.go
+++ b/pkg/jira/ohssService.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	JiraOHSSProjectKey   = "OHSS"
-	CustomFieldClusterID = "customfield_12316349"
+	CustomFieldClusterID = "customfield_10852"
 )
 
 type OHSSIssue struct {


### PR DESCRIPTION
                                                                                                                                                                                                                                                                                                                   ### What type of PR is this?                                                                                                                                                                                                                                                                                    

  - [x] fix (Bug Fix)
  - [ ] feat (New Feature)
  - [ ] docs (Documentation)
  - [ ] test (Test Coverage)
  - [ ] chore (Clean Up / Maintenance Tasks)                                                                                                                                                                                                                                                                        
  - [ ] other (Anything that doesn't fit the above)
                                                                                                                                                                                                                                                                                                                    
  ### What this PR does / Why we need it?                                                                                                                                                                                                                                                                         

  After the migration to Atlassian Cloud, the Jira custom field ID for Cluster ID (`customfield_12316349`) no longer exists. The `formatIssue()` function in the OHSS service reads the Cluster ID from this field, which always returns null/empty. This means any code relying on `OHSSIssue.ClusterID` always    
  gets a blank value.
                                                                                                                                                                                                                                                                                                                    
  This PR updates the constant to the correct field ID (`customfield_10852`) as confirmed via the Jira REST API.                                                                                                                                                                                                    
   
  A corresponding fix for osdctl (which has the same issue plus two additional stale field IDs) will be submitted separately.                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                  
  ### Which Jira/Github issue(s) does this PR fix?                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                  
  - Related Issue: [SREP-4720](https://redhat.atlassian.net/browse/SREP-4720)                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                  
  ### Special notes for your reviewer                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                  
  The old field ID `customfield_12316349` became stale after the Atlassian Cloud migration. Verified against multiple OHSS tickets (OHSS-52710, [OHSS-53044](https://redhat.atlassian.net/browse/OHSS-53044)) that the old ID returns null while the new ID (`customfield_10852`) returns the correct Cluster ID value.                                               
   
  JQL-based searches are not affected by this bug because they use the human-readable field name `"Cluster ID"`, which Jira resolves correctly at query time. Only direct field access via the API response is broken.                                                                                              
                                                                                                                                                                                                                                                                                                                  
  ### Unit Test Coverage                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                  
  - [ ] Added unit tests                                                                                                                                                                                                                                                                                            
  - [ ] Created jira card to add unit test                                                                                                                                                                                                                                                                        
  - [x] This PR may not need unit tests                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                    
  ### Pre-checks (if applicable)                                                                                                                                                                                                                                                                                    
  - [x] Ran unit tests locally                                                                                                                                                                                                                                                                                      
  - [] Validated the changes in a cluster                                                                                                                                                                                                                                                                          
  - [ ] Included documentation changes with PR                                                                                                                                                                                                                                                                      
  - [x] Backward compatible                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal field mapping to ensure correct data retrieval and issue formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->