### PR TITLE
[SREP-3695] feat: add a warning message if mac users run podman without rosetta

### DIFF
--- a/pkg/container/container_podman.go
+++ b/pkg/container/container_podman.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
 	"os"
@@ -9,6 +10,24 @@ import (
 
 	logger "github.com/sirupsen/logrus"
 )
+
+// checkRosettaEnabled verifies if Rosetta is enabled in Podman on macOS
+// This is a non-blocking check that provides a hint to the user if Rosetta is not configured
+func checkRosettaEnabled() {
+	checkCmd := createCommand(PODMAN, "machine", "ssh", "ls /proc/sys/fs/binfmt_misc/")
+	var out bytes.Buffer
+	checkCmd.Stdout = &out
+	checkCmd.Stderr = nil
+
+	if err := checkCmd.Run(); err != nil {
+		// Silently skip if we can't check
+		return
+	}
+
+	if !strings.Contains(out.String(), "rosetta") {
+		logger.Warnf("Rosetta does not appear to be enabled in Podman. For better compatibility with x86_64 images on Apple Silicon, please configure Rosetta. See docs/macOS.md for setup instructions.")
+	}
+}
 
 type podmanLinux struct {
 	fileMountDir string
@@ -82,6 +101,8 @@ func podmanRunConsoleContainer(containerName string, port string, consoleArgs []
 }
 
 func (ce *podmanMac) RunConsoleContainer(containerName string, port string, consoleArgs []string, envVars []EnvVar) error {
+	// Check if Rosetta is enabled for better compatibility
+	checkRosettaEnabled()
 	return podmanRunConsoleContainer(containerName, port, consoleArgs, envVars)
 }
 

--- a/pkg/container/container_podman.go
+++ b/pkg/container/container_podman.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	logger "github.com/sirupsen/logrus"
@@ -14,6 +15,11 @@ import (
 // checkRosettaEnabled verifies if Rosetta is enabled in Podman on macOS
 // This is a non-blocking check that provides a hint to the user if Rosetta is not configured
 func checkRosettaEnabled() {
+	// Rosetta is only relevant on Apple Silicon (arm64); skip on Intel Macs
+	if runtime.GOARCH != "arm64" {
+		return
+	}
+
 	checkCmd := createCommand(PODMAN, "machine", "ssh", "ls /proc/sys/fs/binfmt_misc/")
 	var out bytes.Buffer
 	checkCmd.Stdout = &out

--- a/pkg/container/container_podman.go
+++ b/pkg/container/container_podman.go
@@ -31,7 +31,7 @@ func checkRosettaEnabled() {
 	}
 
 	if !strings.Contains(out.String(), "rosetta") {
-		logger.Warnf("Rosetta does not appear to be enabled in Podman. For better compatibility with x86_64 images on Apple Silicon, please configure Rosetta. See docs/macOS.md for setup instructions.")
+		logger.Warnf("Rosetta does not appear to be enabled in Podman. For better compatibility with x86_64 images on Apple Silicon, please configure Rosetta. See https://github.com/openshift/backplane-cli/blob/main/docs/macOS.md for setup instructions.")
 	}
 }
 

--- a/pkg/container/container_podman.go
+++ b/pkg/container/container_podman.go
@@ -15,8 +15,8 @@ import (
 // checkRosettaEnabled verifies if Rosetta is enabled in Podman on macOS
 // This is a non-blocking check that provides a hint to the user if Rosetta is not configured
 func checkRosettaEnabled() {
-	// Rosetta is only relevant on Apple Silicon (arm64); skip on Intel Macs
-	if runtime.GOARCH != "arm64" {
+	// Rosetta is only relevant on Apple Silicon (arm64) macOS; skip on other platforms
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
 		return
 	}
 

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -100,6 +100,44 @@ var _ = Describe("console container implementation", func() {
 		})
 	})
 
+	Context("when checking Rosetta on macOS Podman", func() {
+		It("should execute podman machine ssh command to check binfmt_misc", func() {
+			capturedCommands = nil
+			checkRosettaEnabled()
+			Expect(len(capturedCommands)).To(Equal(1))
+			command := capturedCommands[0]
+			Expect(command[0]).To(Equal(PODMAN))
+			Expect(command[1]).To(Equal("machine"))
+			Expect(command[2]).To(Equal("ssh"))
+			Expect(strings.Join(command[3:], " ")).To(Equal("ls /proc/sys/fs/binfmt_misc/"))
+		})
+	})
+
+	Context("when running console container on macOS", func() {
+		ce := podmanMac{}
+		It("should check Rosetta before running the container", func() {
+			mockOcmInterface.EXPECT().GetPullSecret().Return(pullSecret, nil).AnyTimes()
+			capturedCommands = nil
+			args := []string{"arg1"}
+			envvars := []EnvVar{{Key: "testkey", Value: "testval"}}
+			err := ce.RunConsoleContainer("console", "8888", args, envvars)
+			Expect(err).To(BeNil())
+			// Should have 2 commands: 1 for Rosetta check, 1 for running container
+			Expect(len(capturedCommands)).To(BeNumerically(">=", 2))
+			// First command should be Rosetta check
+			rosettaCheckCmd := capturedCommands[0]
+			Expect(rosettaCheckCmd[0]).To(Equal(PODMAN))
+			Expect(rosettaCheckCmd[1]).To(Equal("machine"))
+			Expect(rosettaCheckCmd[2]).To(Equal("ssh"))
+			// Last command should be the actual container run
+			runCmd := capturedCommands[len(capturedCommands)-1]
+			fullCommand := strings.Join(runCmd, " ")
+			Expect(fullCommand).To(ContainSubstring("arg1"))
+			Expect(fullCommand).To(ContainSubstring("--env"))
+			Expect(fullCommand).To(ContainSubstring("testkey=testval"))
+		})
+	})
+
 	Context("when running console container", func() {
 		ce := podmanMac{}
 		It("should pass argments and environment variable if specified", func() {
@@ -109,8 +147,9 @@ var _ = Describe("console container implementation", func() {
 			envvars := []EnvVar{{Key: "testkey", Value: "testval"}}
 			err := ce.RunConsoleContainer("console", "8888", args, envvars)
 			Expect(err).To(BeNil())
-			Expect(len(capturedCommands)).To(Equal(1))
-			fullCommand := strings.Join(capturedCommands[0], " ")
+			Expect(len(capturedCommands)).To(BeNumerically(">=", 1))
+			// Find the run command (should be the last one)
+			fullCommand := strings.Join(capturedCommands[len(capturedCommands)-1], " ")
 			// arg
 			Expect(fullCommand).To(ContainSubstring("arg1"))
 			// env var

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -3,6 +3,7 @@ package container
 import (
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -101,40 +102,75 @@ var _ = Describe("console container implementation", func() {
 	})
 
 	Context("when checking Rosetta on macOS Podman", func() {
-		It("should execute podman machine ssh command to check binfmt_misc", func() {
-			capturedCommands = nil
-			checkRosettaEnabled()
-			Expect(len(capturedCommands)).To(Equal(1))
-			command := capturedCommands[0]
-			Expect(command[0]).To(Equal(PODMAN))
-			Expect(command[1]).To(Equal("machine"))
-			Expect(command[2]).To(Equal("ssh"))
-			Expect(strings.Join(command[3:], " ")).To(Equal("ls /proc/sys/fs/binfmt_misc/"))
+		It("should execute podman machine ssh command on arm64", func() {
+			if os.Getenv("GOARCH") == "arm64" || (os.Getenv("GOARCH") == "" && runtime.GOARCH == "arm64") {
+				capturedCommands = nil
+				checkRosettaEnabled()
+				Expect(len(capturedCommands)).To(Equal(1))
+				command := capturedCommands[0]
+				Expect(command[0]).To(Equal(PODMAN))
+				Expect(command[1]).To(Equal("machine"))
+				Expect(command[2]).To(Equal("ssh"))
+				Expect(strings.Join(command[3:], " ")).To(Equal("ls /proc/sys/fs/binfmt_misc/"))
+			} else {
+				Skip("Rosetta check only runs on arm64 architecture")
+			}
+		})
+		It("should skip the check on non-arm64 architectures", func() {
+			if os.Getenv("GOARCH") != "arm64" && (os.Getenv("GOARCH") != "" || runtime.GOARCH != "arm64") {
+				capturedCommands = nil
+				checkRosettaEnabled()
+				Expect(len(capturedCommands)).To(Equal(0))
+			} else {
+				Skip("This test only runs on non-arm64 architectures")
+			}
 		})
 	})
 
 	Context("when running console container on macOS", func() {
 		ce := podmanMac{}
-		It("should check Rosetta before running the container", func() {
-			mockOcmInterface.EXPECT().GetPullSecret().Return(pullSecret, nil).AnyTimes()
-			capturedCommands = nil
-			args := []string{"arg1"}
-			envvars := []EnvVar{{Key: "testkey", Value: "testval"}}
-			err := ce.RunConsoleContainer("console", "8888", args, envvars)
-			Expect(err).To(BeNil())
-			// Should have 2 commands: 1 for Rosetta check, 1 for running container
-			Expect(len(capturedCommands)).To(BeNumerically(">=", 2))
-			// First command should be Rosetta check
-			rosettaCheckCmd := capturedCommands[0]
-			Expect(rosettaCheckCmd[0]).To(Equal(PODMAN))
-			Expect(rosettaCheckCmd[1]).To(Equal("machine"))
-			Expect(rosettaCheckCmd[2]).To(Equal("ssh"))
-			// Last command should be the actual container run
-			runCmd := capturedCommands[len(capturedCommands)-1]
-			fullCommand := strings.Join(runCmd, " ")
-			Expect(fullCommand).To(ContainSubstring("arg1"))
-			Expect(fullCommand).To(ContainSubstring("--env"))
-			Expect(fullCommand).To(ContainSubstring("testkey=testval"))
+		It("should check Rosetta before running the container on arm64", func() {
+			if os.Getenv("GOARCH") == "arm64" || (os.Getenv("GOARCH") == "" && runtime.GOARCH == "arm64") {
+				mockOcmInterface.EXPECT().GetPullSecret().Return(pullSecret, nil).AnyTimes()
+				capturedCommands = nil
+				args := []string{"arg1"}
+				envvars := []EnvVar{{Key: "testkey", Value: "testval"}}
+				err := ce.RunConsoleContainer("console", "8888", args, envvars)
+				Expect(err).To(BeNil())
+				// Should have 2 commands: 1 for Rosetta check, 1 for running container
+				Expect(len(capturedCommands)).To(BeNumerically(">=", 2))
+				// First command should be Rosetta check
+				rosettaCheckCmd := capturedCommands[0]
+				Expect(rosettaCheckCmd[0]).To(Equal(PODMAN))
+				Expect(rosettaCheckCmd[1]).To(Equal("machine"))
+				Expect(rosettaCheckCmd[2]).To(Equal("ssh"))
+				// Last command should be the actual container run
+				runCmd := capturedCommands[len(capturedCommands)-1]
+				fullCommand := strings.Join(runCmd, " ")
+				Expect(fullCommand).To(ContainSubstring("arg1"))
+				Expect(fullCommand).To(ContainSubstring("--env"))
+				Expect(fullCommand).To(ContainSubstring("testkey=testval"))
+			} else {
+				Skip("Rosetta check only runs on arm64 architecture")
+			}
+		})
+		It("should skip Rosetta check on non-arm64 architectures", func() {
+			if os.Getenv("GOARCH") != "arm64" && (os.Getenv("GOARCH") != "" || runtime.GOARCH != "arm64") {
+				mockOcmInterface.EXPECT().GetPullSecret().Return(pullSecret, nil).AnyTimes()
+				capturedCommands = nil
+				args := []string{"arg1"}
+				envvars := []EnvVar{{Key: "testkey", Value: "testval"}}
+				err := ce.RunConsoleContainer("console", "8888", args, envvars)
+				Expect(err).To(BeNil())
+				// Should only have 1 command for running container (no Rosetta check)
+				Expect(len(capturedCommands)).To(Equal(1))
+				fullCommand := strings.Join(capturedCommands[0], " ")
+				Expect(fullCommand).To(ContainSubstring("arg1"))
+				Expect(fullCommand).To(ContainSubstring("--env"))
+				Expect(fullCommand).To(ContainSubstring("testkey=testval"))
+			} else {
+				Skip("This test only runs on non-arm64 architectures")
+			}
 		})
 	})
 

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -103,7 +103,7 @@ var _ = Describe("console container implementation", func() {
 
 	Context("when checking Rosetta on macOS Podman", func() {
 		It("should execute podman machine ssh command on darwin/arm64", func() {
-			if runtime.GOOS == "darwin" && (os.Getenv("GOARCH") == "arm64" || (os.Getenv("GOARCH") == "" && runtime.GOARCH == "arm64")) {
+			if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
 				capturedCommands = nil
 				checkRosettaEnabled()
 				Expect(len(capturedCommands)).To(Equal(1))
@@ -126,7 +126,7 @@ var _ = Describe("console container implementation", func() {
 			}
 		})
 		It("should skip the check on non-arm64 architectures", func() {
-			if runtime.GOOS == "darwin" && os.Getenv("GOARCH") != "arm64" && (os.Getenv("GOARCH") != "" || runtime.GOARCH != "arm64") {
+			if runtime.GOOS == "darwin" && runtime.GOARCH != "arm64" {
 				capturedCommands = nil
 				checkRosettaEnabled()
 				Expect(len(capturedCommands)).To(Equal(0))
@@ -139,7 +139,7 @@ var _ = Describe("console container implementation", func() {
 	Context("when running console container on macOS", func() {
 		ce := podmanMac{}
 		It("should check Rosetta before running the container on darwin/arm64", func() {
-			if runtime.GOOS == "darwin" && (os.Getenv("GOARCH") == "arm64" || (os.Getenv("GOARCH") == "" && runtime.GOARCH == "arm64")) {
+			if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
 				mockOcmInterface.EXPECT().GetPullSecret().Return(pullSecret, nil).AnyTimes()
 				capturedCommands = nil
 				args := []string{"arg1"}
@@ -182,7 +182,7 @@ var _ = Describe("console container implementation", func() {
 			}
 		})
 		It("should skip Rosetta check on darwin with non-arm64 architectures", func() {
-			if runtime.GOOS == "darwin" && os.Getenv("GOARCH") != "arm64" && (os.Getenv("GOARCH") != "" || runtime.GOARCH != "arm64") {
+			if runtime.GOOS == "darwin" && runtime.GOARCH != "arm64" {
 				mockOcmInterface.EXPECT().GetPullSecret().Return(pullSecret, nil).AnyTimes()
 				capturedCommands = nil
 				args := []string{"arg1"}

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -102,8 +102,8 @@ var _ = Describe("console container implementation", func() {
 	})
 
 	Context("when checking Rosetta on macOS Podman", func() {
-		It("should execute podman machine ssh command on arm64", func() {
-			if os.Getenv("GOARCH") == "arm64" || (os.Getenv("GOARCH") == "" && runtime.GOARCH == "arm64") {
+		It("should execute podman machine ssh command on darwin/arm64", func() {
+			if runtime.GOOS == "darwin" && (os.Getenv("GOARCH") == "arm64" || (os.Getenv("GOARCH") == "" && runtime.GOARCH == "arm64")) {
 				capturedCommands = nil
 				checkRosettaEnabled()
 				Expect(len(capturedCommands)).To(Equal(1))
@@ -113,24 +113,33 @@ var _ = Describe("console container implementation", func() {
 				Expect(command[2]).To(Equal("ssh"))
 				Expect(strings.Join(command[3:], " ")).To(Equal("ls /proc/sys/fs/binfmt_misc/"))
 			} else {
-				Skip("Rosetta check only runs on arm64 architecture")
+				Skip("Rosetta check only runs on darwin/arm64")
 			}
 		})
-		It("should skip the check on non-arm64 architectures", func() {
-			if os.Getenv("GOARCH") != "arm64" && (os.Getenv("GOARCH") != "" || runtime.GOARCH != "arm64") {
+		It("should skip the check on non-darwin platforms", func() {
+			if runtime.GOOS != "darwin" {
 				capturedCommands = nil
 				checkRosettaEnabled()
 				Expect(len(capturedCommands)).To(Equal(0))
 			} else {
-				Skip("This test only runs on non-arm64 architectures")
+				Skip("This test only runs on non-darwin platforms")
+			}
+		})
+		It("should skip the check on non-arm64 architectures", func() {
+			if runtime.GOOS == "darwin" && os.Getenv("GOARCH") != "arm64" && (os.Getenv("GOARCH") != "" || runtime.GOARCH != "arm64") {
+				capturedCommands = nil
+				checkRosettaEnabled()
+				Expect(len(capturedCommands)).To(Equal(0))
+			} else {
+				Skip("This test only runs on darwin with non-arm64 architectures")
 			}
 		})
 	})
 
 	Context("when running console container on macOS", func() {
 		ce := podmanMac{}
-		It("should check Rosetta before running the container on arm64", func() {
-			if os.Getenv("GOARCH") == "arm64" || (os.Getenv("GOARCH") == "" && runtime.GOARCH == "arm64") {
+		It("should check Rosetta before running the container on darwin/arm64", func() {
+			if runtime.GOOS == "darwin" && (os.Getenv("GOARCH") == "arm64" || (os.Getenv("GOARCH") == "" && runtime.GOARCH == "arm64")) {
 				mockOcmInterface.EXPECT().GetPullSecret().Return(pullSecret, nil).AnyTimes()
 				capturedCommands = nil
 				args := []string{"arg1"}
@@ -151,11 +160,11 @@ var _ = Describe("console container implementation", func() {
 				Expect(fullCommand).To(ContainSubstring("--env"))
 				Expect(fullCommand).To(ContainSubstring("testkey=testval"))
 			} else {
-				Skip("Rosetta check only runs on arm64 architecture")
+				Skip("Rosetta check only runs on darwin/arm64")
 			}
 		})
-		It("should skip Rosetta check on non-arm64 architectures", func() {
-			if os.Getenv("GOARCH") != "arm64" && (os.Getenv("GOARCH") != "" || runtime.GOARCH != "arm64") {
+		It("should skip Rosetta check on non-darwin platforms", func() {
+			if runtime.GOOS != "darwin" {
 				mockOcmInterface.EXPECT().GetPullSecret().Return(pullSecret, nil).AnyTimes()
 				capturedCommands = nil
 				args := []string{"arg1"}
@@ -169,7 +178,25 @@ var _ = Describe("console container implementation", func() {
 				Expect(fullCommand).To(ContainSubstring("--env"))
 				Expect(fullCommand).To(ContainSubstring("testkey=testval"))
 			} else {
-				Skip("This test only runs on non-arm64 architectures")
+				Skip("This test only runs on non-darwin platforms")
+			}
+		})
+		It("should skip Rosetta check on darwin with non-arm64 architectures", func() {
+			if runtime.GOOS == "darwin" && os.Getenv("GOARCH") != "arm64" && (os.Getenv("GOARCH") != "" || runtime.GOARCH != "arm64") {
+				mockOcmInterface.EXPECT().GetPullSecret().Return(pullSecret, nil).AnyTimes()
+				capturedCommands = nil
+				args := []string{"arg1"}
+				envvars := []EnvVar{{Key: "testkey", Value: "testval"}}
+				err := ce.RunConsoleContainer("console", "8888", args, envvars)
+				Expect(err).To(BeNil())
+				// Should only have 1 command for running container (no Rosetta check)
+				Expect(len(capturedCommands)).To(Equal(1))
+				fullCommand := strings.Join(capturedCommands[0], " ")
+				Expect(fullCommand).To(ContainSubstring("arg1"))
+				Expect(fullCommand).To(ContainSubstring("--env"))
+				Expect(fullCommand).To(ContainSubstring("testkey=testval"))
+			} else {
+				Skip("This test only runs on darwin with non-arm64 architectures")
 			}
 		})
 	})

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -146,8 +146,15 @@ var _ = Describe("console container implementation", func() {
 				envvars := []EnvVar{{Key: "testkey", Value: "testval"}}
 				err := ce.RunConsoleContainer("console", "8888", args, envvars)
 				Expect(err).To(BeNil())
-				// Should have 2 commands: 1 for Rosetta check, 1 for running container
-				Expect(len(capturedCommands)).To(BeNumerically(">=", 2))
+				// Count Rosetta check commands
+				rosettaCheckCount := 0
+				for _, cmd := range capturedCommands {
+					if len(cmd) >= 3 && cmd[0] == PODMAN && cmd[1] == "machine" && cmd[2] == "ssh" {
+						rosettaCheckCount++
+					}
+				}
+				// Should have exactly 1 Rosetta check
+				Expect(rosettaCheckCount).To(Equal(1))
 				// First command should be Rosetta check
 				rosettaCheckCmd := capturedCommands[0]
 				Expect(rosettaCheckCmd[0]).To(Equal(PODMAN))


### PR DESCRIPTION
<!--
PR Title Format (please follow):

[Ticket(optional)] type: short description

Examples:
[SREP-1234] feat: add gcp cloud support
fix: fix timezone convertion
-->

### What type of PR is this?

- [ ] fix (Bug Fix)
- [x] feat (New Feature)
- [ ] docs (Documentation)
- [ ] test (Test Coverage)
- [ ] chore (Clean Up / Maintenance Tasks)
- [ ] other (Anything that doesn't fit the above)

### What this PR does / Why we need it?

This PR adds a warning message to the mac users who run podman without rosetta.

We encountered compatibility issues where podman container exits with seg fault if running an x86_64 image on mac M1/M2/M3. Enabling rosetta can solve the compatibility issue. 

### Which Jira/Github issue(s) does this PR fix?
https://redhat.atlassian.net/browse/SREP-3695

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [x] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
- [x] Backward compatible

<!-- Keep the below label to auto squash commits -->
/label tide/merge-method-squash


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a macOS (Apple Silicon) pre-start hint that warns non-blockingly when Rosetta appears absent before launching the console container; Linux behavior is unchanged.
  * The check runs early to improve startup transparency while still allowing the container to start.

* **Tests**
  * Added architecture-aware tests to ensure the Rosetta check runs on Apple Silicon and is skipped on other platforms; updated console container tests to support multiple captured commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->