### PR TITLE
[SREP-4818] docs: add intructions to install with Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,14 @@ backplane-cli is a CLI tool to interact with [backplane api](https://github.com/
 
 Go should be installed in your local system. We recommend using the latest stable Go version. For the minimum required version, see the `go` directive in [go.mod](go.mod)
 
-### Option 1: Download from release
+### MacOS
+
+```brew
+brew install backplane-cli
+```
+
+
+### Download from release
 
 Download the latest binary from the GitHub [releases](https://github.com/openshift/backplane-cli/releases) page.
 
@@ -24,7 +31,7 @@ $ chmod +x ocm-backplane
 $ mv ocm-backplane $GOBIN
 ```
 
-### Option 2: Build from source
+### Build from source
 
 First clone the repository somewhere in your `$PATH`. A common place would be within your `$GOPATH`.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Go should be installed in your local system. We recommend using the latest stabl
 ### MacOS
 
 ```brew
-brew install backplane-cli
+brew tap openshift-online/sre-tools
+brew install openshift-online/sre-tools/backplane-cli
 ```
 
 


### PR DESCRIPTION
### What type of PR is this?

- [ ] fix (Bug Fix)
- [ ] feat (New Feature)
- [x] docs (Documentation)
- [ ] test (Test Coverage)
- [ ] chore (Clean Up / Maintenance Tasks)
- [ ] other (Anything that doesn't fit the above)

### What this PR does / Why we need it?

`backplane-cli` is now available within Homebrew, therefore instructions to install it should reflect that.

### Which Jira/Github issue(s) does this PR fix?

- Related Issue [SREP-4818](https://redhat.atlassian.net/browse/SREP-4818)

### Special notes for your reviewer

None.

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [x] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [x] Included documentation changes with PR
- [ ] Backward compatible

<!-- Keep the below label to auto squash commits -->
/label tide/merge-method-squash


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added macOS installation instructions using Homebrew
  * Reorganized installation method sections for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->