### PR TITLE
fix: Add missing config set jira-email

### DIFF
--- a/cmd/ocm-backplane/config/config.go
+++ b/cmd/ocm-backplane/config/config.go
@@ -20,11 +20,13 @@ func NewConfigCmd() *cobra.Command {
 The location of the configuration file is gleaned from ~/.config/backplane/config.json or the 'BACKPLANE_CONFIG' environment variable if set.
 
 The following variables are supported:
-url         Backplane API URL
-proxy-url   Squid proxy URL
-session-dir Backplane CLI session directory
-pd-key		PagerDuty API User Key
-govcloud    Set to true if used in FedRAMP
+url          Backplane API URL
+proxy-url    Squid proxy URL
+session-dir  Backplane CLI session directory
+pd-key	     PagerDuty API User Key
+jira-token   JIRA token
+jira-email   JIRA email
+govcloud     Set to true if used in FedRAMP
 `,
 		SilenceUsage: true,
 	}

--- a/cmd/ocm-backplane/config/set.go
+++ b/cmd/ocm-backplane/config/set.go
@@ -61,6 +61,7 @@ func setConfig(cmd *cobra.Command, args []string) error {
 		}
 		bpConfig.SessionDirectory = viper.GetString("session-dir")
 		bpConfig.JiraToken = viper.GetString(config.JiraTokenViperKey)
+		bpConfig.JiraEmail = viper.GetString(config.JiraEmailViperKey)
 	}
 
 	// create config directory if it doesn't exist
@@ -100,13 +101,15 @@ func setConfig(cmd *cobra.Command, args []string) error {
 		bpConfig.PagerDutyAPIKey = args[1]
 	case config.JiraTokenViperKey:
 		bpConfig.JiraToken = args[1]
+	case config.JiraEmailViperKey:
+		bpConfig.JiraEmail = args[1]
 	case GovcloudVar:
 		bpConfig.Govcloud, err = strconv.ParseBool(args[1])
 		if err != nil {
 			return fmt.Errorf("invalid value for %s: %v", GovcloudVar, err)
 		}
 	default:
-		return fmt.Errorf("supported config variables are %s, %s, %s, %s, %s & %s", URLConfigVar, ProxyURLConfigVar, SessionConfigVar, PagerDutyAPIConfigVar, config.JiraTokenViperKey, GovcloudVar)
+		return fmt.Errorf("supported config variables are %s, %s, %s, %s, %s, %s & %s", URLConfigVar, ProxyURLConfigVar, SessionConfigVar, PagerDutyAPIConfigVar, config.JiraTokenViperKey, config.JiraEmailViperKey, GovcloudVar)
 	}
 
 	viper.SetConfigType("json")
@@ -115,6 +118,7 @@ func setConfig(cmd *cobra.Command, args []string) error {
 	viper.Set(SessionConfigVar, bpConfig.SessionDirectory)
 	viper.Set(PagerDutyAPIConfigVar, bpConfig.PagerDutyAPIKey)
 	viper.Set(config.JiraTokenViperKey, bpConfig.JiraToken)
+	viper.Set(config.JiraEmailViperKey, bpConfig.JiraEmail)
 	viper.Set(GovcloudVar, bpConfig.Govcloud)
 
 	err = viper.WriteConfigAs(configPath)


### PR DESCRIPTION
<!--
PR Title Format (please follow):

[Ticket(optional)] type: short description

Examples:
[SREP-1234] feat: add gcp cloud support
fix: fix timezone convertion
-->

### What type of PR is this?

- [x] fix (Bug Fix)
- [ ] feat (New Feature)
- [ ] docs (Documentation)
- [ ] test (Test Coverage)
- [ ] chore (Clean Up / Maintenance Tasks)
- [ ] other (Anything that doesn't fit the above)

### What this PR does / Why we need it?
Add missing config set jira-email argument

### Which Jira/Github issue(s) does this PR fix?

- Related Issue #
- Closes #

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [x] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [x] Validated the changes in a cluster
- [ ] Included documentation changes with PR
- [ ] Backward compatible

<!-- Keep the below label to auto squash commits -->
/label tide/merge-method-squash


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `ocm backplane config set` command now supports updating the Jira email setting.
  * The configured Jira email value is now persisted in the generated configuration output.
* **Bug Fixes**
  * Improved the command help/validation message so the Jira email option (`jira-email`) is recognized as a supported setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->