### PR TITLE
[ROSAENG-61225] fix: correct elevate command in service login prompt

### DIFF
--- a/cmd/ocm-backplane/login/login.go
+++ b/cmd/ocm-backplane/login/login.go
@@ -288,7 +288,7 @@ func runLogin(cmd *cobra.Command, argv []string) (err error) {
 		if !isHostedControlPlane {
 			return fmt.Errorf("manifestworks are only available for hosted control plane clusters")
 		}
-		listManifestWork := fmt.Sprintf("ocm backplane elevate -- oc get manifestworks -n %s -l api.openshift.com/id=%s", managingClusterName, targetClusterID)
+		listManifestWork := fmt.Sprintf("ocm-backplane elevate -n -- get manifestworks -n %s -l api.openshift.com/id=%s", managingClusterName, targetClusterID)
 
 		fmt.Println("A list of associated manifestwork for your given cluster can be found using:")
 		fmt.Println("\t", listManifestWork)


### PR DESCRIPTION
### What type of PR is this?

- [x] fix (Bug Fix)
- [ ] feat (New Feature)
- [ ] docs (Documentation)
- [ ] test (Test Coverage)
- [x] chore (Clean Up / Maintenance Tasks)
- [ ] other (Anything that doesn't fit the above)

### What this PR does / Why we need it?

The suggested elevate command was missing the -n flag to prompt for an elevation reason, and used the plugin invocation form instead of the shipped binary name.

### Which Jira/Github issue(s) does this PR fix?

- Related Issue #[ROSAENG-61225](https://redhat.atlassian.net/browse/ROSAENG-61225)
- Closes #[ROSAENG-61225](https://redhat.atlassian.net/browse/ROSAENG-61225)

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [ ] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [ ] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
- [ ] Backward compatible

<!-- Keep the below label to auto squash commits -->
/label tide/merge-method-squash


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the generated command shown for listing manifestworks on hosted control plane clusters.
  * The command now uses the correct binary name, includes the required `-n` flag, and adjusts the subcommand after `--` for more accurate copy/paste behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->