### PR TITLE
fix: replace abandoned golangci-lint install script in builder image

### DIFF
--- a/make.Dockerfile
+++ b/make.Dockerfile
@@ -2,11 +2,15 @@ ARG GOLANGCI_LINT_VERSION
 
 FROM registry.access.redhat.com/ubi8/ubi
 
+ARG GOLANGCI_LINT_VERSION
+
 RUN yum install -y ca-certificates git go-toolset make
 
 ENV GOPATH=/go
 ENV PATH="$GOPATH/bin:${PATH}"
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin ${GOLANGCI_LINT_VERSION}
+# Official install URL; the abandoned master-branch script fails checksum verification.
+# https://golangci-lint.run/docs/welcome/install/local/#binaries
+RUN curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b ${GOPATH}/bin ${GOLANGCI_LINT_VERSION}
 
 ADD https://password.corp.redhat.com/RH-IT-Root-CA.crt /etc/pki/ca-trust/source/anchors/
 RUN update-ca-trust extract


### PR DESCRIPTION
## Summary
- Switch `make.Dockerfile` from the abandoned `master` branch `install.sh` (checksum failures) to the official `https://golangci-lint.run/install.sh`.
- Re-declare `GOLANGCI_LINT_VERSION` after `FROM` so the pinned version is actually available in the builder stage.

## Test plan
- [ ] `make build-image` succeeds
- [ ] `make lint-in-container` / `make test-in-container` succeed


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development build process to install golangci-lint from its official source.
  * Added configurable version selection for golangci-lint installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->