### PR TITLE
fix: simplify config get to read directly from viper

### DIFF
--- a/cmd/ocm-backplane/config/get.go
+++ b/cmd/ocm-backplane/config/get.go
@@ -29,7 +29,11 @@ func getConfig(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if _, err = os.Stat(configPath); err == nil {
+	if _, err = os.Stat(configPath); err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("unable to access config file %s: %w", configPath, err)
+		}
+	} else {
 		viper.SetConfigFile(configPath)
 		viper.SetConfigType("json")
 		if err := viper.ReadInConfig(); err != nil {

--- a/cmd/ocm-backplane/config/get.go
+++ b/cmd/ocm-backplane/config/get.go
@@ -2,8 +2,11 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/openshift/backplane-cli/pkg/cli/config"
 )
@@ -21,33 +24,36 @@ func newGetCmd() *cobra.Command {
 }
 
 func getConfig(cmd *cobra.Command, args []string) error {
-	config, err := config.GetBackplaneConfiguration()
+	configPath, err := config.GetConfigFilePath()
 	if err != nil {
 		return err
 	}
 
-	proxyURL := ""
-	if config.ProxyURL != nil {
-		proxyURL = *config.ProxyURL
+	if _, err = os.Stat(configPath); err == nil {
+		viper.SetConfigFile(configPath)
+		viper.SetConfigType("json")
+		if err := viper.ReadInConfig(); err != nil {
+			return err
+		}
 	}
 
 	switch args[0] {
 	case URLConfigVar:
-		fmt.Printf("%s: %s\n", URLConfigVar, config.URL)
+		fmt.Printf("%s: %s\n", URLConfigVar, viper.GetString(URLConfigVar))
 	case ProxyURLConfigVar:
-		fmt.Printf("%s: %s\n", ProxyURLConfigVar, proxyURL)
+		fmt.Printf("%s: %s\n", ProxyURLConfigVar, strings.Join(viper.GetStringSlice(ProxyURLConfigVar), ", "))
 	case SessionConfigVar:
-		fmt.Printf("%s: %s\n", SessionConfigVar, config.SessionDirectory)
+		fmt.Printf("%s: %s\n", SessionConfigVar, viper.GetString(SessionConfigVar))
 	case PagerDutyAPIConfigVar:
-		fmt.Printf("%s: %s\n", PagerDutyAPIConfigVar, config.PagerDutyAPIKey)
+		fmt.Printf("%s: %s\n", PagerDutyAPIConfigVar, viper.GetString(PagerDutyAPIConfigVar))
 	case GovcloudVar:
-		fmt.Printf("%s: %t\n", GovcloudVar, config.Govcloud)
+		fmt.Printf("%s: %t\n", GovcloudVar, viper.GetBool(GovcloudVar))
 	case "all":
-		fmt.Printf("%s: %s\n", URLConfigVar, config.URL)
-		fmt.Printf("%s: %s\n", ProxyURLConfigVar, proxyURL)
-		fmt.Printf("%s: %s\n", SessionConfigVar, config.SessionDirectory)
-		fmt.Printf("%s: %s\n", PagerDutyAPIConfigVar, config.PagerDutyAPIKey)
-		fmt.Printf("%s: %t\n", GovcloudVar, config.Govcloud)
+		fmt.Printf("%s: %s\n", URLConfigVar, viper.GetString(URLConfigVar))
+		fmt.Printf("%s: %s\n", ProxyURLConfigVar, strings.Join(viper.GetStringSlice(ProxyURLConfigVar), ", "))
+		fmt.Printf("%s: %s\n", SessionConfigVar, viper.GetString(SessionConfigVar))
+		fmt.Printf("%s: %s\n", PagerDutyAPIConfigVar, viper.GetString(PagerDutyAPIConfigVar))
+		fmt.Printf("%s: %t\n", GovcloudVar, viper.GetBool(GovcloudVar))
 	default:
 		return fmt.Errorf("supported config variables are %s, %s, %s, %s, & %s", URLConfigVar, ProxyURLConfigVar, SessionConfigVar, PagerDutyAPIConfigVar, GovcloudVar)
 	}


### PR DESCRIPTION
## Summary
- Replaces the `GetBackplaneConfiguration()` call in `config get` with direct viper reads from the config file
- Avoids pulling in the OCM connection logic and proxy-testing side effects that are unnecessary for simply displaying config values
- Handles both string and string-slice formats for `proxy-url`

## Test plan
- [ ] Run `ocm backplane config get url` and verify it prints the configured URL
- [ ] Run `ocm backplane config get proxy-url` with both string and array formats in config
- [ ] Run `ocm backplane config get all` and verify all values display correctly
- [ ] Run `ocm backplane config get` with no config file present (should print empty values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration values can now be retrieved directly from the saved JSON configuration file (when present).
  * The `get` command output now includes the proxy URL and the GovCloud setting.
  * The `all` option now displays all supported configuration values from the saved JSON configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->