### PR TITLE
chore: add Dependabot cooldown (~3 days)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
       - "ok-to-test"
     schedule:
       interval: "weekly"
+    # Align with MintMaker minimumReleaseAge (~3 days) for supply-chain delay
+    cooldown:
+      default-days: 3
     # Enable auto-merge for patch and minor updates
     open-pull-requests-limit: 10
     ignore:
@@ -21,6 +24,9 @@ updates:
       - "ok-to-test"
     schedule:
       interval: "weekly"
+    # Align with MintMaker minimumReleaseAge (~3 days) for supply-chain delay
+    cooldown:
+      default-days: 3
     # Enable auto-merge for patch and minor updates
     open-pull-requests-limit: 10
     # Group related updates together to reduce PR volume

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,8 @@
 version: "2"
 run:
   modules-download-mode: readonly
-  timeout: 10m
+  timeout: 15m
+  concurrency: 2
 linters:
   default: none
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 version: "2"
 run:
   modules-download-mode: readonly
+  timeout: 10m
 linters:
   default: none
   enable:

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,8 @@ getlint:
 	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(GOPATH)/bin $(GOLANGCI_LINT_VERSION)
 .PHONY: lint
 lint: getlint
-	$(GOPATH)/bin/golangci-lint run --timeout 10m
+	GOTOOLCHAIN=$(GO_VERSION) go mod download
+	$(GOPATH)/bin/golangci-lint run --timeout 15m
 
 ensure-goreleaser:
 	@command -v goreleaser >/dev/null 2>&1 || go install github.com/goreleaser/goreleaser/v2@${GORELEASER_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ getlint:
 	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(GOPATH)/bin $(GOLANGCI_LINT_VERSION)
 .PHONY: lint
 lint: getlint
-	$(GOPATH)/bin/golangci-lint run --timeout 5m
+	$(GOPATH)/bin/golangci-lint run --timeout 10m
 
 ensure-goreleaser:
 	@command -v goreleaser >/dev/null 2>&1 || go install github.com/goreleaser/goreleaser/v2@${GORELEASER_VERSION}


### PR DESCRIPTION
## Summary
- Add Dependabot `cooldown.default-days: 3` for gomod and docker updates
- Aligns Path B version updates with MintMaker `minimumReleaseAge` (~3 days) for supply-chain delay
- Does not change schedule, auto-merge workflow, or security-update behavior

## Test plan
- [ ] Confirm `dependabot.yml` validates in GitHub Dependabot settings / next Dependabot run
- [ ] Confirm only cooldown was added (no other config drift)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to add a three-day cooldown before proposals are made.
  * Improved linting reliability by running module downloads before lint checks.
  * Increased lint execution timeout to 15 minutes and adjusted golangci-lint concurrency to better utilize available capacity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->