### PR TITLE
[ROSAENG-61275 ]  fix :remove SSM credential logging at Info level

### DIFF
--- a/cmd/ocm-backplane/cloud/ssm.go
+++ b/cmd/ocm-backplane/cloud/ssm.go
@@ -248,10 +248,10 @@ func runSSMsession(ssmClient SSMClient, instanceID string, command []string, reg
 		return fmt.Errorf("session details are incomplete: SessionId=%v, StreamUrl=%v, TokenValue=%v", result.SessionId, result.StreamUrl, result.TokenValue)
 	}
 
-	// Log session details for debugging
-	logger.Infof("SessionId: %v", *result.SessionId)
-	logger.Infof("StreamUrl: %v", *result.StreamUrl)
-	logger.Infof("TokenValue: %v", *result.TokenValue)
+	// Log non-sensitive session identifier for debugging.
+	// StreamUrl and TokenValue are intentionally excluded from logs
+	// to prevent credential exposure (CWE-532, CWE-312).
+	logger.Debugf("SessionId: %v", *result.SessionId)
 
 	sessionJSON, err := json.Marshal(map[string]string{
 		"SessionId":  *result.SessionId,

--- a/cmd/ocm-backplane/cloud/ssm_test.go
+++ b/cmd/ocm-backplane/cloud/ssm_test.go
@@ -1,9 +1,11 @@
 package cloud
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,7 +13,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
-	"go.uber.org/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -21,7 +22,9 @@ import (
 	ocmMock "github.com/openshift/backplane-cli/pkg/ocm/mocks"
 	"github.com/openshift/backplane-cli/pkg/ssm/mocks"
 	"github.com/openshift/backplane-cli/pkg/utils"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -133,6 +136,70 @@ var _ = Describe("SSM command", func() {
 			_, err := GetInstanceID("invalid-node", &rest.Config{})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to get node invalid-node"))
+		})
+	})
+
+	Context("SSM session should not log sensitive credentials", func() {
+		var (
+			logBuf              bytes.Buffer
+			originalExecCommand func(string, ...string) *exec.Cmd
+			originalLevel       log.Level
+			originalOutput      io.Writer
+		)
+
+		BeforeEach(func() {
+			logBuf.Reset()
+			originalLevel = log.GetLevel()
+			originalOutput = log.StandardLogger().Out
+			log.SetLevel(log.InfoLevel)
+			log.SetOutput(&logBuf)
+
+			originalExecCommand = ExecCommand
+			ExecCommand = func(name string, arg ...string) *exec.Cmd {
+				return exec.Command("echo", "mock command")
+			}
+
+			mockSSMClient.EXPECT().StartSession(
+				context.TODO(),
+				gomock.Any(),
+			).Return(&ssm.StartSessionOutput{
+				SessionId:  aws.String("test-session-id"),
+				StreamUrl:  aws.String("wss://secret-stream-url.example.com"),
+				TokenValue: aws.String("secret-token-value-abc123"),
+			}, nil)
+		})
+
+		AfterEach(func() {
+			ExecCommand = originalExecCommand
+			log.SetLevel(originalLevel)
+			log.SetOutput(originalOutput)
+		})
+
+		It("should not log TokenValue at Info level", func() {
+			err := runSSMsession(mockSSMClient, "i-1234567890abcdef0", nil, "us-west-2")
+			Expect(err).ToNot(HaveOccurred())
+
+			logOutput := logBuf.String()
+			Expect(logOutput).ToNot(ContainSubstring("secret-token-value-abc123"),
+				"TokenValue should not appear in log output at Info level")
+		})
+
+		It("should not log StreamUrl at Info level", func() {
+			err := runSSMsession(mockSSMClient, "i-1234567890abcdef0", nil, "us-west-2")
+			Expect(err).ToNot(HaveOccurred())
+
+			logOutput := logBuf.String()
+			Expect(logOutput).ToNot(ContainSubstring("wss://secret-stream-url.example.com"),
+				"StreamUrl should not appear in log output at Info level")
+		})
+
+		It("should not log SessionId at Info level", func() {
+			err := runSSMsession(mockSSMClient, "i-1234567890abcdef0", nil, "us-west-2")
+			Expect(err).ToNot(HaveOccurred())
+
+			logOutput := logBuf.String()
+			Expect(logOutput).ToNot(ContainSubstring("test-session-id"),
+				"SessionId should only appear at Debug level, not Info")
 		})
 	})
 


### PR DESCRIPTION
Remove logger.Infof calls for TokenValue and StreamUrl in runSSMsession (cmd/ocm-backplane/cloud/ssm.go). These sensitive AWS SSM session credentials were logged at Info level on every invocation of "ocm-backplane cloud ssm-session", exposing the websocket auth token to terminal scrollback and log collectors. The token alone is sufficient to hijack an active SSM session to a customer EC2 instance (CWE-532, CWE-312).

SessionId is retained at Debug level since it is not a secret but useful for troubleshooting. The session JSON is already passed privately to session-manager-plugin via argv, so these log lines served no functional purpose.

Added three tests verifying that TokenValue, StreamUrl, and SessionId do not appear in log output at Info level.

Note: golangci-lint could not run in the sandbox (network restriction on install). go vet passed. One pre-existing test failure in common_test.go (network-dependent test blocked by sandbox) is unrelated to this change.


### What type of PR is this?

- [x] fix (Bug Fix)
- [ ] feat (New Feature)
- [ ] docs (Documentation)
- [ ] test (Test Coverage)
- [ ] chore (Clean Up / Maintenance Tasks)
- [ ] other (Anything that doesn't fit the above)

### What this PR does / Why we need it?

### Which Jira/Github issue(s) does this PR fix?

- Related Issue #
- Closes #
https://redhat.atlassian.net/browse/ROSAENG-61275

### Special notes for your reviewer

### Unit Test Coverage
#### Guidelines
- If it's a new sub-command or new function to an existing sub-command, please cover at least 50% of the code
- If it's a bug fix for an existing sub-command, please cover 70% of the code 
 
#### Test coverage checks  
- [x] Added unit tests
- [ ] Created jira card to add unit test
- [ ] This PR may not need unit tests

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR
- [ ] Backward compatible

<!-- Keep the below label to auto squash commits -->
/label tide/merge-method-squash


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by preventing sensitive SSM session credentials and connection details from appearing in application logs.
  * Retained only the non-sensitive session identifier at debug level for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->